### PR TITLE
docs: README rewrite for v2.0.0 (sales-y + AI-indexable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] — 2026-05-08
+
+**v2.0.0 stable.** Promotes the v2.0 prerelease train (alpha.0 → beta.{0,1,2,3,4}) to `@latest` on npm. `npm install @oomkapwn/enquire-mcp` now ships v2.0.0 by default; v1.11.1 stable users update on next install. **No new code changes from beta.4** — this release is the channel promotion only.
+
+### What you get vs v1.11.1
+
+**Hybrid retrieval (the headline):**
+- `obsidian_search` — single umbrella tool that fuses BM25 (FTS5) + TF-IDF cosine + ML embeddings via Reciprocal Rank Fusion (Cormack et al, 2009). Auto-detects available signals, gracefully degrades. Returns per-signal observability so agents see which rankers contributed each hit.
+- `obsidian_embeddings_search` (opt-in, behind `--diagnostic-search-tools`) — standalone ML-embedding retrieval via `@huggingface/transformers` + `paraphrase-multilingual-MiniLM-L12-v2` (50+ languages, 384-dim). Free, offline-capable, multilingual. Closes the gap to Smart Connections without the paywall.
+
+**New CLI subcommands:**
+- `enquire-mcp install-model [alias]` — pre-download embedding model (`multilingual` default, ~120MB; or `bge` English-only, ~33MB).
+- `enquire-mcp build-embeddings --vault <path>` — cold-build the persistent SQLite vector index. Same paragraph-level chunking as the FTS5 index — chunk identity matches across BM25 and embeddings.
+- `enquire-mcp clear-embeddings --vault <path>` — purge the embedding index.
+
+**New CLI flag:**
+- `--diagnostic-search-tools` — register the four single-ranker search tools (`obsidian_search_text`, `obsidian_full_text_search`, `obsidian_semantic_search`, `obsidian_embeddings_search`) for diagnostic / A/B benchmarking. Off by default in v2.0+ since `obsidian_search` produces consistent recall.
+
+**Default tool surface:**
+- 21 always-on read tools (was 22 in v1.11.1: `obsidian_search` replaces the four single-ranker tools as the headline)
+- 4 opt-in: 1 via `--persistent-index` (`obsidian_full_text_search`), 3 via `--diagnostic-search-tools`
+- 5 write tools (unchanged) via `--enable-write`
+- **30 tools total**, same as v1.11.1's count but consolidated for clarity
+
+### Verified end-to-end
+
+Maintainer's 128-note bilingual (Russian + English) real vault:
+- Build: 8854 chunks embedded in 8m 16s (with progress visibility)
+- Query "Claude Code subscription migration": top hit fuses all 3 signals (BM25 rank 1 + TF-IDF rank 3 + embeddings rank 1)
+- Embeddings retrieve Russian content for English queries (multilingual model working as designed)
+
+### Tests, CI/CD, security
+
+- 408 unit tests pass across 19 test files
+- CI: ubuntu × {Node 20, 22, 24} required + macOS advisory job
+- Coverage thresholds enforced (lines ≥86, statements ≥82, functions ≥75, branches ≥73)
+- `npm audit --audit-level=moderate` for production deps; high for dev
+- Branch protection ruleset: `bypass_mode: pull_request` (every change goes through PR with audit trail)
+- Release pipeline integrity: tagged SHA must be reachable from `main` AND all 8 required CI checks must have reported `success` on it
+- Privacy boundary verified across all write paths AND persistent-index search paths (filtering at search time even if user adds `--exclude-glob` between runs)
+
+### Migration from v1.11.1
+
+**Default tool list narrowed.** Clients hard-coded to call `obsidian_search_text`, `obsidian_full_text_search`, `obsidian_semantic_search`, or `obsidian_embeddings_search` directly need to either:
+1. Switch to `obsidian_search` (recommended — auto-fuses signals), or
+2. Pass `--diagnostic-search-tools` to `enquire-mcp serve`
+
+**Optional new dependency:** `@huggingface/transformers` is in `optionalDependencies`. Read-only / TF-IDF / FTS5 paths stay zero-cost. Embedding tools/subcommands surface a clean error if optional deps were skipped (`npm install --omit=optional`).
+
+**No breaking changes to:** `obsidian_read_note`, `obsidian_list_notes`, `obsidian_search_text` (now opt-in), `obsidian_get_backlinks`, `obsidian_dataview_query`, write tools, MCP resources, MCP prompts, or any v1.x CLI flag.
+
+### Migration from v2.0.0-beta.4
+
+**No-op.** This release is the channel promotion (npm `beta` → `latest`). Code is identical to beta.4.
+
+### Acknowledgments
+
+The v2.0 prerelease train (alpha.0 → beta.4) closed 100+ audit findings across two deep five-agent audits and one external auditor pass. Architecture invariants added at CI time prevent recurrence of the patterns that caused the privacy bypasses. End-to-end validation on a real bilingual vault confirms the v2.0 thesis: hybrid retrieval > any single ranker, with consistent recall across languages.
+
 ## [2.0.0-beta.4] — 2026-05-08
 
 **ML build-embeddings UX + throughput fix.** v2.0.0-beta.3 manual smoke on the maintainer's 128-note real vault revealed that `enquire-mcp build-embeddings` was *silent* for 13+ minutes when processing notes with many chunks. Investigation: not actually hung — just very slow on large notes (8,854 chunks total, several notes with 100+ chunks each), with zero feedback to the user. This release fixes both the speed AND the visibility.

--- a/README.md
+++ b/README.md
@@ -1,484 +1,253 @@
 <div align="center">
 
-<a href="https://github.com/oomkapwn/enquire-mcp"><img src="./assets/social-preview.png" alt="enquire — MCP server for Obsidian vaults. Wikilinks, frontmatter, backlinks, Dataview, MCP resources & prompts. Named after Tim Berners-Lee's 1980 prototype of the WWW." width="100%"></a>
+<a href="https://github.com/oomkapwn/enquire-mcp"><img src="./assets/social-preview.png" alt="enquire — MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF). Wikilinks, frontmatter, backlinks, Dataview, multilingual semantic search. For Claude Code, Cursor, Codex." width="100%"></a>
 
-# enquire
+# enquire — MCP server for Obsidian
 
-## Stop your AI guessing at vault paths.
-
-**enquire** turns your **Obsidian** vault into structured, searchable memory for **Claude Code, Cursor, OpenClaw 🦞, Codex**, and any MCP-compatible agent.
-
-Wikilinks resolved with aliases and sections. Backlinks ranked with snippets. Frontmatter typed. Dataview queries first-class. **Hybrid retrieval** (BM25 + TF-IDF + ML embeddings, fused via Reciprocal Rank Fusion) that catches paraphrases and synonyms the way Smart Connections does — but free, offline-capable, and open-source.
-
-Read-only by default. No Obsidian plugin required. One command to install.
+**Hybrid retrieval (BM25 + TF-IDF + ML embeddings, RRF-fused) for your Obsidian vault.** Drop-in for Claude Code, Cursor, OpenClaw 🦞, Codex, Devin, and any MCP-compatible agent. Free. Multilingual (50+ languages). Offline-capable. No Obsidian plugin required.
 
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/latest.svg?label=stable)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![npm beta](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/beta.svg?label=beta)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp/v/beta)
-[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
-[![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen.svg)](#develop)
+[![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/latest.svg?label=npm)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
+[![beta](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/beta.svg?label=beta)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp/v/beta)
+[![Tests](https://img.shields.io/badge/tests-408_passing-brightgreen.svg)](#engineering)
+[![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
+[![SLSA-3](https://img.shields.io/badge/SLSA-3-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
 
 </div>
-
-### Quick start (30 seconds)
-
-> **🚧 Two release channels right now.** Stable `npm install … @latest` is **v1.x** (28 tools, no ML embeddings, no hybrid search). The headline `obsidian_search` (BM25 + TF-IDF + ML embeddings via RRF) and `obsidian_embeddings_search` ship under the **`@beta` channel** — opt in with `@oomkapwn/enquire-mcp@beta`. Stable v2.0 promotes once `@beta` proves out.
-
-```bash
-# Stable (v1.x — 28 tools, hybrid search NOT included):
-claude mcp add --transport stdio obsidian \
-  -- npx -y @oomkapwn/enquire-mcp serve --vault ~/path/to/your/vault
-
-# Beta (v2.0 — adds obsidian_search hybrid + obsidian_embeddings_search):
-claude mcp add --transport stdio obsidian \
-  -- npx -y @oomkapwn/enquire-mcp@beta serve --vault ~/path/to/your/vault
-
-# Cursor / OpenClaw / Codex / others — drop this into your MCP config:
-{
-  "mcpServers": {
-    "obsidian": {
-      "command": "npx",
-      "args": ["-y", "@oomkapwn/enquire-mcp@beta", "serve", "--vault", "/path/to/vault"]
-    }
-  }
-}
-```
-
-Restart your AI client. That's it — your assistant can now follow `[[wikilinks]]`, walk backlinks, run Dataview queries, and reason about your vault the way you do.
-
-```text
-You:    "What was I working on yesterday in the Apollo project?"
-Claude: → obsidian_get_recent_edits({ since_minutes: 1440, folder: "01_Projects" })
-        → obsidian_read_note({ title: "Apollo" })
-        → obsidian_get_backlinks({ title: "Apollo" })
-        "You shipped the v0.3 spec, opened 3 open questions in [[Apollo/Open Threads]],
-        and 2 daily notes link back to it. Top blocker: the auth review."
-```
-
-> Named after [**ENQUIRE**](https://en.wikipedia.org/wiki/ENQUIRE) — the program Tim Berners-Lee wrote at CERN in 1980 to track «the complex web of relationships between people, programs, machines and ideas». ENQUIRE was the direct prototype of the World Wide Web. enquire-mcp brings the same idea to your AI: hyperlinked notes, structured access, zero plugins.
-
----
-
-## Why enquire exists (vs other Obsidian-MCP options)
-
-There are several Obsidian-MCP servers out there. enquire differentiates on three axes — **standalone**, **read-rich**, and **safe-by-default**:
-
-| Capability (✅ = good for you) | Most Obsidian-MCPs | enquire |
-|---|:---:|:---:|
-| Works with `.md` files | ✅ | ✅ |
-| **Standalone** — runs without Obsidian's Local REST API plugin | ❌ usually requires it | ✅ direct vault read |
-| Resolves `[[Wikilink]]` with alias, section, block, `../` relative | partial | ✅ full |
-| Surfaces `![[Embed]]` separately from links | ❌ | ✅ |
-| Finds every note linking to X (**backlinks**) | rare | ✅ ranked + snippets |
-| Finds every **broken `[[wikilink]]`** in the vault | ❌ | ✅ vault-hygiene tool |
-| Lists **outbound links** for one note with resolution status | ❌ | ✅ |
-| Built-in **Dataview-style queries** (`LIST` / `TABLE`, `AND`/`OR`, `LIKE`) | only via Obsidian plugin | ✅ first-class |
-| **MCP resources** for browsing the vault as a tree | ❌ | ✅ |
-| **MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`) | ❌ | ✅ 10 prompts |
-| **Read-only by default** (write tools require explicit flag) | ❌ usually write-default | ✅ `--enable-write` |
-| Symlink-escape safety, realpath-checked reads & writes | rare | ✅ |
-| Persistent on-disk cache for warm cold-starts | ❌ | ✅ `--persistent-cache` |
-| **Per-folder privacy filter** (`--exclude-glob '02_Personal/**'`) | ❌ | ✅ |
-| **Periodic-note aliases** (`title: "today"` / `"weekly"` / `"monthly"` / `"quarterly"` / `"yearly"` — honors Daily Notes & Periodic Notes plugin config) | rare | ✅ |
-| **Per-tool gating** (`--disabled-tools obsidian_xxx ...` — narrow the surface for restricted agents) | ❌ | ✅ |
-| **`Did you mean: ...`** suggestions on note-not-found errors | rare | ✅ |
-| **Document-map projection** (`format: "map"`: headings + counts, no body) | ❌ | ✅ |
-| **Anti-slop write validator** (`obsidian_validate_note_proposal` lints YAML + wikilinks + tags before write) | ❌ | ✅ |
-| **Graph-aware retrieval** (`find_similar` + `get_note_neighbors` — multi-signal lexical hybrid, no embeddings) | ❌ | ✅ |
-| **Vault dashboard** (`obsidian_stats`: orphans, broken links, top tags) | ❌ | ✅ |
-| **Rename + auto-backlink rewrite** (`obsidian_rename_note` — atomic, code-fence-aware, dry-run preview) | ❌ usually breaks links | ✅ |
-| **Bulk find/replace across vault** (`obsidian_replace_in_notes` — code-fence-aware, dry-run, refuses footguns) | ❌ rare or unsafe | ✅ |
-| **Archive workflow** (`obsidian_archive_note` — wraps rename, default `Archive/` folder, preserves backlinks) | ❌ | ✅ |
-| **Live watcher mode** (`--watch` — incremental cache + FTS5 reindex on file changes) | ❌ usually requires restart | ✅ |
-| **Karpathy LLM-Wiki `/lint` workflow** (`obsidian_lint_wiki` + `lint_wiki` prompt — orphans, broken links, stubs, stale, concept candidates) | ❌ | ✅ reference impl |
-| **Multi-hop graph path-finding** (`obsidian_find_path` — BFS shortest path between two notes over the wikilink graph, with alternatives) | ❌ | ✅ |
-| **Strict path allowlist** (`--read-paths '01_Projects/**'` — only paths matching one of these globs are visible; complement to `--exclude-glob` denylist) | ❌ | ✅ |
-| **Canvas (`.canvas`) read tools** (`obsidian_list_canvases` + `obsidian_read_canvas` — typed nodes + edges, broken-ref detection) | ❌ rare / partial | ✅ first-class |
-| **Semantic search** (`obsidian_semantic_search` — TF-IDF cosine, free / offline / no model download) | ❌ usually paywalled (Smart Connections) | ✅ in-tree |
-| **ML embeddings search** (`obsidian_embeddings_search` — paraphrase-multilingual-MiniLM-L12-v2, 50+ languages, persistent SQLite vector index) | ❌ usually paywalled (Smart Connections) | ✅ free + offline-capable (v2.0 beta) |
-| TypeScript strict + Biome lint + 405+ unit tests | varies | ✅ |
-
-That's the gap. enquire closes it in ~7500 lines of TypeScript with five mandatory runtime dependencies (`@modelcontextprotocol/sdk`, `chokidar`, `commander`, `gray-matter`, `zod`) plus two optional (`better-sqlite3` for `--persistent-index` and the `build-embeddings` subcommand; `@huggingface/transformers` for ML embeddings — both are no-ops when not invoked).
-
-> **Not affiliated with Obsidian.md.** Obsidian and the Obsidian logo are trademarks of Dynalist Inc. enquire-mcp is an independent open-source project that reads Obsidian-format vaults. The name «enquire» is a tribute to Tim Berners-Lee's 1980 hypertext system, not a trademark claim against any party.
-
----
-
-## Who is this for?
-
-- **Obsidian users on Claude Code / Cursor / OpenClaw / Codex** (or Devin or any other MCP-compatible client) who want the assistant to draft notes that actually link properly, follow `[[…]]`, and respect frontmatter.
-- **Agentic workflow builders** who need a structured layer over a markdown vault — `dataview_query`, `get_backlinks`, `list_tags` are the kind of primitives that compose into real automations.
-- **Tinkerers** who want to wire their PKM into LLM pipelines without writing a parser. We did the parsing.
-
----
-
-## Configure your AI client
-
-**Recommended: zero-install via `npx` — no clone, no build.** Drop this into your MCP client's config.
-
-> **Pick a channel.** `@oomkapwn/enquire-mcp` (no `@beta`) → stable **v1.11.1** with 28 tools — no `obsidian_search` umbrella, no ML embeddings. Add `@beta` for the v2.0 surface (30 tools, hybrid retrieval). Stable `@latest` will move to v2.0 once beta proves out.
-
-```json
-// Stable v1.x — 28 tools, no hybrid search
-{
-  "mcpServers": {
-    "obsidian": {
-      "command": "npx",
-      "args": ["-y", "@oomkapwn/enquire-mcp", "serve", "--vault", "/Users/you/Documents/Obsidian Vault"]
-    }
-  }
-}
-
-// Beta v2.0 — adds obsidian_search (BM25 + TF-IDF + ML embeddings via RRF)
-{
-  "mcpServers": {
-    "obsidian": {
-      "command": "npx",
-      "args": ["-y", "@oomkapwn/enquire-mcp@beta", "serve", "--vault", "/Users/you/Documents/Obsidian Vault"]
-    }
-  }
-}
-```
-
-**Where to drop that JSON, by client:**
-
-| Client | Config file |
-|---|---|
-| **Claude Desktop** | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`<br>Windows: `%APPDATA%\Claude\claude_desktop_config.json` |
-| **Claude Code (CLI)** | `~/.claude.json` (global) or `.mcp.json` (per-project) |
-| **Cursor** | `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project) |
-| **OpenClaw** | per your OpenClaw shared-memory MCP config |
-| **Codex / Codex CLI** | per-project `.mcp.json` or environment-specific config |
-| **Devin / any other MCP client** | wherever your client expects MCP server JSON |
-
-To enable write tools (`obsidian_create_note`, `obsidian_append_to_note`, `obsidian_rename_note`, `obsidian_replace_in_notes`, `obsidian_archive_note`), add `"--enable-write"` to the `args` array.
-
-<details>
-<summary><b>Alternative: global npm install</b></summary>
 
 ```bash
 npm install -g @oomkapwn/enquire-mcp
 enquire-mcp serve --vault ~/Documents/Obsidian\ Vault
 ```
 
-Then in your client config use `"command": "enquire-mcp"` instead of `"command": "npx"`.
-
-</details>
-
-<details>
-<summary><b>Alternative: from source (development)</b></summary>
-
-```bash
-git clone https://github.com/oomkapwn/enquire-mcp
-cd enquire-mcp && npm install && npm run build
-```
-
-Then `"command": "node"` with `"args": ["/absolute/path/to/dist/index.js", "serve", "--vault", "..."]`.
-
-</details>
-
-Restart your client. The server logs `enquire <version> ready (read-only, vault=…)` on stderr — that's your "it's connected" signal.
+That's it. Your AI now has structured access to wikilinks, backlinks, frontmatter, Dataview queries, and **`obsidian_search`** — a single hybrid-retrieval tool that auto-fuses BM25 + TF-IDF + ML embeddings.
 
 ---
 
-## What you get
+## Why enquire (vs alternatives)
 
-### 21 read tools (always on) + 4 opt-in (`--persistent-index` adds 1 BM25 / `--diagnostic-search-tools` adds 3 single-ranker) — **30 total** with 5 write tools
-
-| Tool | What it does |
-|---|---|
-| `obsidian_list_notes` | Filter by tag / folder / modified-since. Returns title, path, frontmatter, tags, mtime — newest first. |
-| `obsidian_read_note` | Body + frontmatter + wikilinks + embeds + tags for a note (by path or title). `format: "map"` returns just headings + counts. |
-| `obsidian_resolve_wikilink` | `[[Note]]`, `[[Note#Heading]]`, `[[Folder/Note\|alias]]`, `![[Embed]]`, `[[../relative/path]]` — all resolved to a real file. |
-| `obsidian_search_text` | Ranked case-insensitive token search across all notes (AND-tokenizer by default; `any` and `phrase` modes available). Returns structured response: `query`, `mode`, `scanned_notes`, ranked `matches` with snippets. |
-| `obsidian_get_recent_edits` | Newest-first stream, optional time window. |
-| `obsidian_get_backlinks` | Every note linking the target, ranked by hit count, with snippets. Distinguishes wikilink vs embed vs mixed. |
-| `obsidian_get_outbound_links` | Symmetric counterpart to backlinks — every link a note points to, with resolution status. |
-| `obsidian_get_unresolved_wikilinks` | Vault-hygiene: every `[[broken]]` link in the vault. |
-| `obsidian_list_tags` | Every unique tag with frontmatter / inline counts. |
-| `obsidian_dataview_query` | `LIST` / `TABLE` with `FROM`, `WHERE`, `SORT`, `LIMIT`. Supports `AND` / `OR` / `=` / `!=` / `contains` / `like`. |
-| `obsidian_validate_note_proposal` | **Anti-slop write linter.** Lint a draft note BEFORE writing — parses YAML, resolves every `[[wikilink]]` against the live vault, pre-classifies every tag (existing vs new), checks path/title collisions. Returns errors + warnings + per-link/tag diagnostics. Closes the #1 LLM-write pain ("AI generates structurally-broken notes"). |
-| `obsidian_find_similar` | **Hybrid lexical similarity** — given a note, rank others by tag-Jaccard + title 3-gram + shared-outbound + co-backlink. Each signal returned individually so the caller can re-rank. No embeddings, no native deps. |
-| `obsidian_get_note_neighbors` | **Graph context in one call** — outbound + backlinks + tag-cluster siblings for a note. Replaces 4 round-trips with 1. Designed for "give the LLM enough context to reason about THIS note" RAG. |
-| `obsidian_stats` | **Vault dashboard** — total notes, total bytes, recently-modified count, orphans, broken wikilinks, top tags. One-shot orientation call. |
-| `obsidian_lint_wiki` | **Karpathy LLM-Wiki lint workflow.** Five-bucket vault-hygiene report in one call: orphans, broken links, stub pages, stale notes, and concept candidates (capitalised phrases mentioned by ≥ K notes that lack their own page). Each finding ships with a fix suggestion. Pairs with the `lint_wiki` prompt. |
-| `obsidian_open_questions` | Walks every note for `Open question:` / `Q:` / `TODO?` / `??` markers. Returns each hit with source path, context heading, line, and age — sorted oldest-first so deferred threads aging out surface first. |
-| `obsidian_paper_audit` | For every `#paper` note, verifies frontmatter has at least one of arxiv/doi/url/isbn. Flags notes whose body mentions an arxiv ID or DOI but doesn't carry it in frontmatter — common after quick-capture from a chat. Returns a `proposed_frontmatter_patch` the agent can apply. |
-| `obsidian_find_path` | **Multi-hop graph traversal** — BFS from `from` to `to` over the wikilink graph, returns the shortest path up to `max_depth` hops with the wikilink text used at each step. `include_alternatives=true` returns up to 10 same-length paths so the agent can compare. Embeds (`![[…]]`) followed by default. |
-| `obsidian_open_in_ui` | Returns an `obsidian://open?vault=<v>&file=<f>` URI for hand-off to the running Obsidian desktop app. No filesystem or network side effect — just URI emission. `new_pane=true` opens the note in a split. |
-| `obsidian_list_canvases` | Lists `.canvas` files (Obsidian's whiteboard / mind-map format) with each canvas's node and edge counts. Honors `--exclude-glob` and `--read-paths`. |
-| `obsidian_read_canvas` | Parses one `.canvas` file into typed nodes (text / file / link / group / unknown) + edges (with from/to node IDs, sides, labels, colors). Each `file` node carries a `file_resolved` field (vault-relative path or `null` if broken). Returns a node-kind summary + `broken_file_refs` array. |
-| `obsidian_search` | **The default search tool from v2.0.** Hybrid retrieval via Reciprocal Rank Fusion (Cormack et al, 2009) over BM25 (FTS5) + TF-IDF + ML embeddings. Auto-detects available signals and gracefully degrades — TF-IDF only out of the box, BM25+TF-IDF with `--persistent-index`, full hybrid with `build-embeddings`. Returns per-signal observability so you can see which rankers contributed each hit. Use this instead of the per-ranker tools unless you specifically need single-ranker output for diagnostics. |
-| `obsidian_semantic_search` | **TF-IDF cosine retrieval.** Free / offline / no model download. Tokenizes + TF-IDFs + L2-normalizes every note's body once per session, then ranks notes by cosine similarity to the query. Catches synonym + related-term matches that `obsidian_search_text` (substring) and `obsidian_full_text_search` (BM25) miss. |
-| `obsidian_embeddings_search` | _Opt-in via `enquire-mcp install-model` + `enquire-mcp build-embeddings --vault <path>`._ **ML-embedding retrieval** via @huggingface/transformers + paraphrase-multilingual-MiniLM-L12-v2 (50+ languages, 384-dim, runs on CPU). Higher-quality than `obsidian_semantic_search` for paraphrases / synonyms / cross-language queries. Persistent SQLite vector index next to the FTS5 db. Chunks match the FTS5 chunker so v2.0 beta can do hybrid RRF over both. |
-| `obsidian_full_text_search` | _Opt-in via `--persistent-index`._ BM25-ranked full-text search backed by SQLite FTS5 inverted index. Sub-100ms on multi-thousand-note vaults. Hyphenated tokens (`claude-telegram`) auto-quoted. Returns chunk-level hits with `«…»`-bracketed snippets. |
-
-### 5 write tools (opt-in via `--enable-write`)
-
-| Tool | What it does |
-|---|---|
-| `obsidian_create_note` | Create a note with optional frontmatter. Refuses to overwrite by default. |
-| `obsidian_append_to_note` | Append a markdown block to an existing note. Configurable separator. |
-| `obsidian_rename_note` | **Atomic rename + automatic backlink rewrite.** Renames a note AND rewrites every `[[wikilink]]` / `![[embed]]` in the rest of the vault that resolved to it — preserving alias/section/block + the user's bare-vs-path target convention. Code-fence-aware: wikilinks inside ``` / ~~~ blocks stay verbatim. `dry_run: true` previews the plan without touching disk. |
-| `obsidian_replace_in_notes` | **Bulk find/replace across notes, code-fence-aware.** Walks the vault (or a `folder` subset), substitutes every literal occurrence of `search` with `replace` outside fenced code blocks, returns per-file occurrence counts. `dry_run: true` previews. `case_sensitive: false` for case-insensitive substring match. Refuses identical search/replace + empty search (footgun guards). |
-| `obsidian_archive_note` | Convenience wrapper around `obsidian_rename_note` for the common archive workflow. Moves the note's basename into `archive_folder` (default `Archive/`) and rewrites every wikilink/embed pointing at it. All `rename_note` guarantees apply (code-fence-aware, dry-run preview, refuses to clobber). |
-
-### MCP resources
-
-- `obsidian://vault/info` — root, note count, write flag, byte/cache limits, server version.
-- `obsidian://note/{path}` — every note as a first-class browsable resource. Compatible clients show your vault as a tree.
-
-### MCP prompts
-
-| Prompt | Args | What it scaffolds |
-|---|---|---|
-| `summarize_recent_edits` | `since_minutes?` | "What was I working on?" workflow. |
-| `review_tag` | `tag` | Pull every note for a tag, surface open threads. |
-| `find_orphans` | `folder?` | Notes with zero inbound links — archive candidates. |
-| `weekly_review` | `folder?` | Last 7 days of edits, grouped by tag — shipped / open / stuck. |
-| `monthly_review` | `folder?` | 30-day version: themes, what stalled, focus vs intent. |
-| `extract_todos` | `folder?`, `tag?` | Every TODO / FIXME / QUESTION, grouped by note. |
-| `process_inbox` | `folder` | Move / Merge / Promote / Archive proposals for an inbox folder. |
-| `consolidate_tags` | `min_count?` | Surface near-duplicate tags (`#productivity` vs `#productive`) and propose canonical merges. Read-only. |
-| `find_duplicates` | `folder?`, `min_score?` | Walk the vault for clusters of structurally-similar notes via `obsidian_find_similar`. Read-only — outputs merge proposals only. |
-| `lint_wiki` | `folder?` | **Karpathy LLM-Wiki `/lint`** — orchestrates `obsidian_lint_wiki` + `obsidian_open_questions` + `obsidian_paper_audit`, picks the 5 highest-leverage fixes across all three reports, proposes concrete `obsidian_*` calls. Read-only — proposes only. |
-
----
-
-## Example workflows
-
-### 1. Scan tagged ideas
-> "Show me notes tagged `#idea` from the last two weeks."
-
-`obsidian_list_notes({ tag: "idea", since_date: "2026-04-18" })`
-
-### 2. Follow wikilinks
-> "Read [[Project Apollo]] and summarise the open questions."
-
-`obsidian_resolve_wikilink({ wikilink: "Project Apollo" })` → walk any `[[…]]` inside the result.
-
-### 3. Pick up where you left off
-> "What was I editing today?"
-
-`obsidian_get_recent_edits({ since_minutes: 720 })`
-
-### 4. Audit a hub note
-> "Which notes link to [[Project Apollo]]?"
-
-`obsidian_get_backlinks({ title: "Project Apollo" })` → ranked list with snippets.
-
-### 5. Run a Dataview-style query
-> "List active ideas, sorted by mtime."
-
-```text
-TABLE status FROM #idea WHERE status = "active" SORT file.mtime DESC
-```
-
-### 6. Daily journaling (write mode)
-> "Append a 'shipped today' bullet to today's daily note."
-
-With `--enable-write`: `obsidian_append_to_note({ title: "2026-05-03", content: "- shipped a thing" })`
+| | Other Obsidian-MCPs | Smart Connections (paid plugin) | **enquire** |
+|---|:---:|:---:|:---:|
+| Read-only by default | varies | n/a | ✅ |
+| Resolves wikilinks (alias / section / block) | partial | n/a | ✅ full |
+| Backlinks ranked + snippeted | rare | n/a | ✅ |
+| Dataview-style queries | needs plugin | n/a | ✅ first-class |
+| Canvas (`.canvas`) read | rare | n/a | ✅ typed nodes + edges |
+| BM25 full-text search | rare | ❌ | ✅ FTS5 SQLite |
+| TF-IDF semantic search | ❌ | ❌ | ✅ |
+| **ML embeddings (multilingual)** | ❌ | ✅ paid | ✅ **free** |
+| **Hybrid (BM25+TF-IDF+embeddings, RRF)** | ❌ | ❌ | ✅ **only here** |
+| Per-signal observability on each hit | ❌ | ❌ | ✅ |
+| Privacy filter (`--exclude-glob` / `--read-paths`) | ❌ | n/a | ✅ verified at search + write paths |
+| Standalone (no Obsidian plugin) | varies | ❌ requires Obsidian | ✅ direct vault read |
+| MCP-native (any agent) | varies | ❌ Obsidian-only | ✅ stdio JSON-RPC |
+| SLSA-3 provenance | ❌ | n/a | ✅ |
+| Test suite | rare | n/a | ✅ 408 unit tests |
 
 ---
 
 ## Architecture
 
-```
-┌─────────────────┐     stdio JSON-RPC     ┌─────────────────────┐
-│  Claude Code /  │ ◄────────────────────► │   enquire           │
-│  Cursor /       │   tools/resources/     │  (this server)      │
-│  OpenClaw /     │                        │                     │
-│  Codex          │                        │                     │
-└─────────────────┘   prompts                └─────────┬───────────┘
-                                                      │
-                                          ┌───────────┼────────────┐
-                                          │           │            │
-                                          ▼           ▼            ▼
-                                    ┌─────────┐ ┌──────────┐ ┌──────────┐
-                                    │ Vault   │ │  Parser  │ │   DQL    │
-                                    │ walker  │ │  (gray-  │ │  engine  │
-                                    │ + cache │ │  matter) │ │          │
-                                    └────┬────┘ └──────────┘ └──────────┘
-                                         │
-                                         ▼
-                                ┌─────────────────────┐
-                                │  ~/Documents/       │
-                                │  Obsidian Vault/    │
-                                │  *.md *.md *.md ... │
-                                └─────────────────────┘
+```mermaid
+graph LR
+    Q[Query]
+    Q --> S[obsidian_search]
+    S --> BM25[BM25 / FTS5<br/>opt-in: --persistent-index]
+    S --> TFIDF[TF-IDF<br/>always on]
+    S --> EMB[ML embeddings<br/>opt-in: build-embeddings]
+    BM25 --> RRF{RRF fusion<br/>k=60}
+    TFIDF --> RRF
+    EMB --> RRF
+    RRF --> R[Ranked hits<br/>per_signal observability]
 ```
 
-- **Vault walker** — recursive, skips `.git` / `.obsidian` / `.trash` / dot-dirs / symlinks. Realpath-checks every read and write to prevent symlink-escape attacks.
-- **Cache** — mtime-keyed, LRU-evicted. Default cap 1024 entries.
-- **Parser** — `gray-matter` for YAML, hand-rolled regex for wikilinks / embeds / tags. Fenced code blocks are stripped before tag extraction.
-- **DQL engine** — quote-aware tokenizer for keywords (`FROM`, `WHERE`, `SORT`, `LIMIT`, `AND`); won't mis-split on `WHERE x = "foo SORT bar"`.
+`obsidian_search` auto-detects available signals and fuses them via Reciprocal Rank Fusion (Cormack et al, 2009). Returns per-signal contributions on every hit so agents can see WHY each result ranked.
 
-### Benchmarks
+```
+Tier 1: serve --vault <path>                      → TF-IDF (zero setup, instant)
+Tier 2: serve --vault <path> --persistent-index   → + BM25 (sub-100ms top-10)
+Tier 3: + install-model + build-embeddings        → + ML embeddings (multilingual)
+```
 
-Latency per tool against synthetic vaults at 1 000 / 10 000 notes (post-1.3 with the basename-indexed `findBestMatch` shipped in v1.3.0). p50 / p99 in milliseconds, 5 runs after warmup. Bench script: [`scripts/bench.mjs`](./scripts/bench.mjs). Full results in [`bench/results.md`](./bench/results.md).
+---
 
-| Tool | 1 000 notes | 10 000 notes |
+## Quick start
+
+> **Two channels:** `npm install @oomkapwn/enquire-mcp` → **v2.0** (stable, hybrid retrieval). `@beta` → preview track. `@1` → legacy v1.x line.
+
+**Claude Desktop / Claude Code / Cursor / Codex / any MCP client**:
+
+```json
+{
+  "mcpServers": {
+    "obsidian": {
+      "command": "npx",
+      "args": ["-y", "@oomkapwn/enquire-mcp", "serve", "--vault", "/path/to/vault"]
+    }
+  }
+}
+```
+
+| Client | Config file |
+|---|---|
+| Claude Desktop | macOS `~/Library/Application Support/Claude/claude_desktop_config.json` · Windows `%APPDATA%\Claude\claude_desktop_config.json` |
+| Claude Code (CLI) | `~/.claude.json` (global) or `.mcp.json` (per-project) |
+| Cursor | `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project) |
+| Codex / OpenClaw / Devin | per-tool MCP config |
+
+**Enable hybrid retrieval** (one-time setup, ~10 min for a 100-note vault):
+
+```bash
+enquire-mcp install-model multilingual          # ~120MB, 50+ languages
+enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
+# Add --persistent-index to your serve invocation for BM25.
+```
+
+---
+
+## Tools (30 total)
+
+### 21 always-on read tools
+
+| Tool | What it does |
+|---|---|
+| `obsidian_search` | **Hybrid retrieval** — fuses BM25 + TF-IDF + ML embeddings via RRF. The default search tool. Auto-detects available signals. |
+| `obsidian_read_note` | Full content + frontmatter + wikilinks + embeds + tags. Also accepts periodic-note aliases (`title: "today"` / `"weekly"` / `"monthly"`). |
+| `obsidian_list_notes` | Vault-wide or folder-scoped. Includes title + tags + mtime + counts. |
+| `obsidian_resolve_wikilink` | Resolves `[[Note]]`, `[[Note\|Alias]]`, `[[Note#Section]]`, `[[Note#^block]]`, with did-you-mean on near-miss. |
+| `obsidian_get_backlinks` | Every note linking to X, ranked + snippeted. |
+| `obsidian_get_outbound_links` | Outbound `[[wikilinks]]` from one note, with resolution status. |
+| `obsidian_get_unresolved_wikilinks` | Vault-wide broken-link audit. |
+| `obsidian_get_recent_edits` | Notes modified in the last N minutes. |
+| `obsidian_list_tags` | Tag census across vault (frontmatter + inline). |
+| `obsidian_dataview_query` | First-class Dataview-style queries (`LIST` / `TABLE`, `WHERE`, `AND` / `OR` / `LIKE` / `contains`). |
+| `obsidian_find_path` | Multi-hop graph BFS between two notes (with alternatives). |
+| `obsidian_find_similar` | Note-to-note similarity (tag + folder + content signals). |
+| `obsidian_get_note_neighbors` | Outbound + inbound + tag-sibling for one note. |
+| `obsidian_stats` | Vault dashboard: note count, tag count, broken links. |
+| `obsidian_lint_wiki` | Karpathy LLM-Wiki `/lint` workflow (orphans / broken / stubs / stale). |
+| `obsidian_open_questions` | Find open `?` questions across the vault. |
+| `obsidian_paper_audit` | Track arXiv references and read-status. |
+| `obsidian_validate_note_proposal` | Lint a draft note before writing (closes the #1 LLM-write pain). |
+| `obsidian_list_canvases` | List `.canvas` files with node + edge counts. |
+| `obsidian_read_canvas` | Parse `.canvas` into typed nodes (text/file/link/group) + edges. |
+| `obsidian_open_in_ui` | Emit `obsidian://open?vault=...` URI. |
+
+### 4 opt-in read tools
+
+| Tool | Flag | Notes |
 |---|---|---|
-| `list_notes` (no filter) | 21 / 22 | 104 / 105 |
-| `search_text` (linear scan) | 30 / 33 | 536 / 542 |
-| `get_recent_edits` | 11 / 12 | 100 / 102 |
-| `list_tags` | 44 / 45 | 1 037 / 1 076 |
-| `get_backlinks` | 54 / 55 | 1 145 / 1 154 |
-| `find_similar` | 45 / 49 | 1 065 / 1 120 |
-| `get_note_neighbors` | 76 / 81 | 2 002 / 2 279 |
-| `vault_stats` | 45 / 45 | 1 058 / 1 319 |
-| `validate_note_proposal` | 79 / 80 | 1 353 / 1 459 |
+| `obsidian_full_text_search` | `--persistent-index` + `--diagnostic-search-tools` | BM25 ranking, sub-100ms. |
+| `obsidian_search_text` | `--diagnostic-search-tools` | Token search (all/any/phrase modes). |
+| `obsidian_semantic_search` | `--diagnostic-search-tools` | TF-IDF cosine standalone. |
+| `obsidian_embeddings_search` | `--diagnostic-search-tools` | ML embeddings standalone. |
 
-Read this as: most tools are sub-100ms below 1 000 notes. **For vaults above ~1 000 notes, `--persistent-index` is strongly recommended** — `obsidian_full_text_search` runs sub-100ms on 10k vaults via FTS5 BM25 (37–103× faster than the linear `search_text` on the same data, measured separately in [`scripts/bench-search.mjs`](./scripts/bench-search.mjs)).
+### 5 opt-in write tools (`--enable-write`)
 
-The graph-aware tools (`find_similar`, `get_note_neighbors`, `vault_stats`) walk the link graph in pure-JS at O(N · avg_outbound), now backed by a basename-indexed lookup that brought 10k-note latencies from 2–4 s down to 1–2 s — about 30–45 % faster across the board. The remaining cost is parse-cache warmup; the second-and-later calls in a session ride the in-memory cache.
+| Tool | Notes |
+|---|---|
+| `obsidian_create_note` | Refuses overwrite without `overwrite=true`. Empty path rejected. |
+| `obsidian_append_to_note` | Symlink-safe; respects `--max-file-bytes`. |
+| `obsidian_rename_note` | Rewrites every wikilink across vault. Code-fence-aware. `dry_run` available. |
+| `obsidian_replace_in_notes` | Bulk find/replace. Per-file errors collected; `partial: true` on mid-loop fail. |
+| `obsidian_archive_note` | Wraps rename to `Archive/`. Preserves backlinks. |
+
+Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **10 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`).
 
 ---
 
 ## Configuration
 
-| Flag | Default | What it does |
+| Flag | Default | Notes |
 |---|---|---|
-| `--vault <path>` | (required) | Path to the Obsidian vault root. |
-| `--enable-write` | off | Register the five write tools. Server is otherwise strictly read-only. |
-| `--max-file-bytes <n>` | 5 MB | Refuse to read or write any file larger. |
-| `--cache-size <n>` | 1024 | LRU cap for the parsed-note cache. |
-| `--persistent-cache` | off | Persist parsed-note cache to disk; warm cold-starts on large vaults. **Privacy: full note bodies are written to the cache file. See "Cache & privacy" below.** |
-| `--cache-file <path>` | auto | Override persistent-cache file location. |
-| `--persistent-index` | off | Maintain a SQLite FTS5 inverted index for sub-100ms BM25-ranked search. Registers `obsidian_full_text_search` + the `obsidian://chunk/{n}/{path}` resource. **Privacy: stores chunked note content + tag list + wikilink targets. See [`SECURITY.md`](./SECURITY.md).** |
-| `--tokenize <mode>` | `unicode61` | FTS5 tokenize mode. `unicode61` (default; Latin/Cyrillic, removes diacritics) or `trigram` (CJK / mixed-script, ~2x index size). Changing this triggers an automatic index rebuild. |
-| `--index-file <path>` | auto | Override the FTS5 index file location. |
-| `--exclude-glob <pattern...>` | none | Denylist privacy filter — paths matching any pattern are invisible to every tool and refuse direct reads. Supports `*`, `**`, `?`. Repeatable. |
-| `--read-paths <pattern...>` | none | **Strict allowlist.** When set, ONLY paths matching one of these glob patterns are visible to any tool. Complement to `--exclude-glob` (denylist). If both are set: a path must match an allow-glob AND not match any exclude-glob. Same glob semantics. Repeatable. |
-| `--watch` | off | Watch the vault for `.md` file edits. On change: invalidate the parsed-note cache for that file; if `--persistent-index` is also set, incrementally re-sync that file's FTS5 chunks. Editor saves are debounced. Use this for long-running servers where you keep editing in Obsidian. |
-| `--disabled-tools <name...>` | none | Skip registration of specific tools by exact name. Useful for narrowing what an agent can call (e.g. read-only research agent gets only `obsidian_search_text` + `obsidian_read_note`). Repeatable. Names match `tools/list`. |
-| `--enabled-tools <name...>` | none | **Strict allowlist** — when set, ONLY listed tools register. Complement to `--disabled-tools`. If both: a tool must be in allowlist AND not in denylist. Repeatable. |
+| `--vault <path>` | required | Path to Obsidian vault root. |
+| `--enable-write` | off | Register the 5 write tools. |
+| `--exclude-glob <pat...>` | none | Privacy denylist. Repeatable. Example: `'02_Personal/**'`. |
+| `--read-paths <pat...>` | none | Privacy allowlist (only matching paths visible). Repeatable. |
+| `--persistent-index` | off | SQLite FTS5 BM25. Enables `obsidian_full_text_search` (with `--diagnostic-search-tools`). |
+| `--persistent-cache` | off | Persist parsed-note cache across restarts. |
+| `--watch` | off | Live invalidation on `.md` add/change/unlink. |
+| `--diagnostic-search-tools` | off | Register 4 single-ranker search tools (defaults: hybrid `obsidian_search` only). |
+| `--enabled-tools <name...>` | all | Strict allowlist (gate to a subset). |
+| `--disabled-tools <name...>` | none | Denylist. |
+| `--max-file-bytes <n>` | 5 MB | Per-file read/write cap. |
+| `--cache-size <n>` | 1024 | LRU cap for parsed-note cache. |
 
-### Cache & privacy
+Subcommands: `serve` · `clear-cache` · `clear-index` · `index` (cold-build FTS5) · `install-model` · `build-embeddings` · `clear-embeddings`.
 
-When `--persistent-cache` is on, parsed notes are serialized to disk so subsequent server restarts skip re-parsing. By default the file lives at `~/Library/Caches/enquire/<sha1>.json` on macOS, `~/.cache/enquire/<sha1>.json` on Linux. Important caveats:
-
-- **Full note bodies are stored**, not just metadata. Anyone who can read your home cache directory can read your vault.
-- **File mode is `0600`** (user-read/write only) and the parent directory is `0700`. We don't trust shared home directories.
-- **Deleted notes are purged** on the next server start: when enquire sees a cached entry whose source file no longer exists, it drops the entry from memory and rewrites the cache file without it on shutdown.
-- **Stale entries** (file mtime changed since cache write) are silently dropped on load; the source file is re-parsed.
-- **Manual purge:** run `enquire-mcp clear-cache --vault <path>` to delete the cache file for a specific vault.
-- The cache file is **never read or written for vaults other than the one whose realpath matches the cache file's `root` field** — protects against cross-vault content leaks if you share a cache dir.
-
-The server logs `WRITE-ENABLED` to stderr on boot when the flag is on, so you can verify the mode at a glance.
+Full reference: [docs/api.md](./docs/api.md).
 
 ---
 
 ## Security
 
-- **Read-only by default.** Write tools are not even registered unless `--enable-write` is passed.
-- **Path traversal blocked.** Every resolved path is checked against the vault root via `realpath`.
-- **Symlink-escape blocked.** Symlinks inside the vault that resolve outside (file or directory) are skipped on listing and rejected on read/write.
-- **DoS guard.** Default 5 MB cap on any single file read or write; bounded LRU cache.
-- **YAML.** Parsed via `gray-matter` (`js-yaml` `safeLoad` under the hood) — no code execution.
+- **Read-only by default.** Write tools require `--enable-write`.
+- **Path traversal blocked.** Realpath check on every read+write target. Symlinks inside the vault that resolve outside are rejected.
+- **Privacy boundary verified across all paths**, including persistent indexes (FTS5 / embed-db search-time filter) and the `obsidian://chunk/...` resource. Privacy fail-closed: empty `--read-paths` / `--exclude-glob` patterns refuse to start.
+- **`gray-matter` (`js-yaml` safeLoad)** — no code execution via frontmatter.
+- **DQL parser** — no shell, no `eval`, no template expansion.
+- **Cache + index files** — chmod 0600, parent dir 0700.
+- **SLSA-3 provenance** on every npm release.
+- **Branch protection ruleset** with `bypass_mode: pull_request` — every change goes through PR with audit trail. Release pipeline verifies SHA-on-main + 8 required CI checks before publishing.
 
-Found a security issue? See [SECURITY.md](./SECURITY.md).
+Full posture: [SECURITY.md](./SECURITY.md). Report vulnerabilities to `oomkapwn@gmail.com`.
+
+---
+
+## Engineering
+
+| Surface | Posture |
+|---|---|
+| Language | TypeScript strict + `noUncheckedIndexedAccess` |
+| Lint | Biome 2 (zero-warning policy) |
+| Tests | 408 unit tests across 19 files |
+| CI | ubuntu × {Node 20, 22, 24} required + macOS advisory job |
+| Coverage | Lines ≥86%, statements ≥82%, functions ≥75%, branches ≥73% (gated) |
+| Audit | `npm audit --audit-level=moderate` for prod; high for dev |
+| Runtime deps | 5 mandatory (`@modelcontextprotocol/sdk`, `chokidar`, `commander`, `gray-matter`, `zod`) + 2 optional (`better-sqlite3` for FTS5 / embed-db; `@huggingface/transformers` for ML embeddings) |
+| Releases | npm + GitHub release per tag · semver · provenance attached · channels: `latest` (stable), `beta`, `alpha` |
+
+```bash
+git clone https://github.com/oomkapwn/enquire-mcp.git
+cd enquire-mcp && npm install
+npm test          # full suite
+npm run lint      # zero warnings
+npm run build     # tsc → dist/
+```
 
 ---
 
 ## FAQ
 
-**Does it support Roam / Logseq / TiddlyWiki?**
-No. Obsidian's wikilink semantics, frontmatter conventions, and folder structure are baked in. Other tools are out of scope.
+**Q: Do I need Obsidian installed?**
+No. enquire reads `.md` + `.canvas` files directly. Works against any Obsidian-format vault.
 
-**Will it modify my vault?**
-Not unless you start it with `--enable-write`. By default the server is strictly read-only. With write enabled, the five write tools refuse to overwrite existing notes by default (`obsidian_create_note` and `obsidian_rename_note` both require `overwrite=true` to clobber; `obsidian_replace_in_notes` refuses identical search/replace + empty search; `obsidian_archive_note` is a thin rename-into-archive wrapper that inherits the same guards), and all writes refuse to land outside the vault even if a parent dir is symlinked away.
+**Q: Will this write to my vault?**
+No, unless you explicitly start with `--enable-write`. Even then, all 5 write tools are gated by privacy filters and refuse to overwrite without `overwrite: true`.
 
-**Does it work over the network?**
-No. It's a local stdio MCP server, designed for one client process per vault. There's no HTTP transport, no auth, no rate limiting — and that's intentional.
+**Q: Is my data sent anywhere?**
+Only on `enquire-mcp install-model` (downloads ONNX weights from HuggingFace). The serve mode itself never makes outbound HTTP. Embeddings run on CPU locally.
 
-**My DQL query returned nothing.**
-Verify the source. `LIST FROM "01_Projects"` matches notes whose path starts with `01_Projects/`. `LIST FROM #idea` matches notes carrying the `idea` tag. Mix them with `WHERE`. See [docs/api.md](./docs/api.md) for the supported subset and grammar.
+**Q: How is this different from Smart Connections?**
+Smart Connections is a paid Obsidian plugin that does ML embeddings inside Obsidian. enquire-mcp is a standalone MCP server: free, MCP-native (works with Claude / Cursor / Codex / any agent), and adds hybrid retrieval (BM25 + TF-IDF + embeddings via RRF) for higher recall than embeddings alone.
 
-**What about the full Dataview plugin?**
-We implement a deliberately small subset (`LIST` / `TABLE`, `FROM "folder" | #tag`, `WHERE pred (AND|OR pred)*`, `SORT`, `LIMIT`; ops `=`, `!=`, `contains`, `like`). No arithmetic / functions / `FLATTEN` / `GROUP BY` / joins / parenthesized precedence. PRs that close those gaps are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
+**Q: Performance on large vaults?**
+Cold-build of FTS5 on a 1k-note vault: ~5s. Warm BM25 top-10: sub-100ms. Embedding build: ~30ms/chunk on M1 (8s for 256 chunks, ~8min for 8k chunks). Hybrid query latency: <200ms typical.
 
-**How big a vault can it handle?**
-Tested daily against a ~120-note vault; benched up to 1000 synthetic notes (see [`scripts/bench-search.mjs`](./scripts/bench-search.mjs)). The walker is O(notes) per call; the in-memory cache makes repeat reads O(1). For multi-thousand-note vaults pass `--persistent-index` — the SQLite FTS5 backend gives sub-millisecond BM25 search (37–103x faster than the linear-scan path on 100–1000 notes).
-
-**Why scoped npm name (`@oomkapwn/enquire-mcp`)?**
-A scoped name protects the brand and side-steps the very crowded `obsidian-mcp` / `mcp-obsidian` namespace on npm. The CLI binary is `enquire-mcp` to match the npm package name.
-
----
-
-## Develop
-
-```bash
-npm test              # full suite (count in the badge)
-npm run test:coverage # vitest --coverage (v8 provider)
-npm run lint          # biome check
-npm run lint:fix      # biome check --write (auto-fixes)
-npm run dev           # tsc --watch
-node scripts/smoke.mjs [vault-path]   # end-to-end JSON-RPC smoke
-```
-
-Coverage on the latest release: **82% lines · 78% statements · 73% branches**. CI uploads the full HTML report as a workflow artifact (`coverage-report`).
-
-Build runs `tsc` and marks `dist/index.js` executable. CI tests Node 20 / 22 / 24, runs the smoke against a synthetic vault, generates a coverage report, and runs `npm audit --audit-level=high`.
-
----
-
-## Troubleshooting
-
-- **"Vault not found" on boot** — pass an absolute path or `~`-prefixed shell-expanded path to `--vault`. Relative paths resolve against the process cwd.
-- **"Path escapes vault root"** — the path you passed (or a wikilink resolved to) leaves the vault, often via a symlink. The server intentionally refuses these reads.
-- **"File too large" on a `.md` you didn't expect** — usually a sync conflict or binary accidentally renamed `.md`. Bump `--max-file-bytes` if you really want it ingested.
-- **Write tool not visible to the client** — start the server with `--enable-write`, *after* the `serve` subcommand.
-- **Russian / non-ASCII titles** — supported. Both inline `#тег` and YAML `tags: [идея]` are picked up.
-
----
-
-## Versioning & releases
-
-Semantic versioning. See [CHANGELOG.md](./CHANGELOG.md) for the full history.
-
-- **1.9.x** — **Bulk find/replace** (`obsidian_replace_in_notes` — code-fence-aware, dry-run preview, footgun guards). Reuses rename_note's line walker. v1.8.1 patch fixed 3 P1 bugs (findPath O(N²) → O(N), semanticSearch frontmatter leak, exclusion error message accuracy).
-- **1.8.x** — **Semantic search** (`obsidian_semantic_search`) — pure-JS TF-IDF cosine retrieval. Free / offline / no model download. Catches the synonym + related-term matches BM25 misses. Real ML embedding retrieval is the v2.0 follow-up.
-- **1.7.x** — **Canvas (`.canvas`) read tools** (`obsidian_list_canvases` + `obsidian_read_canvas` — parses Obsidian's whiteboard format into typed nodes + edges, surfaces broken file refs).
-- **1.6.x** — **Multi-hop graph traversal** (`obsidian_find_path` BFS) + **`obsidian_open_in_ui`** (obsidian:// URI hand-off) + **strict allowlist** (`--read-paths` complement to `--exclude-glob`).
-- **1.5.x** — **Karpathy LLM-Wiki `/lint` workflow** — `obsidian_lint_wiki` (orphans/broken/stubs/stale/concept candidates) + `obsidian_open_questions` + `obsidian_paper_audit` + `lint_wiki` prompt.
-- **1.4.x** — Three new MCP prompts (`consolidate_tags`, `find_duplicates`, `monthly_review`) bringing the total to 9.
-- **1.3.x** — **Performance + benchmarks.** `findBestMatch` rebuilt around a basename + relPath index (O(N²) → O(1) avg) — 24–46% faster across graph-aware tools at 10k notes. New `scripts/bench.mjs` + reproducible numbers in `bench/results.md`.
-- **1.2.0** — **Watcher mode** (`--watch`) — incremental cache + FTS5 reindex on file changes. Editor saves debounced. `--exclude-glob` honored.
-- **1.1.x** — `obsidian_rename_note` (atomic rename + automatic backlink rewrite, code-fence-aware, dry-run preview).
-- **1.0.0** — **Stable. API freeze.** Stability promise across tool names, argument shapes, resource URIs, prompt names, CLI flags. SLSA-3 release provenance.
-- **0.13.x** — Graph-aware retrieval: `obsidian_find_similar` (multi-signal lexical hybrid), `obsidian_get_note_neighbors` (1-hop graph context in one call), `obsidian_stats` (vault dashboard).
-- **0.12.x** — Anti-slop write validator (`obsidian_validate_note_proposal`) — lints YAML + wikilinks + tags before write.
-- **0.11.x** — Privacy filter (`--exclude-glob`), periodic-note aliases (`title: "today"`), `Did you mean: …` suggestions, document-map projection (`format: "map"`). *(0.11.0 tag preserved for history; npm publish failed on a runner-availability incident — features rolled into 0.12.0.)*
-- **0.10.x** — SQLite FTS5 inverted index (opt-in via `--persistent-index`), BM25 ranking, sub-millisecond search on multi-thousand-note vaults (37–103x faster than the linear scan path), chunk-level addressing via `obsidian://chunk/{n}/{path}` resource. Filter API on full-text search (`tag`, `since`, `folder`).
-- **0.9.x** — `search_text` switched to AND-tokenizer default with structured response (BREAKING). Parallel file reads in scan path.
-- **0.8.x** — DQL `contains` semantics for arrays (membership, not substring). Code of Conduct.
-- **0.7.x** — Renamed `obsidian-mcp` → `enquire-mcp` (via brief `memex` detour) to escape the crowded `obsidian-mcp` npm namespace and to land on a name with a clear historical referent — Tim Berners-Lee's 1980 ENQUIRE prototype of the Web.
-- **Roadmap (1.x)** — Embedding-based retrieval (sqlite-vec + a small JS-runnable model, layered on top of the existing lexical hybrid).
+**Q: Does it support languages other than English?**
+Yes. Default embedding model is `paraphrase-multilingual-MiniLM-L12-v2` (50+ languages). Validated end-to-end on Russian + English bilingual vaults. CJK requires the upcoming Intl.Segmenter pre-pass (v2.1 backlog).
 
 ---
 
 ## Contributing
 
-Bug fixes welcome. New tools should pass the bar of "useful against an Obsidian vault on day 1." See [CONTRIBUTING.md](./CONTRIBUTING.md).
-
----
-
-## Support the project
-
-If enquire-mcp saves you keystrokes or makes your AI assistant smarter about your vault, **consider [starring the repo](https://github.com/oomkapwn/enquire-mcp) to show your ❤️ and support.** Stars help other Obsidian users find the project, and they tell us where to invest the next cycle.
-
-Other ways to help:
-- 🐛 **File a bug** — the more concrete the repro (vault shape, exact tool call, server stderr), the faster the fix. Use [the bug template](https://github.com/oomkapwn/enquire-mcp/issues/new?template=bug_report.yml).
-- 💡 **Propose a feature** — open a [feature request](https://github.com/oomkapwn/enquire-mcp/issues/new?template=feature_request.yml) and we'll align on scope before any code is written.
-- 🔧 **Send a PR** — bug fixes always welcome. New tools should pass the «useful against an Obsidian vault on day 1» bar. See [CONTRIBUTING.md](./CONTRIBUTING.md).
-- 💬 **Tell us how you use it** — open a thread in [Discussions](https://github.com/oomkapwn/enquire-mcp/discussions) and we'll figure out what to build next from real workflows.
-
----
+Issues and PRs welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md). All changes go through PR review per branch protection ruleset.
 
 ## License & credits
 
-[MIT](./LICENSE). Built by Alex — [GitHub `@oomkapwn`](https://github.com/oomkapwn) · [X `@OomkaBear`](https://x.com/OomkaBear). Powered by [Model Context Protocol](https://modelcontextprotocol.io/), [`gray-matter`](https://github.com/jonschlinkert/gray-matter), [`commander`](https://github.com/tj/commander.js), and the patience of one specific Obsidian vault that didn't deserve to be parsed by hand.
+[MIT](./LICENSE). Built by Alex — [GitHub `@oomkapwn`](https://github.com/oomkapwn) · [X `@OomkaBear`](https://x.com/OomkaBear).
 
-Named after [ENQUIRE](https://en.wikipedia.org/wiki/ENQUIRE) — the 1980 hypertext prototype of the World Wide Web (see the inline note above for the longer story).
+Named after [ENQUIRE](https://en.wikipedia.org/wiki/ENQUIRE) — Tim Berners-Lee's 1980 hypertext prototype of the World Wide Web.
+
+> **Not affiliated with Obsidian.md.** Obsidian and the Obsidian logo are trademarks of Dynalist Inc. enquire-mcp is an independent open-source project that reads Obsidian-format vaults.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.0.0-beta.4";
+const VERSION = "2.0.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {

--- a/tests/docs-consistency.test.ts
+++ b/tests/docs-consistency.test.ts
@@ -96,10 +96,12 @@ describe("docs/code consistency — README mirrors registered MCP surface", () =
     const alwaysOnRead = [...registered].filter(
       (n) => !writeNames.has(n) && !ftsNames.has(n) && !diagnosticGated.has(n)
     );
-    // Look for a heading or sentence claiming "<N> read tools (always on)".
-    const m = /(\d+) read tools \(always on\)/.exec(readme);
+    // Look for a heading or sentence claiming an always-on read tool count.
+    // Accept "<N> read tools (always on)" (legacy phrasing) or "<N> always-on
+    // read tools" (current heading-style phrasing in v2.0.0+ README).
+    const m = /(\d+) read tools \(always on\)|(\d+) always-on read tools/.exec(readme);
     expect(m, "README must declare a number of always-on read tools").not.toBeNull();
-    const claimed = Number.parseInt(m?.[1] ?? "0", 10);
+    const claimed = Number.parseInt(m?.[1] ?? m?.[2] ?? "0", 10);
     expect(claimed).toBe(alwaysOnRead.length);
   });
 


### PR DESCRIPTION
## Summary
- README: 484 → 253 lines (rewrite for v2.0.0 stable launch)
- Mermaid diagram of hybrid retrieval (BM25 + TF-IDF + embeddings via RRF)
- Comparison table vs other Obsidian-MCPs + Smart Connections
- Tool catalog as structured tables (was prose)
- FAQ section, security posture summary
- AI-indexability: clear keywords, structured H2/H3, scannable

## Test plan
- [x] 408/408 unit tests
- [x] docs-consistency invariant updated to accept new heading style