### PR TITLE
v2.0.0-beta.3: backlog cleanup + tool-surface consolidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       - run: npm run lint
 
   test:
+    # Required gate. Runs on Linux to keep check-run names stable for the
+    # branch protection ruleset (ruleset hardcodes "test (20)" etc.).
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -39,6 +41,27 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  test-macos:
+    # v2.0.0-beta.3: cross-platform advisory job (not required by branch
+    # protection, doesn't block merges). Catches macOS-specific path /
+    # symlink / chmod regressions on Apple silicon. The user dogfoods on
+    # macOS arm64 — bugs that only show up there used to ship until manual
+    # smoke caught them.
+    runs-on: macos-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm run build
       - run: npm test
@@ -82,6 +105,11 @@ jobs:
         run: node scripts/smoke.mjs "${{ steps.vault.outputs.path }}" --with-fts
 
   audit:
+    # v2.0.0-beta.3: elevate from --audit-level=high to moderate for prod
+    # deps. Pre-fix, the ip-address moderate XSS advisory sat undetected
+    # between Dependabot scans because audit didn't gate on it. Production
+    # transitive deps are usually safe, but elevating closes that gap.
+    # Dev deps stay at high (test/build tooling, less surface, more noise).
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -91,7 +119,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npm audit --audit-level=high
+      - run: npm audit --omit=dev --audit-level=moderate
+      - run: npm audit --include=dev --audit-level=high
 
   version-consistency:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.3] — 2026-05-08
+
+**Backlog cleanup + tool-surface consolidation.** All audit-driven P0/P1 work landed in beta.2; this release closes the long tail of P2/P3 backlog items the same audits surfaced. No new features, no breaking changes for default users — but the default tool list is now narrower (21 read tools instead of 24) because the four single-ranker search tools moved behind a new opt-in flag.
+
+### Changed — `obsidian_search` is the headline; single-ranker tools moved behind `--diagnostic-search-tools`
+
+The audit's recurring observation: agents routinely picked the wrong single-ranker search tool from the five options (`search_text`, `full_text_search`, `semantic_search`, `embeddings_search`, `search`). The umbrella `obsidian_search` (added v2.0.0-beta.0) auto-detects available signals and produces consistent recall — five-tool surface is now bloat.
+
+- **Default surface (v2.0.0-beta.3+):** 21 always-on read tools. The single search tool is `obsidian_search`. Hybrid retrieval auto-detects what's available (BM25 if `--persistent-index`, ML embeddings if `build-embeddings` ran) and falls back gracefully.
+- **Diagnostic surface:** add `--diagnostic-search-tools` to register `obsidian_search_text`, `obsidian_semantic_search`, `obsidian_embeddings_search` (and `obsidian_full_text_search` if `--persistent-index` is also set). Use these for A/B benchmarking or when you specifically need single-ranker output.
+
+This is **not breaking** for clients calling `obsidian_search` (the v2.0 default). It IS a change for clients hard-coded to call `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` / `obsidian_full_text_search` — they need to either switch to `obsidian_search` (recommended) or add the flag.
+
+### Added — Cross-platform CI: macOS advisory job
+
+CI test matrix was Linux-only. `Vault` does cross-platform path work (`vault.ts:631` has a Windows separator normalization), symlink handling, and `chmod` operations — all of which behave differently on non-Linux platforms. Pre-fix, regressions only surfaced on user reports.
+
+New `test-macos` job runs the same suite on `macos-latest` × Node 22. **Advisory only** (`continue-on-error: true`) so it doesn't block merges, but failures appear in the PR check list. Required CI gate stays Linux × {Node 20, 22, 24} for ruleset stability.
+
+### Added — Coverage threshold gates in vitest
+
+Pre-fix: the `coverage` CI job uploaded an HTML report and exited 0 regardless of the numbers. A regression that dropped coverage 90% → 40% would ship green. New `vitest.config.ts` thresholds:
+
+- lines: ≥86%
+- statements: ≥82%
+- functions: ≥75%
+- branches: ≥73%
+
+All ~5pp below current. Excludes `src/index.ts` (registration boilerplate; line-count doesn't reflect quality) and test files. Fails CI if any threshold drops below.
+
+### Changed — `npm audit` elevated to `moderate` for production deps
+
+Pre-fix: `--audit-level=high` everywhere. The recently-resolved `ip-address` advisory (CVE-2026-42338, moderate severity) sat undetected between Dependabot scans because no audit gate caught it. Now production deps gate at `moderate`, dev deps stay at `high` (more noise, less surface).
+
+### Process — branch-protection ruleset bypass mode hardened
+
+`bypass_actors` for the admin role was `bypass_mode: always`. Changed to `bypass_mode: pull_request`. The maintainer's own pushes now go through PR (auto-mergeable), creating an audit trail. Combined with the v2.0.0-beta.2 release-pipeline integrity check, this means every change shipped to npm has a reviewable diff.
+
+### Docs
+
+- README "Configure your AI client" tool count: `24 read + 1 opt-in` → `21 read + 4 opt-in` (3 diagnostic + 1 FTS) reflecting the consolidation above.
+- `docs/api.md` header updated with the new tool-count math + opt-in flag breakdown.
+- README footer ENQUIRE paragraph deduplicated (was repeated near-verbatim at lines 59 and 484; footer now just references the inline note).
+- GitHub repo About description shortened from 340 → 195 chars to fit OpenGraph truncation.
+
+### Tests
+
+408 unit tests pass (was 408 in beta.2 — no test count delta; tests exercise the same surfaces with the new gating reflected in `tests/docs-consistency.test.ts` to count diagnostic-gated tools as opt-in, not always-on).
+
+`scripts/smoke.mjs` adds `--diagnostic-search-tools` to its server invocation so smoke continues to exercise all 5 search tools (was: 4, post-consolidation default surface is 1).
+
+### Migration from v2.0.0-beta.2
+
+**No-op for clients of `obsidian_search`** (the v2.0 hybrid default). Recommended path forward.
+
+**Clients calling per-ranker tools directly:**
+- Either switch to `obsidian_search` (preferred — auto-fuses signals)
+- Or pass `--diagnostic-search-tools` to your `enquire-mcp serve` invocation
+
+**Programmatic API surface unchanged.** The 4 gated tools have identical schemas + behavior when registered.
+
 ## [2.0.0-beta.2] — 2026-05-06
 
 **Audit-driven patch.** A second deep audit (5 parallel agents covering architecture, tests, docs, CI/CD, security threat model) surfaced one P0 privacy bypass of the same shape as the writeNote bug from beta.1, three release-pipeline P0s, and a long tail of P1 hardening. This release closes 16 findings and adds new architectural invariants to prevent recurrence.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Restart your client. The server logs `enquire <version> ready (read-only, vault=
 
 ## What you get
 
-### 24 read tools (always on) + 1 opt-in (`--persistent-index`) — **30 total** with 5 write tools
+### 21 read tools (always on) + 4 opt-in (`--persistent-index` adds 1 BM25 / `--diagnostic-search-tools` adds 3 single-ranker) — **30 total** with 5 write tools
 
 | Tool | What it does |
 |---|---|
@@ -481,4 +481,4 @@ Other ways to help:
 
 [MIT](./LICENSE). Built by Alex — [GitHub `@oomkapwn`](https://github.com/oomkapwn) · [X `@OomkaBear`](https://x.com/OomkaBear). Powered by [Model Context Protocol](https://modelcontextprotocol.io/), [`gray-matter`](https://github.com/jonschlinkert/gray-matter), [`commander`](https://github.com/tj/commander.js), and the patience of one specific Obsidian vault that didn't deserve to be parsed by hand.
 
-Named after [ENQUIRE](https://en.wikipedia.org/wiki/ENQUIRE) — the program Tim Berners-Lee wrote at CERN in 1980 to track «the complex web of relationships between people, programs, machines and ideas». ENQUIRE was the direct prototype of the World Wide Web. enquire-mcp brings the same idea to your AI: hyperlinked notes, structured access, no plugin required.
+Named after [ENQUIRE](https://en.wikipedia.org/wiki/ENQUIRE) — the 1980 hypertext prototype of the World Wide Web (see the inline note above for the longer story).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # enquire — API
 
-**enquire is an MCP server for Obsidian vaults.** 30 MCP tools (24 always-on read + 1 opt-in read via `--persistent-index` + 5 opt-in write via `--enable-write`), 2 + 1 opt-in MCP resources, 10 MCP prompts. The server speaks stdio JSON-RPC and is launched per-vault.
+**enquire is an MCP server for Obsidian vaults.** 30 MCP tools (21 always-on read + 4 opt-in read + 5 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 10 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
 
 > **Channels:** stable v1.x (`@latest` on npm) ships 28 tools — no ML embeddings, no hybrid search. **v2.0 beta** (`@beta` on npm) adds `obsidian_search` (hybrid RRF) + `obsidian_embeddings_search` + the `install-model` / `build-embeddings` / `clear-embeddings` subcommands. This document covers the **v2.0 beta** surface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -18,7 +18,10 @@ const positional = args.filter((a) => !a.startsWith("--"));
 const vault = positional[0] ?? path.join(os.homedir(), "Documents", "Obsidian Vault");
 const withFts = args.includes("--with-fts");
 
-const serveArgs = [bin, "serve", "--vault", vault];
+// v2.0.0-beta.3: enable --diagnostic-search-tools so smoke exercises the
+// full historical surface (5 search tools, including the 4 single-ranker
+// diagnostics gated behind the new flag in v2.0.0-beta.3+).
+const serveArgs = [bin, "serve", "--vault", vault, "--diagnostic-search-tools"];
 if (withFts) serveArgs.push("--persistent-index");
 
 if (withFts) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.0.0-beta.2";
+const VERSION = "2.0.0-beta.3";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {
@@ -67,6 +67,7 @@ interface ServeOptions {
   watch?: boolean;
   disabledTools?: string[];
   enabledTools?: string[];
+  diagnosticSearchTools?: boolean;
 }
 
 async function main(): Promise<void> {
@@ -116,6 +117,10 @@ async function main(): Promise<void> {
     .option(
       "--enabled-tools <name...>",
       "Strict allowlist — when set, ONLY listed tools register. Complement to --disabled-tools (denylist). If both are set: a tool must be in the allowlist AND not in the denylist. Repeatable. Example: `--enabled-tools obsidian_search_text obsidian_read_note obsidian_get_recent_edits`."
+    )
+    .option(
+      "--diagnostic-search-tools",
+      "Register the four single-ranker search tools (obsidian_search_text, obsidian_full_text_search, obsidian_semantic_search, obsidian_embeddings_search) IN ADDITION to the default obsidian_search hybrid tool. Off by default in v2.0+ — the umbrella obsidian_search auto-detects available signals and produces consistent recall. Enable when you need single-ranker output for diagnostics or A/B benchmarking."
     )
     .action(async (opts: ServeOptions) => {
       await startServer(opts);
@@ -349,9 +354,9 @@ async function startServer(opts: ServeOptions): Promise<void> {
     };
   }
 
-  registerReadTools(server, vault, ftsIndex);
+  registerReadTools(server, vault, ftsIndex, opts.diagnosticSearchTools ?? false);
   if (vault.writeEnabled) registerWriteTools(server, vault);
-  if (ftsIndex) registerFtsTools(server, ftsIndex, vault);
+  if (ftsIndex && opts.diagnosticSearchTools) registerFtsTools(server, ftsIndex, vault);
   registerResources(server, vault);
   if (ftsIndex) registerChunkResource(server, ftsIndex, vault);
   registerPrompts(server);
@@ -609,7 +614,12 @@ function registerFtsTools(server: McpServer, idx: FtsIndex, vault: Vault): void 
   );
 }
 
-function registerReadTools(server: McpServer, vault: Vault, ftsIndex: FtsIndex | null): void {
+function registerReadTools(
+  server: McpServer,
+  vault: Vault,
+  ftsIndex: FtsIndex | null,
+  diagnosticSearchTools: boolean
+): void {
   const READ_ONLY = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
 
   server.registerTool(
@@ -670,28 +680,34 @@ function registerReadTools(server: McpServer, vault: Vault, ftsIndex: FtsIndex |
     async (args) => textResult(await resolveWikilink(vault, args))
   );
 
-  server.registerTool(
-    "obsidian_search_text",
-    {
-      title: "Search text",
-      description:
-        "Case-insensitive token search across all notes. Default mode `all` requires every whitespace-separated token to appear in a note (AND-tokenizer); `any` requires at least one (OR); `phrase` does the old contiguous-substring match. Returns a structured response with `query`, `mode`, `scanned_notes`, and ranked `matches` (each with snippet, line, score, matched_terms) — empty matches are explicit, not ambiguous with a broken call.",
-      annotations: { ...READ_ONLY, title: "Search text" },
-      inputSchema: {
-        query: z
-          .string()
-          .min(1)
-          .describe('Search string. With mode=all/any, whitespace tokenizes ("foo bar" → ["foo","bar"]).'),
-        folder: z.string().optional().describe("Restrict to a subfolder"),
-        limit: z.number().int().positive().max(200).optional().describe("Max results (default 25)"),
-        mode: z
-          .enum(["all", "any", "phrase"])
-          .optional()
-          .describe('"all" (default, AND), "any" (OR), or "phrase" (literal substring — pre-v0.9 behavior)')
-      }
-    },
-    async (args) => textResult(await searchText(vault, args))
-  );
+  // v2.0.0-beta.3: obsidian_search_text is now a DIAGNOSTIC tool — gated
+  // behind --diagnostic-search-tools. Default search surface is the umbrella
+  // obsidian_search which auto-detects + fuses signals. Pre-fix, agents
+  // routinely picked the wrong single-ranker tool; consolidation reduces
+  // tool-list bloat and produces consistent recall.
+  if (diagnosticSearchTools)
+    server.registerTool(
+      "obsidian_search_text",
+      {
+        title: "Search text",
+        description:
+          "Case-insensitive token search across all notes. Default mode `all` requires every whitespace-separated token to appear in a note (AND-tokenizer); `any` requires at least one (OR); `phrase` does the old contiguous-substring match. Returns a structured response with `query`, `mode`, `scanned_notes`, and ranked `matches` (each with snippet, line, score, matched_terms) — empty matches are explicit, not ambiguous with a broken call.",
+        annotations: { ...READ_ONLY, title: "Search text" },
+        inputSchema: {
+          query: z
+            .string()
+            .min(1)
+            .describe('Search string. With mode=all/any, whitespace tokenizes ("foo bar" → ["foo","bar"]).'),
+          folder: z.string().optional().describe("Restrict to a subfolder"),
+          limit: z.number().int().positive().max(200).optional().describe("Max results (default 25)"),
+          mode: z
+            .enum(["all", "any", "phrase"])
+            .optional()
+            .describe('"all" (default, AND), "any" (OR), or "phrase" (literal substring — pre-v0.9 behavior)')
+        }
+      },
+      async (args) => textResult(await searchText(vault, args))
+    );
 
   server.registerTool(
     "obsidian_get_recent_edits",
@@ -1023,57 +1039,61 @@ function registerReadTools(server: McpServer, vault: Vault, ftsIndex: FtsIndex |
     async (args) => textResult(await readCanvas(vault, args))
   );
 
-  server.registerTool(
-    "obsidian_semantic_search",
-    {
-      title: "Semantic search (TF-IDF cosine)",
-      description:
-        "Pure-JS lexical-semantic retrieval. Tokenizes + TF-IDFs + L2-normalizes every note's body once per session, then ranks notes by cosine similarity to the query. Free / offline / no model download — closes the gap to Smart Connections without paywall, ML deps, or HTTP. Use this when `obsidian_search_text` (substring) and `obsidian_full_text_search` (BM25) miss synonyms or related-term matches. For best results pair with `--persistent-index` so BM25 + semantic both run cheap. Returns ranked hits with snippet + matched terms (highest-IDF first).",
-      annotations: { ...READ_ONLY, title: "Semantic search" },
-      inputSchema: {
-        query: z.string().min(1).describe("Free-form query — multi-word, natural language is fine"),
-        folder: z.string().optional().describe("Restrict to a subfolder (vault-relative)"),
-        limit: z.number().int().positive().max(100).optional().describe("Max hits (default 10)"),
-        min_score: z
-          .number()
-          .min(0)
-          .max(1)
-          .optional()
-          .describe("Drop hits below this cosine score (default 0.05). Cosine ranges 0–1.")
-      }
-    },
-    async (args) => textResult(await semanticSearch(vault, args))
-  );
+  // v2.0.0-beta.3: gated — see comment on obsidian_search_text above.
+  if (diagnosticSearchTools)
+    server.registerTool(
+      "obsidian_semantic_search",
+      {
+        title: "Semantic search (TF-IDF cosine)",
+        description:
+          "Pure-JS lexical-semantic retrieval. Tokenizes + TF-IDFs + L2-normalizes every note's body once per session, then ranks notes by cosine similarity to the query. Free / offline / no model download — closes the gap to Smart Connections without paywall, ML deps, or HTTP. Use this when `obsidian_search_text` (substring) and `obsidian_full_text_search` (BM25) miss synonyms or related-term matches. For best results pair with `--persistent-index` so BM25 + semantic both run cheap. Returns ranked hits with snippet + matched terms (highest-IDF first).",
+        annotations: { ...READ_ONLY, title: "Semantic search" },
+        inputSchema: {
+          query: z.string().min(1).describe("Free-form query — multi-word, natural language is fine"),
+          folder: z.string().optional().describe("Restrict to a subfolder (vault-relative)"),
+          limit: z.number().int().positive().max(100).optional().describe("Max hits (default 10)"),
+          min_score: z
+            .number()
+            .min(0)
+            .max(1)
+            .optional()
+            .describe("Drop hits below this cosine score (default 0.05). Cosine ranges 0–1.")
+        }
+      },
+      async (args) => textResult(await semanticSearch(vault, args))
+    );
 
   // v2.0 alpha — ML-embeddings retrieval. Reads a persistent vector index
   // built by `enquire-mcp build-embeddings`. Returns clean error if the index
   // doesn't exist (rather than silently downloading a model).
-  server.registerTool(
-    "obsidian_embeddings_search",
-    {
-      title: "Embeddings search (ML, paraphrase-multilingual)",
-      description:
-        "ML-embedding retrieval via @huggingface/transformers + paraphrase-multilingual-MiniLM-L12-v2 (50+ languages, 384-dim, runs on CPU). Higher-quality than `obsidian_semantic_search` for paraphrases / synonyms / cross-language queries, but requires a one-time setup: (1) `enquire-mcp install-model multilingual` downloads the ONNX weights (~120MB) and (2) `enquire-mcp build-embeddings --vault <path>` writes the persistent vector index (~1ms/chunk on M1). Subsequent queries are sub-100ms top-10. If the index is missing, the tool returns a clean error with the exact command to run — it does NOT silently kick off a model download.",
-      annotations: { ...READ_ONLY, title: "Embeddings search" },
-      inputSchema: {
-        query: z.string().min(1).describe("Free-form query — multi-word, natural language, any supported language"),
-        folder: z.string().optional().describe("Restrict to a subfolder (vault-relative)"),
-        limit: z.number().int().positive().max(100).optional().describe("Max hits (default 10)"),
-        min_score: z
-          .number()
-          .min(0)
-          .max(1)
-          .optional()
-          .describe(
-            "Drop hits below this cosine score (default 0.3). Cosine ranges -1 to 1; embeddings cluster ~0.4-0.9."
-          )
+  // v2.0.0-beta.3: gated — see comment on obsidian_search_text above.
+  if (diagnosticSearchTools)
+    server.registerTool(
+      "obsidian_embeddings_search",
+      {
+        title: "Embeddings search (ML, paraphrase-multilingual)",
+        description:
+          "ML-embedding retrieval via @huggingface/transformers + paraphrase-multilingual-MiniLM-L12-v2 (50+ languages, 384-dim, runs on CPU). Higher-quality than `obsidian_semantic_search` for paraphrases / synonyms / cross-language queries, but requires a one-time setup: (1) `enquire-mcp install-model multilingual` downloads the ONNX weights (~120MB) and (2) `enquire-mcp build-embeddings --vault <path>` writes the persistent vector index (~1ms/chunk on M1). Subsequent queries are sub-100ms top-10. If the index is missing, the tool returns a clean error with the exact command to run — it does NOT silently kick off a model download.",
+        annotations: { ...READ_ONLY, title: "Embeddings search" },
+        inputSchema: {
+          query: z.string().min(1).describe("Free-form query — multi-word, natural language, any supported language"),
+          folder: z.string().optional().describe("Restrict to a subfolder (vault-relative)"),
+          limit: z.number().int().positive().max(100).optional().describe("Max hits (default 10)"),
+          min_score: z
+            .number()
+            .min(0)
+            .max(1)
+            .optional()
+            .describe(
+              "Drop hits below this cosine score (default 0.3). Cosine ranges -1 to 1; embeddings cluster ~0.4-0.9."
+            )
+        }
+      },
+      async (args) => {
+        const embedFile = embedDbPath(vault.root);
+        return textResult(await embeddingsSearch(vault, args, embedFile));
       }
-    },
-    async (args) => {
-      const embedFile = embedDbPath(vault.root);
-      return textResult(await embeddingsSearch(vault, args, embedFile));
-    }
-  );
+    );
 
   // v2.0 beta — hybrid RRF over BM25 + TF-IDF + embeddings. Single umbrella
   // tool that auto-detects which signals are available and gracefully

--- a/tests/docs-consistency.test.ts
+++ b/tests/docs-consistency.test.ts
@@ -74,7 +74,8 @@ describe("docs/code consistency — README mirrors registered MCP surface", () =
     const readme = await read("README.md");
     const registered = registeredNames(indexSrc, "registerTool");
     // Heuristic: split by always-on read / opt-in read / write tools.
-    // Always-on read = registered NOT in registerWriteTools or registerFtsTools.
+    // Always-on read = registered NOT in registerWriteTools or registerFtsTools
+    // AND NOT gated behind `if (diagnosticSearchTools) server.registerTool(`.
     const writeFnStart = indexSrc.indexOf("function registerWriteTools(");
     const writeFnEnd = writeFnStart > 0 ? indexSrc.indexOf("\n}\n", writeFnStart) : -1;
     const ftsFnStart = indexSrc.indexOf("function registerFtsTools(");
@@ -83,7 +84,14 @@ describe("docs/code consistency — README mirrors registered MCP surface", () =
     const ftsBody = ftsFnStart > 0 && ftsFnEnd > 0 ? indexSrc.slice(ftsFnStart, ftsFnEnd) : "";
     const writeNames = registeredNames(writeBody, "registerTool");
     const ftsNames = registeredNames(ftsBody, "registerTool");
-    const alwaysOnRead = [...registered].filter((n) => !writeNames.has(n) && !ftsNames.has(n));
+    // v2.0.0-beta.3: tools gated behind `if (diagnosticSearchTools)` are
+    // opt-in, not always-on.
+    const diagnosticGated = new Set(
+      [...indexSrc.matchAll(/if \(diagnosticSearchTools\) server\.registerTool\(\s*"([^"]+)"/g)].map((m) => m[1] ?? "")
+    );
+    const alwaysOnRead = [...registered].filter(
+      (n) => !writeNames.has(n) && !ftsNames.has(n) && !diagnosticGated.has(n)
+    );
     // Look for a heading or sentence claiming "<N> read tools (always on)".
     const m = /(\d+) read tools \(always on\)/.exec(readme);
     expect(m, "README must declare a number of always-on read tools").not.toBeNull();

--- a/tests/docs-consistency.test.ts
+++ b/tests/docs-consistency.test.ts
@@ -85,9 +85,13 @@ describe("docs/code consistency — README mirrors registered MCP surface", () =
     const writeNames = registeredNames(writeBody, "registerTool");
     const ftsNames = registeredNames(ftsBody, "registerTool");
     // v2.0.0-beta.3: tools gated behind `if (diagnosticSearchTools)` are
-    // opt-in, not always-on.
+    // opt-in, not always-on. Use `\s+` (matches newlines) instead of a
+    // single space — Biome's formatter splits `if (...) server.registerTool(`
+    // onto separate lines, which would have escaped a single-line regex.
     const diagnosticGated = new Set(
-      [...indexSrc.matchAll(/if \(diagnosticSearchTools\) server\.registerTool\(\s*"([^"]+)"/g)].map((m) => m[1] ?? "")
+      [...indexSrc.matchAll(/if \(diagnosticSearchTools\)\s+server\.registerTool\(\s*"([^"]+)"/g)].map(
+        (m) => m[1] ?? ""
+      )
     );
     const alwaysOnRead = [...registered].filter(
       (n) => !writeNames.has(n) && !ftsNames.has(n) && !diagnosticGated.has(n)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,24 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
-    environment: "node"
+    environment: "node",
+    // v2.0.0-beta.3: coverage thresholds set ~5pp BELOW current (lines
+    // 91.35, statements 87.03, functions 80.6, branches 77.85) so a real
+    // regression has to skip a meaningful chunk before CI fails. The
+    // coverage job is in CI's required checks, so a regression that drops
+    // below blocks merge. index.ts is excluded — it's registration
+    // boilerplate where line coverage doesn't reflect quality.
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts", "**/*.test.ts"],
+      thresholds: {
+        lines: 86,
+        statements: 82,
+        functions: 75,
+        branches: 73
+      }
+    }
   }
 });


### PR DESCRIPTION
Audit P2/P3 backlog cleanup. No new features. See CHANGELOG for full list.

## Summary
- Tool-surface consolidation: 4 single-ranker search tools moved behind `--diagnostic-search-tools` flag
- CI hardening: macOS advisory job, coverage thresholds, audit-level=moderate for prod deps
- Process: ruleset bypass_mode → pull_request (this PR is the first one going through it!)
- Docs polish

## Test plan
- [x] 408/408 unit tests pass
- [x] Lint clean (3 pre-existing warnings)
- [x] Build clean
- [x] Smoke pass on real + synthetic vault
- [x] CI required checks must pass before merge (per ruleset)