### PR TITLE
chore: clean 3 pre-existing lint warnings (zero-warning gate)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -121,7 +121,7 @@ function extractHeadings(body: string): Array<{ level: number; text: string; lin
     }
     if (inFence) continue;
     const m = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
-    if (m && m[1] && m[2]) {
+    if (m?.[1] && m[2]) {
       out.push({ level: m[1].length, text: m[2], line: i + 1 });
     }
   }
@@ -1877,7 +1877,7 @@ export async function getOpenQuestions(
         continue;
       }
       const m = re.exec(line);
-      if (!m || !m[1]) continue;
+      if (!m?.[1]) continue;
       out.push({
         question: m[1].trim(),
         source_path: e.relPath,

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -7,7 +7,6 @@ import {
   appendToNote,
   archiveNote,
   createNote,
-  embeddingsSearch,
   listNotes,
   readNote,
   renameNote,


### PR DESCRIPTION
Trivial cleanup. Zero-warning lint state means future regressions surface as the only finding.