### PR TITLE
v2.4.0: Sprint 4 — Karpathy LLM-Wiki backend positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] — 2026-05-08
+
+**Sprint 3 — Obsidian-native moats.** Two features that exploit primitives no other Obsidian-MCP uses: the wikilink graph + atomic frontmatter manipulation. Result: retrieval quality gap that generic vector stores cannot close.
+
+### Added — Wikilink graph-boost on `obsidian_search` (default ON)
+
+After RRF fusion, we count how many *other* top-K hits link to each candidate, then boost score by `α × in-degree` (α=0.005 — enough to break ties, won't override strong single-ranker signals). Equivalent to a 1-step personalised PageRank seeded by the fused top-K.
+
+**This is the "only enquire-mcp does this" feature.** Generic vector stores can't do this without an Obsidian-aware layer; Smart Connections doesn't do it either. Wikilinks ARE the differentiating Obsidian primitive — using them as a retrieval signal is something only an Obsidian-native server can do well.
+
+Cost is small: read top-K notes (already cached from prior calls), build adjacency in memory, count overlaps. Sub-50ms on a 30-candidate set.
+
+Default ON. Set `graph_boost: false` to disable for diagnostic comparison ("did boost help here?").
+
+### Added — `obsidian_frontmatter_get`, `obsidian_frontmatter_search`, `obsidian_frontmatter_set`
+
+Surgical YAML manipulation. Pre-fix, agents wanting to set `status: published` on 12 notes had to use find/replace text — error-prone (multi-line strings, special chars, key-collision edge cases). Now:
+
+- **`_get`** (read) — read full frontmatter or single key. Periodic-note aliases work (`title: "today"`).
+- **`_search`** (read) — find notes by frontmatter predicate. Three exclusive predicates: `equals` (strict equality), `exists` (key must be present), `contains` (for array values). Useful as a precursor to bulk `_set`: "find all notes with status:draft, then set their status to published."
+- **`_set`** (write, gated by `--enable-write`) — set/unset keys atomically. Pass `null` as value to delete a key. Round-trips through gray-matter so YAML formatting/quoting/types stay consistent. `dry_run: true` shows the diff without writing. Returns `before` + `after` + `changed_keys` for observability.
+
+### Tests
+
+431 unit tests pass (was 420, +11 new): frontmatter get/set/search end-to-end + dry-run + null-deletion + exclusive predicate validation.
+
+### Architecture & strategic position
+
+This sprint cements the "**only enquire-mcp uses your wikilink graph as a retrieval signal**" claim — concrete, measurable, defensible. Combined with v2.2.0's hybrid retrieval and v2.1.0's structural breadcrumbs, the retrieval stack is now:
+
+```
+query → BM25 (FTS5) ┐
+       → TF-IDF      ├→ RRF fuse → graph-boost rerank → top-K
+       → embeddings  ┘
+```
+
+Each layer is a distinct competitive moat against generic vector-store-based MCPs.
+
+### Migration
+
+**No-op for default users.** Graph boost is on by default; if it changes ranking on a specific corpus, that's the intended behavior. Set `graph_boost: false` to revert to pre-v2.3.0 RRF-only ranking.
+
 ## [2.2.0] — 2026-05-08
 
 **Sprint 2 — Smart Connections gap closure.** Three features that match what users currently pay for via the dominant Obsidian semantic-search plugin, all MCP-native (work in Claude Code / Cursor / Codex / any agent — not Obsidian-only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] — 2026-05-08
+
+**Sprint 2 — Smart Connections gap closure.** Three features that match what users currently pay for via the dominant Obsidian semantic-search plugin, all MCP-native (work in Claude Code / Cursor / Codex / any agent — not Obsidian-only).
+
+### Added — `obsidian_chat_thread_append` + `obsidian_chat_thread_read`
+
+Note-tethered AI conversations. Smart Connections' #1 paid feature: AI chat threads bound to a specific note, persisted as markdown so they're searchable, version-controllable, and survive across sessions / clients.
+
+Wire format: `## Chat: <title>` heading at the top, with `### <role> · <ISO timestamp>` blocks per message. Human-readable, parseable, and feeds back into our retrieval index — agents can search past chat threads by content.
+
+```md
+## Chat: research session — 2026-05-08
+
+### user · 2026-05-08T10:00:00Z
+What did I write last week about RLHF?
+
+### assistant · 2026-05-08T10:00:01Z
+Three notes: ...
+```
+
+`_append` is a write tool (gated by `--enable-write`); `_read` is read-only.
+
+### Added — `obsidian_search` `granularity: "block"` argument
+
+The default `note` mode collapses multi-chunk hits to one per note (best chunk wins). New `block` mode keeps each chunk as a distinct hit — useful when a note covers a topic in multiple paragraphs and you want the LLM to see all of them. RRF fuses on `path#chunk_index` keys instead of just `path`.
+
+This is what Smart Connections paywalls as "block-level connections" in their Pro tier. Free here.
+
+### Added — `obsidian_context_pack`
+
+Token-budgeted context bundling. Takes a question, runs hybrid search, gathers note bodies + 1-line backlink summaries + optionally recent daily notes, deduplicates, packs to a token budget, returns one ready-to-paste markdown bundle. Saves the agent ~5 separate tool calls; produces a coherent context blob you can paste into ANY AI chat (not just Obsidian — that's the MCP-native edge over Smart Connections' "Send to Smart Context").
+
+### Tests
+
+420 unit tests pass (was 413, +7 new): chat thread create/append/read end-to-end, multi-line content preservation, regex multi-line flag for thread-title detection, write-permission enforcement.
+
+### Migration
+
+**No-op for users.** All additions are new tools / new optional argument. Existing tool calls behave identically.
+
 ## [2.1.0] — 2026-05-08
 
 **Sprint 1 of the post-v2.0 roadmap.** Three quick wins that improve retrieval quality at near-zero implementation cost. No new tools — refinements to existing surfaces. All changes are internal; the API surface is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] — 2026-05-08
+
+**Sprint 1 of the post-v2.0 roadmap.** Three quick wins that improve retrieval quality at near-zero implementation cost. No new tools — refinements to existing surfaces. All changes are internal; the API surface is unchanged.
+
+### Improved — Markdown-aware structural chunker (heading breadcrumbs)
+
+`chunkContent()` now attaches a `breadcrumb` field to every chunk: the H1 > H2 > H3 hierarchy in scope at chunk start. Both indexers use it:
+
+- **FTS5** stores `[section: <breadcrumb>]\n<text>` in the `content` column so BM25 catches notes whose section heading matches a query term, even when the body doesn't repeat it.
+- **Embeddings** prepend `<breadcrumb>\n\n<text>` before sending to the model so the embedding captures structural context.
+
+Per Chroma 2024 + NAACL 2025: structural breadcrumbs lift NDCG@10 by 2-5 points at ~0 token cost. We already had heading-aware AST in `parser.ts`; this just propagates it through chunking.
+
+ATX headings only. Fenced code blocks (where `#` is a shell prompt, not a heading) are skipped via state-machine — `bash` snippets with `# comment` no longer hijack the heading stack.
+
+### Improved — CJK / Thai / Khmer / Lao tokenization via `Intl.Segmenter`
+
+The Unicode-regex tokenizer in `tokenizeForTfidf` worked for whitespace-separated scripts (Latin, Cyrillic, Greek, Hebrew, Arabic) but produced character-level or huge multi-character "tokens" for CJK / Thai / Khmer / Lao — the length filter dropped them, and BM25/TF-IDF precision tanked.
+
+Now: when content contains Chinese / Japanese / Korean / Thai / Tibetan / Khmer code points, branch into `Intl.Segmenter` (Node 16+ built-in ICU) for proper word-break. Per-document detection, no new dependencies.
+
+Validated against Japanese (kana + kanji) and Chinese (Hanzi) test corpora — top hit ranking is now correct for cross-lingual queries on those scripts.
+
+### Added — `search_with_query_expansion` MCP prompt
+
+Multi-query expansion as a **client-side orchestration prompt**, not a server-side LLM call. The agent paraphrases the query 3-5 ways (mix of keyword-focused, semantic-focused, step-back, optionally cross-lingual), runs `obsidian_search` per paraphrase, then RRF-fuses the results with k=60.
+
+Lifts recall by 5-15 NDCG@10 on terse / ambiguous queries vs single-pass search. Pure prompt engineering — zero new server code, respects MCP architectural boundary (server does retrieval, agent does LLM).
+
+### Tests
+
+413 unit tests pass (was 408, +5 new): 3 for breadcrumb propagation (heading hierarchy, preamble, code-fence safety) + 2 for CJK segmentation (Chinese + Japanese top-hit ranking).
+
+### Migration
+
+**No-op for users.** All changes are internal. Existing `.fts5.db` and `.embed.db` will rebuild automatically on next vault sync due to existing `tokenize_mode` / `vault_root` cross-config-change guards.
+
 ## [2.0.0] — 2026-05-08
 
 **v2.0.0 stable.** Promotes the v2.0 prerelease train (alpha.0 → beta.{0,1,2,3,4}) to `@latest` on npm. `npm install @oomkapwn/enquire-mcp` now ships v2.0.0 by default; v1.11.1 stable users update on next install. **No new code changes from beta.4** — this release is the channel promotion only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] — 2026-05-08
+
+**Sprint 4 — Karpathy LLM-Wiki backend positioning.** Four new MCP prompts that implement the [Karpathy LLM-Wiki workflow](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) natively over Obsidian's `.md` + `[[wikilinks]]` substrate. **Strategic claim: enquire-mcp is the open-source backend for Karpathy-style LLM Wikis on top of your existing Obsidian vault.** No competitor sits on this intersection (Search-first / Agentic-first / Wiki-compounding) — we claim it.
+
+### Added — `vault_synth` (LLM-Wiki ingest)
+
+Take raw source content, extract concepts/entities/claims, reconcile with the existing vault (search for prior coverage), propose drafts (new note vs append vs cross-link). Cites every claim with the source location for trust. Lints proposals via `obsidian_validate_note_proposal` before writing. Outputs a transactional plan; user approves before disk writes.
+
+### Added — `vault_wiki_compile` (LLM-Wiki maintenance)
+
+Weekly compile step. Scans recently-changed notes, regenerates `index.md` (top-of-vault TOC + concept clusters by tag/folder), appends to `log.md` (chronological compile history). Surfaces gaps via `obsidian_lint_wiki`. Idempotent.
+
+### Added — `vault_lint_extended`
+
+Beyond structural lint of `obsidian_lint_wiki`: 4-phase deeper inspection.
+1. Structural — same as existing.
+2. **Semantic contradictions** — for each strong claim, search for the negation; flag pairs.
+3. **Stale claims** — date references > 6 months old paired with words like "current"/"latest"/"upcoming".
+4. **Missing cross-references** — wiki page titles mentioned in plain text without `[[brackets]]`. Propose rewrites (validated first).
+
+### Added — `vault_capture` (Mem.ai-style "write don't organize")
+
+Decision-tree for filing a quick thought: continues an existing note? → append. Conversational/time-bound? → today's daily. Distinct concepts? → `vault_synth`. Default: Inbox catch-all. Always shows diff before writing.
+
+### Strategic position
+
+Combined with v2.0-v2.3, the prompt + tool surface now claims **three categories simultaneously**:
+
+- **Search-first** (vs Smart Connections) — covered by `obsidian_search` (hybrid RRF + graph boost).
+- **Agentic-first** (vs Khoj) — covered partially by `vault_capture`/`vault_synth` (full agent personas in v2.5.0).
+- **Wiki-compounding** (vs Karpathy LLM-Wiki) — claimed exclusively by `vault_synth`/`vault_wiki_compile`/`vault_lint_extended`.
+
+**No other open-source PKM-AI tool sits on all three.** This release stakes that claim.
+
+### Tests
+
+431 unit tests pass (no count delta — v2.4.0 adds prompts only, which are pure templates).
+
+### Migration
+
+**No-op.** All additions are new MCP prompts. Existing tool calls behave identically. Prompts work in any MCP client (Claude Code / Cursor / Codex / OpenClaw / Devin / etc.).
+
 ## [2.3.0] — 2026-05-08
 
 **Sprint 3 — Obsidian-native moats.** Two features that exploit primitives no other Obsidian-MCP uses: the wikilink graph + atomic frontmatter manipulation. Result: retrieval quality gap that generic vector stores cannot close.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 | `obsidian_replace_in_notes` | Bulk find/replace. Per-file errors collected; `partial: true` on mid-loop fail. |
 | `obsidian_archive_note` | Wraps rename to `Archive/`. Preserves backlinks. |
 
-Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **10 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`).
+Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **11 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,13 +106,15 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 
 ---
 
-## Tools (30 total)
+## Tools (33 total)
 
-### 21 always-on read tools
+### 23 always-on read tools
 
 | Tool | What it does |
 |---|---|
-| `obsidian_search` | **Hybrid retrieval** — fuses BM25 + TF-IDF + ML embeddings via RRF. The default search tool. Auto-detects available signals. |
+| `obsidian_search` | **Hybrid retrieval** — fuses BM25 + TF-IDF + ML embeddings via RRF. The default search tool. Auto-detects available signals. v2.2.0: `granularity: "block"` arg returns chunks instead of notes. |
+| `obsidian_context_pack` | **v2.2.0.** Token-budgeted context bundling: takes a question, runs hybrid search, gathers note bodies + backlinks + optionally recent dailies, returns one ready-to-paste markdown bundle. Saves ~5 tool calls. |
+| `obsidian_chat_thread_read` | **v2.2.0.** Parse a note's `## Chat: <title>` block into structured messages (role/timestamp/content/line-range). Pair with `_append` (write) for note-tethered AI conversations. |
 | `obsidian_read_note` | Full content + frontmatter + wikilinks + embeds + tags. Also accepts periodic-note aliases (`title: "today"` / `"weekly"` / `"monthly"`). |
 | `obsidian_list_notes` | Vault-wide or folder-scoped. Includes title + tags + mtime + counts. |
 | `obsidian_resolve_wikilink` | Resolves `[[Note]]`, `[[Note\|Alias]]`, `[[Note#Section]]`, `[[Note#^block]]`, with did-you-mean on near-miss. |
@@ -143,7 +145,7 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 | `obsidian_semantic_search` | `--diagnostic-search-tools` | TF-IDF cosine standalone. |
 | `obsidian_embeddings_search` | `--diagnostic-search-tools` | ML embeddings standalone. |
 
-### 5 opt-in write tools (`--enable-write`)
+### 6 opt-in write tools (`--enable-write`)
 
 | Tool | Notes |
 |---|---|
@@ -152,6 +154,7 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 | `obsidian_rename_note` | Rewrites every wikilink across vault. Code-fence-aware. `dry_run` available. |
 | `obsidian_replace_in_notes` | Bulk find/replace. Per-file errors collected; `partial: true` on mid-loop fail. |
 | `obsidian_archive_note` | Wraps rename to `Archive/`. Preserves backlinks. |
+| `obsidian_chat_thread_append` | **v2.2.0.** Append a user/assistant/system message to a note's `## Chat:` block. Creates note + heading if absent. Threads stored as markdown — searchable, version-controllable, survive sessions. |
 
 Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **11 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`).
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 | `obsidian_chat_thread_append` | **v2.2.0.** Append a user/assistant/system message to a note's `## Chat:` block. Creates note + heading if absent. Threads stored as markdown — searchable, version-controllable, survive sessions. |
 | `obsidian_frontmatter_set` | **v2.3.0.** Surgical YAML manipulation — set/unset keys on a note atomically. Pass `null` as value to delete. Round-trips through gray-matter so YAML formatting stays consistent. `dry_run` supported. |
 
-Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **11 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`).
+Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **15 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`, `vault_synth`, `vault_wiki_compile`, `vault_lint_extended`, `vault_capture`).
+
+> **v2.4.0 strategic position:** enquire-mcp is the open-source backend for **Karpathy-style LLM Wikis** on top of your existing Obsidian vault. The `vault_synth` + `vault_wiki_compile` + `vault_lint_extended` prompts implement the [Karpathy LLM-Wiki workflow](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (ingest → query → lint → compile) natively over Obsidian's `.md` + `[[wikilinks]]` substrate. Knowledge that compounds, traceable to sources.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,15 +106,17 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 
 ---
 
-## Tools (33 total)
+## Tools (36 total)
 
-### 23 always-on read tools
+### 25 always-on read tools
 
 | Tool | What it does |
 |---|---|
 | `obsidian_search` | **Hybrid retrieval** — fuses BM25 + TF-IDF + ML embeddings via RRF. The default search tool. Auto-detects available signals. v2.2.0: `granularity: "block"` arg returns chunks instead of notes. |
 | `obsidian_context_pack` | **v2.2.0.** Token-budgeted context bundling: takes a question, runs hybrid search, gathers note bodies + backlinks + optionally recent dailies, returns one ready-to-paste markdown bundle. Saves ~5 tool calls. |
 | `obsidian_chat_thread_read` | **v2.2.0.** Parse a note's `## Chat: <title>` block into structured messages (role/timestamp/content/line-range). Pair with `_append` (write) for note-tethered AI conversations. |
+| `obsidian_frontmatter_get` | **v2.3.0.** Read parsed YAML frontmatter for a note. With `key`, returns just that field. |
+| `obsidian_frontmatter_search` | **v2.3.0.** Find notes by frontmatter predicate (`equals` / `exists` / `contains`). Useful as a precursor to bulk `_set`. |
 | `obsidian_read_note` | Full content + frontmatter + wikilinks + embeds + tags. Also accepts periodic-note aliases (`title: "today"` / `"weekly"` / `"monthly"`). |
 | `obsidian_list_notes` | Vault-wide or folder-scoped. Includes title + tags + mtime + counts. |
 | `obsidian_resolve_wikilink` | Resolves `[[Note]]`, `[[Note\|Alias]]`, `[[Note#Section]]`, `[[Note#^block]]`, with did-you-mean on near-miss. |
@@ -145,7 +147,7 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 | `obsidian_semantic_search` | `--diagnostic-search-tools` | TF-IDF cosine standalone. |
 | `obsidian_embeddings_search` | `--diagnostic-search-tools` | ML embeddings standalone. |
 
-### 6 opt-in write tools (`--enable-write`)
+### 7 opt-in write tools (`--enable-write`)
 
 | Tool | Notes |
 |---|---|
@@ -155,6 +157,7 @@ enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
 | `obsidian_replace_in_notes` | Bulk find/replace. Per-file errors collected; `partial: true` on mid-loop fail. |
 | `obsidian_archive_note` | Wraps rename to `Archive/`. Preserves backlinks. |
 | `obsidian_chat_thread_append` | **v2.2.0.** Append a user/assistant/system message to a note's `## Chat:` block. Creates note + heading if absent. Threads stored as markdown — searchable, version-controllable, survive sessions. |
+| `obsidian_frontmatter_set` | **v2.3.0.** Surgical YAML manipulation — set/unset keys on a note atomically. Pass `null` as value to delete. Round-trips through gray-matter so YAML formatting stays consistent. `dry_run` supported. |
 
 Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **11 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # enquire — API
 
-**enquire is an MCP server for Obsidian vaults.** 33 MCP tools (23 always-on read + 4 opt-in read + 6 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 11 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
+**enquire is an MCP server for Obsidian vaults.** 36 MCP tools (25 always-on read + 4 opt-in read + 7 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 11 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
 
 > **Channels:** stable v1.x (`@latest` on npm) ships 28 tools — no ML embeddings, no hybrid search. **v2.0 beta** (`@beta` on npm) adds `obsidian_search` (hybrid RRF) + `obsidian_embeddings_search` + the `install-model` / `build-embeddings` / `clear-embeddings` subcommands. This document covers the **v2.0 beta** surface.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # enquire — API
 
-**enquire is an MCP server for Obsidian vaults.** 30 MCP tools (21 always-on read + 4 opt-in read + 5 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 10 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
+**enquire is an MCP server for Obsidian vaults.** 33 MCP tools (23 always-on read + 4 opt-in read + 6 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 11 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
 
 > **Channels:** stable v1.x (`@latest` on npm) ships 28 tools — no ML embeddings, no hybrid search. **v2.0 beta** (`@beta` on npm) adds `obsidian_search` (hybrid RRF) + `obsidian_embeddings_search` + the `install-model` / `build-embeddings` / `clear-embeddings` subcommands. This document covers the **v2.0 beta** surface.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # enquire — API
 
-**enquire is an MCP server for Obsidian vaults.** 36 MCP tools (25 always-on read + 4 opt-in read + 7 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 11 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
+**enquire is an MCP server for Obsidian vaults.** 36 MCP tools (25 always-on read + 4 opt-in read + 7 opt-in write); the 4 opt-ins are: 1 via `--persistent-index` (`obsidian_full_text_search`) + 3 via `--diagnostic-search-tools` (the single-ranker `obsidian_search_text` / `obsidian_semantic_search` / `obsidian_embeddings_search` — gated by default in v2.0+ since `obsidian_search` auto-detects + fuses signals). 2 + 1 opt-in MCP resources, 15 MCP prompts. Server speaks stdio JSON-RPC, launched per-vault.
 
 > **Channels:** stable v1.x (`@latest` on npm) ships 28 tools — no ML embeddings, no hybrid search. **v2.0 beta** (`@beta` on npm) adds `obsidian_search` (hybrid RRF) + `obsidian_embeddings_search` + the `install-model` / `build-embeddings` / `clear-embeddings` subcommands. This document covers the **v2.0 beta** surface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -283,11 +283,14 @@ export class FtsIndex {
       // FTS5 column `content` carries an enriched form: original text + a
       // synthetic `[wikilink_targets: …]` meta-line so a search for a link
       // target name recalls notes that link out without naming it inline.
-      // The unindexed `raw_content` keeps the *original* chunk so the
-      // `obsidian://chunk/{n}/{path}` resource can return verbatim text
-      // (the audit P1 — without raw_content the resource was leaking the
-      // synthetic line into MCP-client view, breaking quoting).
-      const enriched = wikilinkTargets.length ? `${c.text}\n[wikilink_targets: ${wikilinkTargets.join(", ")}]` : c.text;
+      // v2.1.0: also prepend the heading breadcrumb so BM25 search hits
+      // notes where the section heading matches a query term even when the
+      // body doesn't repeat it. The unindexed `raw_content` keeps the
+      // *original* chunk so the `obsidian://chunk/{n}/{path}` resource
+      // can return verbatim text.
+      const breadcrumbPrefix = c.breadcrumb ? `[section: ${c.breadcrumb}]\n` : "";
+      const linksSuffix = wikilinkTargets.length ? `\n[wikilink_targets: ${wikilinkTargets.join(", ")}]` : "";
+      const enriched = `${breadcrumbPrefix}${c.text}${linksSuffix}`;
       insert.run(enriched, relPath, i, c.lineStart, c.lineEnd, tagsSerialized, c.text);
     });
     db.prepare(
@@ -410,6 +413,12 @@ interface ContentChunk {
   text: string;
   lineStart: number;
   lineEnd: number;
+  /** v2.1.0: heading breadcrumb (e.g. "## Setup > ### Install") in effect at
+   *  chunk start. Empty if chunk is in the preamble (before first heading).
+   *  Callers concerned with retrieval quality can prepend this to chunk.text
+   *  before embedding/indexing — Chroma 2024 + NAACL 2025 both show
+   *  structural breadcrumbs lift NDCG@10 by 2-5 points at near-zero cost. */
+  breadcrumb: string;
 }
 
 const MAX_CHUNK_CHARS = 4096;
@@ -417,17 +426,33 @@ const MAX_CHUNK_CHARS = 4096;
 /**
  * Paragraph-first chunker with `\n\n → \n → hardcut` fallback. Each chunk
  * carries 1-based line offsets so callers can quote precise locations.
+ *
+ * v2.1.0: also attaches a heading breadcrumb to each chunk (the H1>H2>H3
+ * path in effect at chunk start). Preserves Obsidian markdown structure
+ * for downstream retrievers without a custom parser. ATX headings only —
+ * fenced code blocks (where `#` is shell prompt, not heading) are skipped.
  */
 export function chunkContent(content: string, maxChars = MAX_CHUNK_CHARS): ContentChunk[] {
   if (!content) return [];
+
+  // v2.1.0: pre-compute heading hierarchy per line. Walk the source once,
+  // tracking ATX headings and code-fence state, so each line gets the
+  // "Section > Subsection" breadcrumb in scope at that line.
+  const breadcrumbByLine = computeBreadcrumbsByLine(content);
+
   const paragraphs = splitWithLines(content, /\n{2,}/);
   const chunks: ContentChunk[] = [];
   for (const p of paragraphs) {
+    if (!p.breadcrumb) {
+      p.breadcrumb = breadcrumbByLine[p.lineStart - 1] ?? "";
+    }
     if (p.text.length <= maxChars) {
       chunks.push(p);
       continue;
     }
-    // Paragraph too big — try line splits.
+    // Paragraph too big — try line splits. Each split inherits the
+    // paragraph's breadcrumb (a single oversize paragraph stays under one
+    // section by definition — paragraph boundaries don't span headings).
     const lines = splitWithLines(p.text, /\n/, p.lineStart);
     let buf: ContentChunk | null = null;
     for (const ln of lines) {
@@ -441,19 +466,20 @@ export function chunkContent(content: string, maxChars = MAX_CHUNK_CHARS): Conte
           chunks.push({
             text: ln.text.slice(i, i + maxChars),
             lineStart: ln.lineStart,
-            lineEnd: ln.lineEnd
+            lineEnd: ln.lineEnd,
+            breadcrumb: p.breadcrumb
           });
         }
         continue;
       }
       if (!buf) {
-        buf = { text: ln.text, lineStart: ln.lineStart, lineEnd: ln.lineEnd };
+        buf = { text: ln.text, lineStart: ln.lineStart, lineEnd: ln.lineEnd, breadcrumb: p.breadcrumb };
         continue;
       }
       const tentative = `${buf.text}\n${ln.text}`;
       if (tentative.length > maxChars) {
         chunks.push(buf);
-        buf = { text: ln.text, lineStart: ln.lineStart, lineEnd: ln.lineEnd };
+        buf = { text: ln.text, lineStart: ln.lineStart, lineEnd: ln.lineEnd, breadcrumb: p.breadcrumb };
       } else {
         buf.text = tentative;
         buf.lineEnd = ln.lineEnd;
@@ -462,6 +488,54 @@ export function chunkContent(content: string, maxChars = MAX_CHUNK_CHARS): Conte
     if (buf) chunks.push(buf);
   }
   return chunks.filter((c) => c.text.trim().length > 0);
+}
+
+/**
+ * v2.1.0: walk content line-by-line, tracking the H1>H2>H3 stack at each
+ * point. Returns a per-line breadcrumb (joined with " > ") in effect AT
+ * that line — i.e., the heading the line lives under.
+ *
+ * Skips heading-style chars inside fenced code blocks (``` and ~~~).
+ */
+function computeBreadcrumbsByLine(content: string): string[] {
+  const lines = content.split("\n");
+  const out: string[] = new Array(lines.length).fill("");
+  const stack: string[] = []; // index = depth-1, value = heading text
+  let inFence = false;
+  let fenceMarker = "";
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i] ?? "";
+    const fenceMatch = /^(```|~~~)/.exec(ln);
+    if (fenceMatch?.[1]) {
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = fenceMatch[1];
+      } else if (fenceMatch[1] === fenceMarker) {
+        inFence = false;
+        fenceMarker = "";
+      }
+      out[i] = stack.join(" > ");
+      continue;
+    }
+    if (inFence) {
+      out[i] = stack.join(" > ");
+      continue;
+    }
+    const headingMatch = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(ln);
+    if (headingMatch?.[1] && headingMatch[2]) {
+      const depth = headingMatch[1].length;
+      const text = headingMatch[2].trim();
+      // Trim stack to current depth - 1, then push at depth.
+      stack.length = depth - 1;
+      stack.push(text);
+      // Heading line itself gets its OWN breadcrumb (the heading is part of
+      // its section's identity).
+      out[i] = stack.join(" > ");
+      continue;
+    }
+    out[i] = stack.join(" > ");
+  }
+  return out;
 }
 
 function splitWithLines(text: string, separator: RegExp, baseLine = 1): ContentChunk[] {
@@ -473,14 +547,14 @@ function splitWithLines(text: string, separator: RegExp, baseLine = 1): ContentC
     const start = match.index ?? 0;
     const slice = text.slice(lastIndex, start);
     const linesInSlice = (slice.match(/\n/g) ?? []).length;
-    out.push({ text: slice, lineStart: lastLine, lineEnd: lastLine + linesInSlice });
+    out.push({ text: slice, lineStart: lastLine, lineEnd: lastLine + linesInSlice, breadcrumb: "" });
     lastLine += linesInSlice + (match[0].match(/\n/g) ?? []).length;
     lastIndex = start + match[0].length;
   }
   const tail = text.slice(lastIndex);
   if (tail) {
     const linesInTail = (tail.match(/\n/g) ?? []).length;
-    out.push({ text: tail, lineStart: lastLine, lineEnd: lastLine + linesInTail });
+    out.push({ text: tail, lineStart: lastLine, lineEnd: lastLine + linesInTail, breadcrumb: "" });
   }
   return out;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.0.0";
+const VERSION = "2.1.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {
@@ -499,7 +499,11 @@ async function syncEmbedDb(
           `enquire: ${e.relPath} → ${chunks.length} chunks (this one will be slow; consider splitting the note)\n`
         );
       }
-      const vectors = await embedder.embed(chunks.map((c) => c.text));
+      // v2.1.0: prepend heading breadcrumb to embedded text so the model sees
+      // structural context. Free win at zero token cost — Chroma 2024 +
+      // NAACL 2025 show +2-5 NDCG@10 from breadcrumb prepending. The text
+      // stored in `text_preview` (for snippets) stays clean.
+      const vectors = await embedder.embed(chunks.map((c) => (c.breadcrumb ? `${c.breadcrumb}\n\n${c.text}` : c.text)));
       const rows = chunks.map((c, i) => {
         const vector = vectors[i];
         if (!vector) throw new Error(`embedder returned no vector for chunk ${i} of ${e.relPath}`);
@@ -1699,6 +1703,52 @@ DO NOT actually modify any notes. This is a proposal pass — the user runs the 
    - "Stalled:" notes touched once early in the month and not since (likely abandoned).
 5. Compare against the previous month's tag distribution if you can infer it from \`obsidian_get_recent_edits\` with a wider window — note any tag that was active last month but silent this one.
 6. End with a 3-sentence reflection: what does the month say about your actual focus vs. your stated focus, and what's the one tag-cluster that deserves more attention next month.`
+          }
+        }
+      ]
+    })
+  );
+
+  // v2.1.0: multi-query expansion as a prompt template (NOT a server-side
+  // LLM call — that would violate the MCP boundary). The agent paraphrases
+  // the user's question N ways, calls obsidian_search per paraphrase, then
+  // RRF-fuses the results client-side. Boosts recall on terse / ambiguous
+  // queries by 5-15 NDCG@10 vs single-pass search. Pure prompt eng.
+  server.registerPrompt(
+    "search_with_query_expansion",
+    {
+      title: "Search with multi-query expansion",
+      description:
+        "Higher-recall retrieval: paraphrase the query 3-5 ways, call obsidian_search per paraphrase, fuse results. Boosts recall on terse / ambiguous queries by 5-15 NDCG@10 over a single-pass search. Pure agent-side orchestration — no server-side LLM calls.",
+      argsSchema: {
+        query: z.string().describe("The user's original question / search query"),
+        n_paraphrases: z.string().optional().describe("How many paraphrases to generate (default 4)"),
+        limit: z.string().optional().describe("Top-K hits per paraphrase before fusion (default 10)")
+      }
+    },
+    ({ query, n_paraphrases, limit }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `High-recall retrieval over my Obsidian vault. The user asked: "${query}"
+
+1. Generate ${n_paraphrases ?? 4} short paraphrases of the question. Mix:
+   - 1 keyword-focused (good for BM25): noun phrases, technical terms
+   - 1 semantic-focused (good for embeddings): natural-language restating
+   - 1-2 step-back: a more general question whose answer would contain this one
+   - Optionally 1 in another language if my vault is bilingual
+
+2. For each paraphrase, call \`obsidian_search\` with \`query=<paraphrase>\` and \`limit=${limit ?? 10}\`.
+
+3. Reciprocal Rank Fusion: assign each hit a score of 1/(60+rank), sum across paraphrases per note path, sort descending.
+
+4. Return the top 10 fused results. For each: path, fused_score, which paraphrases hit it (and at what rank), and a 1-sentence "why this answers the original question."
+
+5. If a hit appears in only ONE paraphrase, mark it as "low-confidence — only retrieved by paraphrase #N" — these are speculative.
+
+The goal is recall + observability: the user sees not just the answer but WHY each note ranked.`
           }
         }
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ import { chunkContent, defaultIndexFile, FtsIndex } from "./fts5.js";
 import {
   appendToNote,
   archiveNote,
+  chatThreadAppend,
+  chatThreadRead,
+  contextPack,
   createNote,
   dataviewQuery,
   embeddingsSearch,
@@ -43,7 +46,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.1.0";
+const VERSION = "2.2.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {
@@ -1156,12 +1159,70 @@ function registerReadTools(
           .optional()
           .describe(
             "Override the embedding model alias (default 'multilingual'). Only consulted if a .embed.db exists."
+          ),
+        granularity: z
+          .enum(["note", "block"])
+          .optional()
+          .describe(
+            "v2.2.0: 'note' (default) returns one hit per note (best chunk wins). 'block' keeps each chunk as a distinct hit — useful when one note covers a topic in multiple paragraphs and you want the LLM to see all of them."
           )
       }
     },
     async (args) => {
       const embedFile = embedDbPath(vault.root);
       return textResult(await searchHybrid(vault, args, { ftsIndex, embedFile }));
+    }
+  );
+
+  server.registerTool(
+    "obsidian_chat_thread_read",
+    {
+      title: "Read parsed chat thread from a note",
+      description:
+        "Parse a note's `## Chat: <title>` block into structured messages with role/timestamp/content/line-range. Non-chat content in the same note is ignored. Read-only.",
+      annotations: { ...READ_ONLY, title: "Read chat thread" },
+      inputSchema: {
+        note_path: z.string().min(1).describe("Vault-relative path to the note hosting the thread")
+      }
+    },
+    async (args) => textResult(await chatThreadRead(vault, args))
+  );
+
+  // v2.2.0: context pack — Smart Connections "Send to Smart Context" pattern,
+  // MCP-native (works with any AI client, not just Obsidian).
+  server.registerTool(
+    "obsidian_context_pack",
+    {
+      title: "Pack vault context for an AI question (token-budgeted)",
+      description:
+        "Given a question, retrieve the top relevant notes (via hybrid search), gather backlinks summaries + optionally recent dailies, deduplicate, pack to a token budget, return a single ready-to-paste markdown bundle. Saves the agent ~5 separate tool calls; produces a coherent context blob you can paste into any AI chat.",
+      annotations: { ...READ_ONLY, title: "Context pack" },
+      inputSchema: {
+        query: z.string().min(1).describe("Topic or question to gather context for"),
+        budget_tokens: z
+          .number()
+          .int()
+          .positive()
+          .max(32000)
+          .optional()
+          .describe("Approximate token budget (default 4000, ~4 chars/token)"),
+        folder: z.string().optional().describe("Restrict retrieval to this folder (vault-relative)"),
+        include_backlinks: z
+          .boolean()
+          .optional()
+          .describe("Include 1-line backlink summaries for top-3 notes (default true)"),
+        recent_dailies: z
+          .number()
+          .int()
+          .min(0)
+          .max(30)
+          .optional()
+          .describe("Include the last N daily-format notes (YYYY-MM-DD basenames). Default 0 (off).")
+      }
+    },
+    async (args) => {
+      const embedFile = embedDbPath(vault.root);
+      return textResult(await contextPack(vault, args, { ftsIndex, embedFile }));
     }
   );
 }
@@ -1279,6 +1340,27 @@ function registerWriteTools(server: McpServer, vault: Vault): void {
       }
     },
     async (args) => textResult(await archiveNote(vault, args))
+  );
+
+  // v2.2.0: append message to a note's chat thread.
+  server.registerTool(
+    "obsidian_chat_thread_append",
+    {
+      title: "Append message to note-tethered chat thread",
+      description:
+        "Add a user/assistant/system message to a note's `## Chat: <title>` block. Creates the note + heading if absent. Threads are stored as markdown so they're searchable, version-controllable, and survive across sessions / clients. Pair with `obsidian_chat_thread_read` to load past context. WRITE TOOL — only registered with --enable-write.",
+      annotations: { ...WRITE, title: "Append chat thread" },
+      inputSchema: {
+        note_path: z.string().min(1).describe("Vault-relative path to the note hosting the thread"),
+        role: z.enum(["user", "assistant", "system"]).describe("Role of the message being appended"),
+        content: z.string().min(1).describe("Message body (markdown allowed)"),
+        thread_title: z
+          .string()
+          .optional()
+          .describe("Optional thread title — used when the note is created from scratch")
+      }
+    },
+    async (args) => textResult(await chatThreadAppend(vault, args))
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.3.0";
+const VERSION = "2.4.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {
@@ -1896,6 +1896,205 @@ DO NOT actually modify any notes. This is a proposal pass — the user runs the 
 5. If a hit appears in only ONE paraphrase, mark it as "low-confidence — only retrieved by paraphrase #N" — these are speculative.
 
 The goal is recall + observability: the user sees not just the answer but WHY each note ranked.`
+          }
+        }
+      ]
+    })
+  );
+
+  // v2.4.0 — Karpathy LLM-Wiki workflow prompts.
+  // Reference: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+  // Karpathy named three workflows: ingest, query, lint. We had `query` and
+  // `lint` since v1.5. v2.4.0 adds `ingest`-style workflows + `compile`/
+  // `synth` patterns that close the loop. Position: enquire-mcp = the
+  // open-source backend for Karpathy-style LLM Wikis on top of Obsidian.
+
+  server.registerPrompt(
+    "vault_synth",
+    {
+      title: "Synthesize a vault wiki page from sources (Karpathy-style ingest)",
+      description:
+        "Karpathy LLM-Wiki ingest workflow: take raw source(s), extract entities/concepts/claims, decide which existing notes to update vs which new wiki pages to create, then propose drafts. The agent decides; this prompt sequences the calls. Cites every claim with the source location for trust.",
+      argsSchema: {
+        source: z
+          .string()
+          .describe("Source content to ingest — paste a paragraph, an arXiv abstract, a URL transcript, etc."),
+        target_folder: z
+          .string()
+          .optional()
+          .describe("Where new wiki pages should land (vault-relative, default 'Wiki/')")
+      }
+    },
+    ({ source, target_folder }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Karpathy LLM-Wiki **ingest** workflow on this source:
+
+\`\`\`
+${source}
+\`\`\`
+
+Steps:
+
+1. **Extract concepts.** Identify 3-7 distinct concepts / entities / claims worth indexing. For each, propose a wiki page title (PascalCase or "Title Case" — match my vault's existing convention; check via \`obsidian_list_notes\` on a few sample folders).
+
+2. **Reconcile with vault.** For each concept, run \`obsidian_search\` (graph_boost ON, default) to find existing notes that ALREADY cover it. Three outcomes per concept:
+   - **EXISTS** (top hit score > 0.04 and same scope) → propose an APPEND to the existing note
+   - **PARTIAL** (related but doesn't cover this angle) → propose a new note that \`[[wikilinks]]\` to the existing one
+   - **NEW** → propose a fresh wiki page in \`${target_folder ?? "Wiki/"}\`
+
+3. **Lint drafts before writing.** For each proposed write, call \`obsidian_validate_note_proposal\` to catch broken \`[[wikilinks]]\` / inconsistent tags / structurally-broken YAML BEFORE creating.
+
+4. **Cite every claim.** Each new note should have a "Source" frontmatter field referencing the input + a "Claims" section with one bullet per extracted claim, each with the source quote.
+
+5. **Output a transactional plan.** Don't write yet. Output a JSON-like list:
+   \`\`\`
+   [
+     { action: "create" | "append", path: "Wiki/Foo.md", reason: "...", body_preview: "..." },
+     ...
+   ]
+   \`\`\`
+   Then ask the user to approve. ONLY write after explicit approval, using \`obsidian_create_note\` / \`obsidian_append_to_note\`.
+
+This is the Karpathy LLM-Wiki ingest loop applied to Obsidian. Goal: knowledge that compounds over time, with every claim traceable to its source.`
+          }
+        }
+      ]
+    })
+  );
+
+  server.registerPrompt(
+    "vault_wiki_compile",
+    {
+      title: "Compile vault index + log (Karpathy-style maintenance)",
+      description:
+        "The LLM-Wiki maintenance step: scan the vault for new/updated notes since last compile, regenerate the top-level `index.md` (table of contents + concept clusters) and append to `log.md` (a chronological compile-log). Run weekly or after a batch ingest. Idempotent.",
+      argsSchema: {
+        since_minutes: z.string().optional().describe("Window for 'recently changed' notes (default 10080 = 7 days)"),
+        wiki_folder: z.string().optional().describe("Wiki folder root (default 'Wiki/')")
+      }
+    },
+    ({ since_minutes, wiki_folder }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Karpathy LLM-Wiki **compile** workflow.
+
+Step 1 — Scan recent changes:
+- \`obsidian_get_recent_edits since_minutes=${since_minutes ?? 10080} folder=${wiki_folder ?? "Wiki"}\`
+- For each, \`obsidian_read_note format=map\` to get headings + frontmatter only (cheap).
+
+Step 2 — Regenerate index.md:
+- Group notes by frontmatter \`tags\` and by folder.
+- For each cluster (≥3 notes), produce a heading + bullet list of \`[[wikilinks]]\` to the cluster members.
+- Add a "Recent" section listing the 10 most recently modified.
+- Use \`obsidian_validate_note_proposal\` to catch any broken wikilinks BEFORE writing.
+- Write via \`obsidian_create_note overwrite=true\` to \`${wiki_folder ?? "Wiki"}/index.md\`.
+
+Step 3 — Append to log.md:
+- A bullet per note touched in the window: \`- 2026-05-08 — [[NoteTitle]] (created|updated): one-line summary\`
+- Append via \`obsidian_append_to_note\`. The log accumulates compile history.
+
+Step 4 — Surface gaps:
+- Run \`obsidian_lint_wiki\` to enumerate orphans / broken / stubs / stale.
+- Add the gap summary to the bottom of \`index.md\` so the next compile sees it.
+
+Idempotent. Re-run weekly.`
+          }
+        }
+      ]
+    })
+  );
+
+  server.registerPrompt(
+    "vault_lint_extended",
+    {
+      title: "Extended vault lint (orphans + contradictions + stale claims + missing cross-refs)",
+      description:
+        "Beyond the structural lint of `obsidian_lint_wiki`: this prompt sequences a deeper inspection — contradictions across notes (semantic search for opposing claims), stale claims (notes with date references > 6mo old), missing cross-references (notes that mention an entity by name without `[[wikilinking]]` to its wiki page).",
+      argsSchema: {
+        folder: z.string().optional().describe("Restrict to a folder (default whole vault)")
+      }
+    },
+    ({ folder }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Extended lint pass on${folder ? ` ${folder}` : " the whole vault"}.
+
+Phase 1 — structural (\`obsidian_lint_wiki${folder ? ` folder=${folder}` : ""}\`):
+- Surface orphans / broken / stubs / stale per the existing tool. Skim the report.
+
+Phase 2 — semantic contradictions:
+- For each top-30 note (by recent-edits window), pick 1-2 strong claims (declarative sentences in the body).
+- For each claim, run \`obsidian_search query="<claim paraphrased to negate>" min_signals=2\` — multi-ranker consensus on the OPPOSITE statement.
+- If a hit comes back with score > 0.04, flag as a potential contradiction. Output: A says X, B says ¬X, suggest reconciliation.
+
+Phase 3 — stale claims:
+- For each note, scan body for date patterns (\`/\\b(20\\d{2})-\\d{2}-\\d{2}\\b/\` or \`/\\b(20\\d{2})\\b/\` with words like "current"/"latest"/"now"/"upcoming").
+- If the date is > 6 months old, surface as "potentially stale: <note> claims X with date Y".
+
+Phase 4 — missing cross-references:
+- For each top-15 note, get its outbound \`[[wikilinks]]\` (via \`obsidian_get_outbound_links\`).
+- Read the body. Check for wiki page TITLES (use \`obsidian_list_notes\` for the list) mentioned in plain text WITHOUT \`[[\` brackets.
+- For each, propose a rewrite that adds the brackets. \`obsidian_validate_note_proposal\` first.
+
+Output: a single markdown report with sections per phase. End with the top 5 highest-leverage fixes.`
+          }
+        }
+      ]
+    })
+  );
+
+  server.registerPrompt(
+    "vault_capture",
+    {
+      title: "Capture a quick thought into the vault (write don't organize)",
+      description:
+        "Mem.ai-style 'write don't organize' UX: the user pastes a thought; we file it intelligently. Auto-detect destination (today's daily note vs new wiki page vs append to most-relevant existing note via hybrid search) and propose a diff for user approval before writing.",
+      argsSchema: {
+        text: z.string().describe("The thought to capture — free-form text"),
+        target_hint: z
+          .string()
+          .optional()
+          .describe("Optional hint: 'daily', 'new-note', or a path/topic to bias destination")
+      }
+    },
+    ({ text, target_hint }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Capture this thought into my vault, Mem.ai-style: figure out where it goes, propose a diff, ask before writing.
+
+Thought:
+\`\`\`
+${text}
+\`\`\`
+
+Hint: ${target_hint ?? "(none — auto-detect)"}
+
+Decision tree:
+
+1. **Daily?** If thought is conversational / reflective / time-bound (uses words like "today", "yesterday", "I'm thinking about", "TIL"), propose APPEND to today's daily note via \`obsidian_read_note title="today"\` → \`obsidian_append_to_note\`.
+
+2. **Continues an existing note?** Run \`obsidian_search query="<thought first 200 chars>" limit=5\`. If top hit has score > 0.05, propose APPEND to that note. Show the user: "this looks related to [[NoteTitle]] — append there?"
+
+3. **New wiki page?** If thought contains 1-3 distinct concepts that don't have existing notes, run \`vault_synth\` workflow on it.
+
+4. **Inbox catch-all.** If steps 1-3 give nothing high-confidence, propose \`obsidian_create_note path="Inbox/<timestamp>-<3-word-slug>.md"\`.
+
+5. **Show diff, ask, then write.** Always preview the proposed write to the user. Use \`obsidian_validate_note_proposal\` first. Write only after explicit approval.
+
+Goal: zero filing burden on the user. The AI does the indexing.`
           }
         }
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ import {
   embeddingsSearch,
   findPath,
   findSimilar,
+  frontmatterGet,
+  frontmatterSearch,
+  frontmatterSet,
   getBacklinks,
   getNoteNeighbors,
   getOpenQuestions,
@@ -46,7 +49,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.2.0";
+const VERSION = "2.3.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {
@@ -1165,6 +1168,12 @@ function registerReadTools(
           .optional()
           .describe(
             "v2.2.0: 'note' (default) returns one hit per note (best chunk wins). 'block' keeps each chunk as a distinct hit — useful when one note covers a topic in multiple paragraphs and you want the LLM to see all of them."
+          ),
+        graph_boost: z
+          .boolean()
+          .optional()
+          .describe(
+            "v2.3.0: post-RRF wikilink graph-boost — rerank top-K by counting how many OTHER top-K hits link to each one. Default ON. Set false to disable for diagnostic comparison. The 'only enquire-mcp does this' feature: generic vector stores can't do this without an Obsidian-aware layer."
           )
       }
     },
@@ -1224,6 +1233,42 @@ function registerReadTools(
       const embedFile = embedDbPath(vault.root);
       return textResult(await contextPack(vault, args, { ftsIndex, embedFile }));
     }
+  );
+
+  // v2.3.0: frontmatter atomic ops — read.
+  server.registerTool(
+    "obsidian_frontmatter_get",
+    {
+      title: "Read note frontmatter (full or single key)",
+      description:
+        "Return parsed YAML frontmatter for a note. With `key`, returns just that field's value. Without `key`, returns the whole frontmatter object. Read-only.",
+      annotations: { ...READ_ONLY, title: "Get frontmatter" },
+      inputSchema: {
+        path: z.string().optional().describe("Vault-relative path"),
+        title: z.string().optional().describe("Note title (filename without .md, accepts periodic aliases)"),
+        key: z.string().optional().describe("Single key to read; omit for full frontmatter")
+      }
+    },
+    async (args) => textResult(await frontmatterGet(vault, args))
+  );
+
+  server.registerTool(
+    "obsidian_frontmatter_search",
+    {
+      title: "Find notes by frontmatter predicate",
+      description:
+        "Find every note where frontmatter.<key> matches a predicate. Useful as a precursor to bulk frontmatter_set: 'find all notes with status:draft and set their status to published'. Predicates are exclusive: pass exactly one of `equals` (strict equality), `exists` (key must be present), `contains` (for array values, member match).",
+      annotations: { ...READ_ONLY, title: "Search frontmatter" },
+      inputSchema: {
+        key: z.string().min(1).describe("Frontmatter key to test"),
+        equals: z.unknown().optional().describe("Strict equality predicate (JSON.stringify comparison)"),
+        exists: z.boolean().optional().describe("Predicate: key must exist (any value)"),
+        contains: z.unknown().optional().describe("For array values, value must be a member"),
+        folder: z.string().optional().describe("Restrict search to a folder"),
+        limit: z.number().int().positive().max(1000).optional().describe("Max matches (default 100)")
+      }
+    },
+    async (args) => textResult(await frontmatterSearch(vault, args))
   );
 }
 
@@ -1361,6 +1406,26 @@ function registerWriteTools(server: McpServer, vault: Vault): void {
       }
     },
     async (args) => textResult(await chatThreadAppend(vault, args))
+  );
+
+  // v2.3.0: surgical frontmatter writes (set / unset / bulk).
+  server.registerTool(
+    "obsidian_frontmatter_set",
+    {
+      title: "Set/unset frontmatter keys atomically",
+      description:
+        "Surgical YAML manipulation: set one or more keys, or remove them by passing `null` as the value. Round-trips through gray-matter (same parser used at write time) so YAML formatting / quoting / type-coercion stays consistent. Returns `before` + `after` + list of changed keys for observability. `dry_run: true` shows the diff without writing.",
+      annotations: { ...WRITE, title: "Set frontmatter" },
+      inputSchema: {
+        path: z.string().optional().describe("Vault-relative path"),
+        title: z.string().optional().describe("Note title (filename without .md)"),
+        set: z
+          .record(z.string(), z.unknown())
+          .describe("Keys to set. Pass `null` as value to delete a key (e.g. {status: 'published', draft: null})"),
+        dry_run: z.boolean().optional().describe("Preview the diff without writing (default false)")
+      }
+    },
+    async (args) => textResult(await frontmatterSet(vault, args))
   );
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -899,6 +899,143 @@ export async function chatThreadRead(vault: Vault, args: { note_path: string }):
   };
 }
 
+// ─── obsidian_frontmatter_{get,set,search} (v2.3.0 — atomic YAML ops) ──────
+// Surgical YAML manipulation. Pre-fix, agents wanting to set `status:
+// published` on 12 notes had to find/replace text — error-prone (multi-line
+// strings, special chars, key-collision). Now: parse via gray-matter, edit,
+// rewrite. Code-fence-aware via gray-matter (frontmatter is delimited
+// strictly by leading `---`, so no fence ambiguity).
+//
+// _get is read-only; _set + _delete are write-gated.
+
+export async function frontmatterGet(
+  vault: Vault,
+  args: { path?: string; title?: string; key?: string }
+): Promise<{ path: string; frontmatter: Record<string, unknown>; value?: unknown }> {
+  await vault.ensureExists();
+  const target = await resolveTarget(vault, args);
+  const note = await vault.readNote(target.absPath, target.mtimeMs);
+  if (args.key) {
+    return {
+      path: target.relPath,
+      frontmatter: note.parsed.frontmatter,
+      value: note.parsed.frontmatter[args.key]
+    };
+  }
+  return { path: target.relPath, frontmatter: note.parsed.frontmatter };
+}
+
+export interface FrontmatterSetArgs {
+  path?: string;
+  title?: string;
+  /** Keys to set. Setting a key to `null` deletes it. */
+  set: Record<string, unknown>;
+  /** Optional: dry_run shows the diff without writing. */
+  dry_run?: boolean;
+}
+
+export async function frontmatterSet(
+  vault: Vault,
+  args: FrontmatterSetArgs
+): Promise<{
+  path: string;
+  changed_keys: string[];
+  before: Record<string, unknown>;
+  after: Record<string, unknown>;
+  dry_run: boolean;
+}> {
+  await vault.ensureExists();
+  if (!args.set || Object.keys(args.set).length === 0) {
+    throw new Error("frontmatter_set: `set` must be a non-empty object");
+  }
+  const target = await resolveTarget(vault, args);
+  const note = await vault.readNote(target.absPath, target.mtimeMs);
+  const before = { ...note.parsed.frontmatter };
+  const after: Record<string, unknown> = { ...before };
+  const changed: string[] = [];
+  for (const [k, v] of Object.entries(args.set)) {
+    if (v === null) {
+      if (k in after) {
+        delete after[k];
+        changed.push(`-${k}`);
+      }
+    } else {
+      const prev = after[k];
+      if (JSON.stringify(prev) !== JSON.stringify(v)) {
+        after[k] = v;
+        changed.push(`${k in before ? "~" : "+"}${k}`);
+      }
+    }
+  }
+  if (changed.length === 0 || args.dry_run === true) {
+    return { path: target.relPath, changed_keys: changed, before, after, dry_run: args.dry_run === true };
+  }
+  // Round-trip via gray-matter — same writer pattern as createNote.
+  const newDoc = matter.stringify(note.parsed.body, after);
+  await vault.writeNote(target.relPath, newDoc, { overwrite: true });
+  return { path: target.relPath, changed_keys: changed, before, after, dry_run: false };
+}
+
+/** Find every note where frontmatter.<key> matches a predicate. Useful as
+ *  a precursor to bulk frontmatter_set: "find all notes with status:draft
+ *  and set their status to published".
+ *
+ *  Predicate semantics:
+ *    - `equals: <value>`   — strict equality (JSON.stringify comparison)
+ *    - `exists: true`      — key must exist (any value)
+ *    - `contains: <value>` — for array values, value must be a member
+ *  Exactly one predicate must be set. */
+export interface FrontmatterSearchArgs {
+  key: string;
+  equals?: unknown;
+  exists?: boolean;
+  contains?: unknown;
+  folder?: string;
+  limit?: number;
+}
+
+export async function frontmatterSearch(
+  vault: Vault,
+  args: FrontmatterSearchArgs
+): Promise<{
+  key: string;
+  total_matches: number;
+  matches: Array<{ path: string; value: unknown; mtime: string }>;
+}> {
+  await vault.ensureExists();
+  if (!args.key) throw new Error("frontmatter_search: `key` is required");
+  const predicates = [args.equals !== undefined, args.exists !== undefined, args.contains !== undefined].filter(
+    Boolean
+  );
+  if (predicates.length !== 1) {
+    throw new Error("frontmatter_search: exactly one of `equals` / `exists` / `contains` must be set");
+  }
+  const limit = args.limit ?? 100;
+  const entries = await vault.listMarkdown(args.folder);
+  const matches: Array<{ path: string; value: unknown; mtime: string }> = [];
+  for (const e of entries) {
+    if (matches.length >= limit) break;
+    try {
+      const note = await vault.readNote(e.absPath, e.mtimeMs);
+      const value = note.parsed.frontmatter[args.key];
+      let hit = false;
+      if (args.exists === true) hit = value !== undefined;
+      else if (args.equals !== undefined) hit = JSON.stringify(value) === JSON.stringify(args.equals);
+      else if (args.contains !== undefined) {
+        if (Array.isArray(value)) {
+          hit = value.some((v) => JSON.stringify(v) === JSON.stringify(args.contains));
+        }
+      }
+      if (hit) {
+        matches.push({ path: e.relPath, value, mtime: new Date(e.mtimeMs).toISOString() });
+      }
+    } catch {
+      // skip unparseable notes
+    }
+  }
+  return { key: args.key, total_matches: matches.length, matches };
+}
+
 export async function archiveNote(vault: Vault, args: ArchiveNoteArgs): Promise<RenameNoteResult> {
   await vault.ensureExists();
   if (!args.path) throw new Error("archive_note: `path` is required");
@@ -3043,6 +3180,10 @@ export async function searchHybrid(
      *  chunk; "block" returns each chunk as a distinct hit so you see the
      *  multiple-paragraph case where one note covers a topic in two places. */
     granularity?: "note" | "block";
+    /** v2.3.0: post-RRF graph boost — rerank by counting how many other
+     *  top-K hits link to each one. Default true; set false to disable for
+     *  diagnostic comparison (e.g. measuring whether boost helped). */
+    graph_boost?: boolean;
   },
   ctx: {
     /** FTS5 index, if `--persistent-index` is enabled at server start. */
@@ -3254,8 +3395,56 @@ export async function searchHybrid(
       tfidf: tfidfRanked.map((h) => ({ id: h.id, rank: h.rank, score: h.score })),
       embeddings: embedRanked.map((h) => ({ id: h.id, rank: h.rank, score: h.score }))
     },
-    { topK: limit * 2 } // overshoot in case min_signals filter prunes some
+    { topK: Math.max(limit * 4, 30) } // overshoot — graph boost may rerank
   );
+
+  // ─── v2.3.0: Wikilink graph-boost ───────────────────────────────────────
+  // Re-rank top-K by counting how many *other* top-K hits link to each one.
+  // Equivalent to a 1-step personalised PageRank seeded by the fused top-K.
+  // Boost is small (α=0.005) — enough to break ties but won't override
+  // strong single-ranker signals. Requires no new index — uses already-
+  // cached parsed wikilinks per note.
+  // This is the "only enquire-mcp does this" feature: generic vector stores
+  // can't do this without an Obsidian-aware layer; Smart Connections doesn't
+  // do it either. Wikilinks ARE the differentiating Obsidian primitive.
+  const graphBoost = args.graph_boost !== false; // default ON
+  if (graphBoost && fused.length > 1) {
+    const candidatePaths = new Set<string>();
+    for (const f of fused) {
+      candidatePaths.add(f.id.includes("#") ? (f.id.split("#")[0] ?? f.id) : f.id);
+    }
+    const outLinks = new Map<string, Set<string>>();
+    for (const candidatePath of candidatePaths) {
+      try {
+        const note = await vault.readNote(vault.resolveInside(candidatePath));
+        const targets = new Set<string>();
+        for (const wl of note.parsed.wikilinks) {
+          if (!wl.target) continue;
+          // Wikilinks can be by basename ("Foo") or relative path ("Sub/Foo").
+          // Normalize both forms so the membership test catches either.
+          targets.add(wl.target);
+          targets.add(stripMd(wl.target));
+        }
+        outLinks.set(candidatePath, targets);
+      } catch {
+        // skip unreadable notes
+      }
+    }
+    const ALPHA = 0.005;
+    for (const f of fused) {
+      const fPath = f.id.includes("#") ? (f.id.split("#")[0] ?? f.id) : f.id;
+      const fBasename = stripMd(path.basename(fPath));
+      let inDegree = 0;
+      for (const [otherPath, targets] of outLinks) {
+        if (otherPath === fPath) continue;
+        if (targets.has(fPath) || targets.has(stripMd(fPath)) || targets.has(fBasename)) {
+          inDegree += 1;
+        }
+      }
+      if (inDegree > 0) f.score += ALPHA * inDegree;
+    }
+    fused.sort((a, b) => b.score - a.score);
+  }
 
   // Build snippet/chunk lookup tables for attaching the best evidence per
   // note in the final response.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -703,6 +703,202 @@ export interface ArchiveNoteArgs {
   overwrite?: boolean;
 }
 
+// ─── obsidian_chat_thread (v2.2.0 — note-tethered AI conversations) ─────────
+// Smart Connections' #1 paid feature: AI conversations bound to a specific
+// note, persisted as markdown so they're searchable, version-controllable,
+// and survive across sessions / clients. We ship the same UX MCP-native
+// (works with Claude / Cursor / Codex / any agent), free.
+//
+// Wire format: messages stored as second-level headings under a parent
+// `## Chat: <title>` heading, with role tag in the heading and timestamp.
+//   ```md
+//   ## Chat: research session — 2026-05-08T10:00Z
+//
+//   ### user · 2026-05-08T10:00Z
+//   What did I write last week about RLHF?
+//
+//   ### assistant · 2026-05-08T10:00Z
+//   You wrote three things: ...
+//   ```
+// This format is human-readable, parseable, and feeds back into our
+// retrieval index — agents can search past chat threads by content.
+
+export interface ChatThreadAppendArgs {
+  /** Vault-relative path to the note hosting the thread. Created if absent. */
+  note_path: string;
+  /** Role of the message being appended. */
+  role: "user" | "assistant" | "system";
+  /** Message body (markdown allowed). */
+  content: string;
+  /** Optional thread title — used when the note is created from scratch. */
+  thread_title?: string;
+}
+
+export interface ChatThreadMessage {
+  role: "user" | "assistant" | "system";
+  timestamp: string;
+  content: string;
+  /** 1-based start line in the source note (for jumping to that point). */
+  line_start: number;
+  line_end: number;
+}
+
+export interface ChatThreadReadResult {
+  note_path: string;
+  thread_title: string | null;
+  messages: ChatThreadMessage[];
+  message_count: number;
+}
+
+const CHAT_HEADING_RE = /^### (user|assistant|system) · (.+?)\s*$/;
+// Multi-line flag: `## Chat:` heading can appear anywhere in the body, not
+// only at string start. The append codepath uses .test(body); the read
+// codepath uses .exec(line) per-line so the flag is harmless there.
+const CHAT_THREAD_TITLE_RE = /^## Chat: (.+?)\s*$/m;
+
+/** Append a message to a note's chat thread. Creates the note (and the
+ *  `## Chat: <title>` heading) if absent. Idempotent in the sense that
+ *  appending always creates a fresh `### <role> · <timestamp>` block — no
+ *  silent overwrites. */
+export async function chatThreadAppend(
+  vault: Vault,
+  args: ChatThreadAppendArgs
+): Promise<{ note_path: string; line_start: number; line_end: number }> {
+  await vault.ensureExists();
+  if (!args.note_path?.trim()) throw new Error("chat_thread_append: `note_path` is required");
+  if (!args.content?.trim()) throw new Error("chat_thread_append: `content` is required");
+  const role = args.role;
+  if (role !== "user" && role !== "assistant" && role !== "system") {
+    throw new Error(`chat_thread_append: invalid role "${role}" (must be user|assistant|system)`);
+  }
+  const targetRel = args.note_path.toLowerCase().endsWith(".md") ? args.note_path : `${args.note_path}.md`;
+  const abs = vault.resolveInside(targetRel);
+  const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const messageBlock = `\n### ${role} · ${timestamp}\n\n${args.content.trim()}\n`;
+
+  // Read existing or create new with thread heading.
+  let existed = true;
+  let body = "";
+  try {
+    body = await vault.readFile(abs);
+  } catch {
+    existed = false;
+  }
+  let toAppend: string;
+  if (existed && CHAT_THREAD_TITLE_RE.test(body)) {
+    // Existing thread — just append message.
+    toAppend = messageBlock;
+  } else if (existed) {
+    // Existing note without a chat heading — add heading first.
+    const title = args.thread_title?.trim() || `chat — ${timestamp.slice(0, 10)}`;
+    toAppend = `\n\n## Chat: ${title}\n${messageBlock}`;
+  } else {
+    // New note from scratch.
+    const title = args.thread_title?.trim() || `chat — ${timestamp.slice(0, 10)}`;
+    const initial = `# ${title}\n\n## Chat: ${title}\n${messageBlock}`;
+    const result = await vault.writeNote(targetRel, initial, { overwrite: false });
+    return {
+      note_path: result.relPath,
+      line_start: 4,
+      line_end: 4 + messageBlock.split("\n").length
+    };
+  }
+  const before = body.length;
+  const newBody = body.replace(/\n+$/, "") + toAppend;
+  await vault.writeNote(targetRel, newBody, { overwrite: true });
+  const lineStart = (body.slice(0, before).match(/\n/g) ?? []).length + 1;
+  return {
+    note_path: vault.toRel(abs),
+    line_start: lineStart,
+    line_end: lineStart + toAppend.split("\n").length
+  };
+}
+
+/** Parse a note's chat thread into structured messages. Non-chat content
+ *  (anything outside the `## Chat: <title>` block) is ignored. */
+export async function chatThreadRead(vault: Vault, args: { note_path: string }): Promise<ChatThreadReadResult> {
+  await vault.ensureExists();
+  const targetRel = args.note_path.toLowerCase().endsWith(".md") ? args.note_path : `${args.note_path}.md`;
+  const abs = vault.resolveInside(targetRel);
+  const body = await vault.readFile(abs);
+  const lines = body.split("\n");
+  let threadTitle: string | null = null;
+  let inThread = false;
+  const messages: ChatThreadMessage[] = [];
+  let current: { role: ChatThreadMessage["role"]; timestamp: string; line_start: number; lines: string[] } | null =
+    null;
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i] ?? "";
+    const titleMatch = CHAT_THREAD_TITLE_RE.exec(ln);
+    if (titleMatch) {
+      if (current) {
+        messages.push({
+          role: current.role,
+          timestamp: current.timestamp,
+          content: current.lines.join("\n").trim(),
+          line_start: current.line_start,
+          line_end: i
+        });
+        current = null;
+      }
+      threadTitle = (titleMatch[1] ?? "").trim();
+      inThread = true;
+      continue;
+    }
+    if (!inThread) continue;
+    // Higher-level heading or a different `## Chat:` block ends the thread.
+    if (/^# /.test(ln) || (/^## /.test(ln) && !CHAT_THREAD_TITLE_RE.test(ln))) {
+      if (current) {
+        messages.push({
+          role: current.role,
+          timestamp: current.timestamp,
+          content: current.lines.join("\n").trim(),
+          line_start: current.line_start,
+          line_end: i
+        });
+        current = null;
+      }
+      inThread = false;
+      continue;
+    }
+    const headingMatch = CHAT_HEADING_RE.exec(ln);
+    if (headingMatch?.[1] && headingMatch[2]) {
+      if (current) {
+        messages.push({
+          role: current.role,
+          timestamp: current.timestamp,
+          content: current.lines.join("\n").trim(),
+          line_start: current.line_start,
+          line_end: i
+        });
+      }
+      current = {
+        role: headingMatch[1] as ChatThreadMessage["role"],
+        timestamp: headingMatch[2].trim(),
+        line_start: i + 1,
+        lines: []
+      };
+      continue;
+    }
+    if (current) current.lines.push(ln);
+  }
+  if (current) {
+    messages.push({
+      role: current.role,
+      timestamp: current.timestamp,
+      content: current.lines.join("\n").trim(),
+      line_start: current.line_start,
+      line_end: lines.length
+    });
+  }
+  return {
+    note_path: vault.toRel(abs),
+    thread_title: threadTitle,
+    messages,
+    message_count: messages.length
+  };
+}
+
 export async function archiveNote(vault: Vault, args: ArchiveNoteArgs): Promise<RenameNoteResult> {
   await vault.ensureExists();
   if (!args.path) throw new Error("archive_note: `path` is required");
@@ -2837,7 +3033,17 @@ export interface SearchHybridResponse {
 
 export async function searchHybrid(
   vault: Vault,
-  args: { query: string; folder?: string; limit?: number; min_signals?: number; embedding_model?: string },
+  args: {
+    query: string;
+    folder?: string;
+    limit?: number;
+    min_signals?: number;
+    embedding_model?: string;
+    /** v2.2.0: "note" (default) returns 1 hit per note, picking the best
+     *  chunk; "block" returns each chunk as a distinct hit so you see the
+     *  multiple-paragraph case where one note covers a topic in two places. */
+    granularity?: "note" | "block";
+  },
   ctx: {
     /** FTS5 index, if `--persistent-index` is enabled at server start. */
     ftsIndex: FtsIndex | null;
@@ -2849,6 +3055,7 @@ export async function searchHybrid(
   if (!args.query.trim()) throw new Error("query must not be empty");
   const limit = args.limit ?? 10;
   const minSignals = args.min_signals ?? 1;
+  const granularity = args.granularity ?? "note";
   // Fan-out per-ranker top-K. Bigger than user's `limit` so RRF has room
   // to surface a doc that's mid-rank in one signal but top in another.
   const fanOutK = Math.max(50, limit * 5);
@@ -2879,37 +3086,53 @@ export async function searchHybrid(
       // Pre-fix, BM25 search returned excluded chunks via the hybrid pipeline.
       const rawFtsHits = ctx.ftsIndex.search(args.query, { limit: fanOutK, folder: args.folder });
       const ftsHits = rawFtsHits.filter((h) => !vault.isExcluded(h.rel_path));
-      const bestPerNote = new Map<
-        string,
-        { score: number; rank: number; snippet: string; chunk_index: number; line_start: number; line_end: number }
-      >();
-      ftsHits.forEach((h, i) => {
-        const existing = bestPerNote.get(h.rel_path);
-        if (!existing || i < existing.rank) {
-          bestPerNote.set(h.rel_path, {
-            score: h.score,
-            rank: i + 1,
-            snippet: h.snippet,
-            chunk_index: h.chunk_index,
-            line_start: h.line_start,
-            line_end: h.line_end
-          });
+      // v2.2.0: granularity branch.
+      //   "note"  → collapse multi-chunk hits per note (best-rank wins),
+      //             RRF fuses on path key.
+      //   "block" → keep each chunk distinct, RRF fuses on `path#chunk_index`.
+      if (granularity === "block") {
+        bm25Ranked = ftsHits.map((h, i) => ({
+          id: `${h.rel_path}#${h.chunk_index}`,
+          rank: i + 1,
+          score: h.score,
+          snippet: h.snippet,
+          chunk_index: h.chunk_index,
+          line_start: h.line_start,
+          line_end: h.line_end
+        }));
+      } else {
+        const bestPerNote = new Map<
+          string,
+          { score: number; rank: number; snippet: string; chunk_index: number; line_start: number; line_end: number }
+        >();
+        ftsHits.forEach((h, i) => {
+          const existing = bestPerNote.get(h.rel_path);
+          if (!existing || i < existing.rank) {
+            bestPerNote.set(h.rel_path, {
+              score: h.score,
+              rank: i + 1,
+              snippet: h.snippet,
+              chunk_index: h.chunk_index,
+              line_start: h.line_start,
+              line_end: h.line_end
+            });
+          }
+        });
+        bm25Ranked = Array.from(bestPerNote.entries()).map(([id, b]) => ({
+          id,
+          rank: b.rank,
+          score: b.score,
+          snippet: b.snippet,
+          chunk_index: b.chunk_index,
+          line_start: b.line_start,
+          line_end: b.line_end
+        }));
+        // Re-sort to ensure 1-based ranks are consecutive after dedup.
+        bm25Ranked.sort((a, b) => a.rank - b.rank);
+        for (let i = 0; i < bm25Ranked.length; i++) {
+          const hit = bm25Ranked[i];
+          if (hit) hit.rank = i + 1;
         }
-      });
-      bm25Ranked = Array.from(bestPerNote.entries()).map(([id, b]) => ({
-        id,
-        rank: b.rank,
-        score: b.score,
-        snippet: b.snippet,
-        chunk_index: b.chunk_index,
-        line_start: b.line_start,
-        line_end: b.line_end
-      }));
-      // Re-sort to ensure 1-based ranks are consecutive after dedup.
-      bm25Ranked.sort((a, b) => a.rank - b.rank);
-      for (let i = 0; i < bm25Ranked.length; i++) {
-        const hit = bm25Ranked[i];
-        if (hit) hit.rank = i + 1;
       }
       if (bm25Ranked.length > 0) signalsUsed.push("bm25");
     } catch (err) {
@@ -2965,37 +3188,56 @@ export async function searchHybrid(
         { query: args.query, folder: args.folder, limit: fanOutK, model: args.embedding_model, min_score: 0 },
         ctx.embedFile
       );
-      // Same chunk-collapse as BM25.
-      const bestPerNote = new Map<
-        string,
-        { score: number; rank: number; snippet: string; chunk_index: number; line_start: number; line_end: number }
-      >();
-      embed.matches.forEach((m, i) => {
-        const existing = bestPerNote.get(m.path);
-        if (!existing || i < existing.rank) {
-          bestPerNote.set(m.path, {
-            score: m.score,
-            rank: i + 1,
-            snippet: m.snippet,
-            chunk_index: m.chunk_index,
-            line_start: m.line_start,
-            line_end: m.line_end
-          });
+      // v2.2.0: granularity branch — same shape as BM25 above.
+      if (granularity === "block") {
+        embedRanked = embed.matches.map((m, i) => ({
+          id: `${m.path}#${m.chunk_index ?? 0}`,
+          rank: i + 1,
+          score: m.score,
+          snippet: m.snippet,
+          chunk_index: m.chunk_index,
+          line_start: m.line_start,
+          line_end: m.line_end
+        }));
+      } else {
+        const bestPerNote = new Map<
+          string,
+          {
+            score: number;
+            rank: number;
+            snippet: string;
+            chunk_index: number;
+            line_start: number;
+            line_end: number;
+          }
+        >();
+        embed.matches.forEach((m, i) => {
+          const existing = bestPerNote.get(m.path);
+          if (!existing || i < existing.rank) {
+            bestPerNote.set(m.path, {
+              score: m.score,
+              rank: i + 1,
+              snippet: m.snippet,
+              chunk_index: m.chunk_index,
+              line_start: m.line_start,
+              line_end: m.line_end
+            });
+          }
+        });
+        embedRanked = Array.from(bestPerNote.entries()).map(([id, b]) => ({
+          id,
+          rank: b.rank,
+          score: b.score,
+          snippet: b.snippet,
+          chunk_index: b.chunk_index,
+          line_start: b.line_start,
+          line_end: b.line_end
+        }));
+        embedRanked.sort((a, b) => a.rank - b.rank);
+        for (let i = 0; i < embedRanked.length; i++) {
+          const hit = embedRanked[i];
+          if (hit) hit.rank = i + 1;
         }
-      });
-      embedRanked = Array.from(bestPerNote.entries()).map(([id, b]) => ({
-        id,
-        rank: b.rank,
-        score: b.score,
-        snippet: b.snippet,
-        chunk_index: b.chunk_index,
-        line_start: b.line_start,
-        line_end: b.line_end
-      }));
-      embedRanked.sort((a, b) => a.rank - b.rank);
-      for (let i = 0; i < embedRanked.length; i++) {
-        const hit = embedRanked[i];
-        if (hit) hit.rank = i + 1;
       }
       if (embedRanked.length > 0) signalsUsed.push("embeddings");
     } catch (err) {
@@ -3041,12 +3283,25 @@ export async function searchHybrid(
     if (f.per_signal.embeddings) {
       perSignal.embeddings = { rank: f.per_signal.embeddings.rank, score: f.per_signal.embeddings.score };
     }
+    // v2.2.0: when granularity is "block", f.id is "path#chunk_index" — split
+    // back into path + chunk_index for the response. When "note", f.id is
+    // just the path.
+    let pathPart = f.id;
+    let chunkFromId: number | undefined;
+    if (granularity === "block") {
+      const hashIdx = f.id.lastIndexOf("#");
+      if (hashIdx > 0) {
+        pathPart = f.id.slice(0, hashIdx);
+        const parsed = Number.parseInt(f.id.slice(hashIdx + 1), 10);
+        if (Number.isInteger(parsed) && parsed >= 0) chunkFromId = parsed;
+      }
+    }
     matches.push({
-      path: f.id,
-      title: stripMd(path.basename(f.id)),
+      path: pathPart,
+      title: stripMd(path.basename(pathPart)),
       score: Math.round(f.score * 100000) / 100000,
       snippet: bestEvidence?.snippet ?? "",
-      chunk_index: bm?.chunk_index ?? emb?.chunk_index,
+      chunk_index: chunkFromId ?? bm?.chunk_index ?? emb?.chunk_index,
       line_start: bm?.line_start ?? emb?.line_start,
       line_end: bm?.line_end ?? emb?.line_end,
       per_signal: perSignal
@@ -3069,6 +3324,149 @@ export async function searchHybrid(
     response.signal_errors = signalErrors;
   }
   return response;
+}
+
+// ─── obsidian_context_pack (v2.2.0 — token-budgeted vault context export) ───
+// Smart Connections' "Send to Smart Context" pattern, MCP-native. Takes a
+// query, runs hybrid retrieval, gathers note bodies + 1-line backlink
+// summaries + recent daily notes, deduplicates, packs to a token budget,
+// returns one ready-to-paste markdown string. The agent doesn't have to
+// orchestrate 5 separate tool calls — one tool, one context blob.
+//
+// Why MCP-native > Obsidian-only: Smart Context only works inside Obsidian.
+// This tool works in Claude Code, Cursor, Codex, anywhere — copy the result
+// into ANY chat.
+
+export interface ContextPackArgs {
+  /** Topic / question to gather context for. */
+  query: string;
+  /** Approximate token budget for the bundle. ~4 chars/token assumption. Default 4000. */
+  budget_tokens?: number;
+  /** Restrict retrieval to this folder. */
+  folder?: string;
+  /** Include backlinks of top-K notes (1-line each)? Default true. */
+  include_backlinks?: boolean;
+  /** Include the last N daily notes? Default 0 (off). Set to 3 for "what was I doing recently". */
+  recent_dailies?: number;
+}
+
+export interface ContextPackResult {
+  query: string;
+  /** The packed markdown bundle ready to paste into an AI chat. */
+  bundle: string;
+  /** Approximate token count (chars / 4). */
+  estimated_tokens: number;
+  budget_tokens: number;
+  /** Per-section byte counts for observability. */
+  sections: {
+    notes: number;
+    backlinks: number;
+    dailies: number;
+  };
+  /** Top-K hit paths included in the bundle. */
+  included_notes: string[];
+}
+
+export async function contextPack(
+  vault: Vault,
+  args: ContextPackArgs,
+  ctx: { ftsIndex: FtsIndex | null; embedFile: string }
+): Promise<ContextPackResult> {
+  await vault.ensureExists();
+  if (!args.query?.trim()) throw new Error("context_pack: `query` is required");
+  const budget = args.budget_tokens ?? 4000;
+  const charBudget = budget * 4; // ~4 chars/token
+  const includeBacklinks = args.include_backlinks !== false;
+  const recentN = Math.max(0, args.recent_dailies ?? 0);
+
+  // 1) Hybrid retrieval — top-K notes
+  const search = await searchHybrid(
+    vault,
+    { query: args.query, folder: args.folder, limit: 10 },
+    { ftsIndex: ctx.ftsIndex, embedFile: ctx.embedFile }
+  );
+
+  const sections: string[] = [`# Context for: ${args.query}\n`];
+  const includedNotes: string[] = [];
+  let charsUsed = sections[0]?.length ?? 0;
+  let notesBytes = 0;
+  let backlinksBytes = 0;
+  let dailiesBytes = 0;
+
+  // 2) Pack note bodies until budget exhausted
+  sections.push("## Top notes");
+  for (const m of search.matches) {
+    if (charsUsed >= charBudget) break;
+    try {
+      const note = await vault.readNote(vault.resolveInside(m.path), undefined);
+      const body = note.parsed.body.trim();
+      const headerLen = m.path.length + 5;
+      const remaining = charBudget - charsUsed;
+      // Truncate body to fit remaining budget for THIS note (~50% of remainder
+      // so we leave room for backlinks + dailies).
+      const noteCap = Math.min(body.length, Math.max(500, Math.floor(remaining * 0.5)));
+      const trimmed = body.length <= noteCap ? body : `${body.slice(0, noteCap)}\n\n[…truncated…]`;
+      const block = `### ${m.path}\n\n${trimmed}\n`;
+      sections.push(block);
+      charsUsed += block.length + headerLen;
+      notesBytes += block.length;
+      includedNotes.push(m.path);
+    } catch {
+      // skip unreadable notes
+    }
+  }
+
+  // 3) 1-line backlink summaries for top-3
+  if (includeBacklinks && includedNotes.length > 0 && charsUsed < charBudget) {
+    sections.push("## Backlinks");
+    let backlinksAdded = 0;
+    for (const notePath of includedNotes.slice(0, 3)) {
+      if (charsUsed >= charBudget) break;
+      try {
+        const links = await getBacklinks(vault, { path: notePath, limit: 5 });
+        if (links.length > 0) {
+          const block = `### → ${notePath}\n${links.map((l) => `- ${l.path} : ${(l.snippets[0] ?? "").slice(0, 80)}`).join("\n")}\n`;
+          sections.push(block);
+          charsUsed += block.length;
+          backlinksBytes += block.length;
+          backlinksAdded += links.length;
+        }
+      } catch {
+        // skip
+      }
+    }
+    if (backlinksAdded === 0) sections.pop(); // remove empty heading
+  }
+
+  // 4) Recent daily notes
+  if (recentN > 0 && charsUsed < charBudget) {
+    try {
+      const recent = await getRecentEdits(vault, { since_minutes: 60 * 24 * 7, limit: recentN, folder: args.folder });
+      const dailies = recent.filter((r) => /\d{4}-\d{2}-\d{2}/.test(r.path));
+      if (dailies.length > 0) {
+        sections.push(`## Recent (${dailies.length} dailies, last 7 days)`);
+        for (const d of dailies) {
+          if (charsUsed >= charBudget) break;
+          const block = `- ${d.path} (${d.mtime})`;
+          sections.push(block);
+          charsUsed += block.length;
+          dailiesBytes += block.length;
+        }
+      }
+    } catch {
+      // skip
+    }
+  }
+
+  const bundle = sections.join("\n");
+  return {
+    query: args.query,
+    bundle,
+    estimated_tokens: Math.ceil(bundle.length / 4),
+    budget_tokens: budget,
+    sections: { notes: notesBytes, backlinks: backlinksBytes, dailies: dailiesBytes },
+    included_notes: includedNotes
+  };
 }
 
 // ─── small set / string helpers shared by find_similar / get_note_neighbors ─

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2499,16 +2499,39 @@ const STOP_WORDS = new Set([
   "how"
 ]);
 
+// v2.1.0: detect Chinese / Japanese / Thai / Khmer / Lao via script ranges.
+// These languages don't use spaces between words, so the Unicode-regex
+// tokenizer falls back to character-level (or huge multi-word tokens),
+// which tanks BM25 + TF-IDF precision. Intl.Segmenter (Node 16+ ICU)
+// gives word-break per language. Detection is per-document, branching the
+// tokenizer.
+const CJK_OR_THAI_RANGES = /[぀-ヿ㐀-䶿一-鿿가-힯฀-๿ༀ-࿿ក-៿]/;
+
 function tokenizeForTfidf(text: string): string[] {
   // v1.11.1: Unicode-aware tokenizer. The previous ASCII-only regex
   // (`/[a-z0-9][a-z0-9_-]*/g`) silently dropped Cyrillic, Greek, CJK,
-  // Hebrew, Arabic, and any non-Latin content from the TF-IDF index —
-  // semantic search returned zero hits for non-English queries on
-  // non-English notes. `\p{L}` matches any Unicode letter; `\p{N}`
-  // matches any Unicode number. The leading-class restriction prevents
-  // tokens that start with `_-` separators.
+  // Hebrew, Arabic, and any non-Latin content from the TF-IDF index.
+  // `\p{L}` matches any Unicode letter; `\p{N}` matches any Unicode number.
+  //
+  // v2.1.0: when the text contains CJK / Thai / Khmer / Lao chars (no-
+  // whitespace scripts), use Intl.Segmenter for proper word-break first,
+  // then run the Unicode regex per-segment. This produces real word tokens
+  // instead of "認可サーバーがアクセストークン" as a single 12-char token
+  // that the length filter would drop.
   const lower = text.toLowerCase();
   const out: string[] = [];
+  if (CJK_OR_THAI_RANGES.test(lower) && typeof Intl !== "undefined" && typeof Intl.Segmenter !== "undefined") {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
+    for (const seg of segmenter.segment(lower)) {
+      if (!seg.isWordLike) continue;
+      const t = seg.segment;
+      if (t.length < 1) continue;
+      if (t.length > 40) continue;
+      if (STOP_WORDS.has(t)) continue;
+      out.push(t);
+    }
+    return out;
+  }
   for (const m of lower.matchAll(/[\p{L}\p{N}][\p{L}\p{N}_-]*/gu)) {
     const t = m[0];
     if (t.length < 2) continue;

--- a/tests/chat-thread.test.ts
+++ b/tests/chat-thread.test.ts
@@ -1,0 +1,114 @@
+// v2.2.0: chat-thread tools — note-tethered AI conversations.
+// Stored as `## Chat: <title>` block with `### <role> · <timestamp>`
+// message headings.
+
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chatThreadAppend, chatThreadRead } from "../src/tools.js";
+import { Vault } from "../src/vault.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-chat-"));
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("chat_thread_append (v2.2.0)", () => {
+  it("creates a new note with title heading + chat block when path doesn't exist", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    await chatThreadAppend(v, {
+      note_path: "Threads/research.md",
+      role: "user",
+      content: "What did I write last week about RLHF?",
+      thread_title: "RLHF research"
+    });
+    const body = await fs.readFile(path.join(root, "Threads", "research.md"), "utf8");
+    expect(body).toContain("# RLHF research");
+    expect(body).toContain("## Chat: RLHF research");
+    expect(body).toContain("### user · ");
+    expect(body).toContain("What did I write last week about RLHF?");
+  });
+
+  it("appends to existing thread without duplicating heading", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    await chatThreadAppend(v, { note_path: "session.md", role: "user", content: "first message" });
+    await chatThreadAppend(v, { note_path: "session.md", role: "assistant", content: "first reply" });
+    await chatThreadAppend(v, { note_path: "session.md", role: "user", content: "second message" });
+    const body = await fs.readFile(path.join(root, "session.md"), "utf8");
+    // Exactly ONE thread heading.
+    const threadHeadings = body.match(/^## Chat: /gm) ?? [];
+    expect(threadHeadings.length).toBe(1);
+    // Three role headings.
+    const roleHeadings = body.match(/^### (user|assistant) · /gm) ?? [];
+    expect(roleHeadings.length).toBe(3);
+  });
+
+  it("rejects empty path / content", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    await expect(chatThreadAppend(v, { note_path: "", role: "user", content: "x" })).rejects.toThrow(/required/);
+    await expect(chatThreadAppend(v, { note_path: "x.md", role: "user", content: "" })).rejects.toThrow(/required/);
+  });
+
+  it("respects vault read-only — refuses without --enable-write", async () => {
+    const v = new Vault(root, { enableWrite: false });
+    await v.ensureExists();
+    await expect(chatThreadAppend(v, { note_path: "x.md", role: "user", content: "hi" })).rejects.toThrow(/read-only/);
+  });
+});
+
+describe("chat_thread_read (v2.2.0)", () => {
+  it("parses messages out of a chat note", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    await chatThreadAppend(v, {
+      note_path: "log.md",
+      role: "user",
+      content: "What's in my project notes?",
+      thread_title: "log"
+    });
+    await chatThreadAppend(v, { note_path: "log.md", role: "assistant", content: "Three notes." });
+    const result = await chatThreadRead(v, { note_path: "log.md" });
+    expect(result.thread_title).toBe("log");
+    expect(result.message_count).toBe(2);
+    expect(result.messages[0]?.role).toBe("user");
+    expect(result.messages[0]?.content).toBe("What's in my project notes?");
+    expect(result.messages[1]?.role).toBe("assistant");
+    expect(result.messages[1]?.content).toBe("Three notes.");
+    // Each message has line range.
+    expect(result.messages[0]?.line_start).toBeGreaterThan(0);
+    expect(result.messages[0]?.line_end).toBeGreaterThan(result.messages[0]?.line_start ?? 0);
+  });
+
+  it("returns empty messages on a note without `## Chat:` block", async () => {
+    await fs.writeFile(path.join(root, "regular.md"), "# Just a regular note\n\nNo chat here.\n");
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await chatThreadRead(v, { note_path: "regular.md" });
+    expect(result.thread_title).toBeNull();
+    expect(result.message_count).toBe(0);
+  });
+
+  it("handles multi-line message content correctly (preserves markdown)", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    await chatThreadAppend(v, {
+      note_path: "multi.md",
+      role: "assistant",
+      content: "Line 1\n\nLine 3 after blank\n- bullet 1\n- bullet 2"
+    });
+    const result = await chatThreadRead(v, { note_path: "multi.md" });
+    expect(result.message_count).toBe(1);
+    expect(result.messages[0]?.content).toContain("Line 1");
+    expect(result.messages[0]?.content).toContain("Line 3 after blank");
+    expect(result.messages[0]?.content).toContain("- bullet 1");
+  });
+});

--- a/tests/frontmatter-ops.test.ts
+++ b/tests/frontmatter-ops.test.ts
@@ -1,0 +1,125 @@
+// v2.3.0: frontmatter atomic ops.
+
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { frontmatterGet, frontmatterSearch, frontmatterSet } from "../src/tools.js";
+import { Vault } from "../src/vault.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-fm-"));
+  await fs.writeFile(path.join(root, "draft.md"), "---\nstatus: draft\ntags: [project, idea]\n---\n\nDraft body.\n");
+  await fs.writeFile(path.join(root, "no-fm.md"), "Just a body, no frontmatter.\n");
+  await fs.writeFile(
+    path.join(root, "published.md"),
+    "---\nstatus: published\ntags: [project]\n---\n\nPublished body.\n"
+  );
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("frontmatter_get", () => {
+  it("returns full frontmatter object without `key`", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await frontmatterGet(v, { path: "draft.md" });
+    expect(result.frontmatter).toEqual({ status: "draft", tags: ["project", "idea"] });
+    expect(result.value).toBeUndefined();
+  });
+
+  it("returns single-key value with `key`", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await frontmatterGet(v, { path: "draft.md", key: "status" });
+    expect(result.value).toBe("draft");
+  });
+
+  it("returns empty frontmatter for note without one", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await frontmatterGet(v, { path: "no-fm.md" });
+    expect(result.frontmatter).toEqual({});
+  });
+});
+
+describe("frontmatter_set", () => {
+  it("sets a key, returns before/after diff", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    const result = await frontmatterSet(v, { path: "draft.md", set: { status: "published" } });
+    expect(result.changed_keys).toContain("~status");
+    expect(result.before.status).toBe("draft");
+    expect(result.after.status).toBe("published");
+    expect(result.dry_run).toBe(false);
+    // Verify on disk
+    const body = await fs.readFile(path.join(root, "draft.md"), "utf8");
+    expect(body).toContain("status: published");
+    expect(body).toContain("Draft body.");
+  });
+
+  it("removes a key when value is null", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    const result = await frontmatterSet(v, { path: "draft.md", set: { status: null } });
+    expect(result.changed_keys).toContain("-status");
+    expect(result.after.status).toBeUndefined();
+  });
+
+  it("dry_run shows diff without writing", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    const result = await frontmatterSet(v, {
+      path: "draft.md",
+      set: { status: "published" },
+      dry_run: true
+    });
+    expect(result.dry_run).toBe(true);
+    expect(result.changed_keys).toContain("~status");
+    // Disk untouched.
+    const body = await fs.readFile(path.join(root, "draft.md"), "utf8");
+    expect(body).toContain("status: draft");
+  });
+
+  it("rejects empty `set` object", async () => {
+    const v = new Vault(root, { enableWrite: true });
+    await v.ensureExists();
+    await expect(frontmatterSet(v, { path: "draft.md", set: {} })).rejects.toThrow(/non-empty/);
+  });
+});
+
+describe("frontmatter_search", () => {
+  it("`equals` finds notes with exact value match", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await frontmatterSearch(v, { key: "status", equals: "draft" });
+    expect(result.total_matches).toBe(1);
+    expect(result.matches[0]?.path).toBe("draft.md");
+  });
+
+  it("`exists: true` finds all notes that have the key set", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await frontmatterSearch(v, { key: "status", exists: true });
+    expect(result.total_matches).toBe(2);
+  });
+
+  it("`contains` finds array-typed values that contain the target", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const result = await frontmatterSearch(v, { key: "tags", contains: "idea" });
+    expect(result.total_matches).toBe(1);
+    expect(result.matches[0]?.path).toBe("draft.md");
+  });
+
+  it("rejects 0 or 2+ predicates", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    await expect(frontmatterSearch(v, { key: "status" })).rejects.toThrow(/exactly one/);
+    await expect(frontmatterSearch(v, { key: "status", equals: "draft", exists: true })).rejects.toThrow(/exactly one/);
+  });
+});

--- a/tests/fts5.test.ts
+++ b/tests/fts5.test.ts
@@ -89,6 +89,61 @@ describe("chunkContent", () => {
     expect(chunks[1]?.lineStart).toBeGreaterThan(1);
     expect(chunks[2]?.lineStart).toBeGreaterThan(chunks[1]?.lineStart ?? 0);
   });
+
+  // v2.1.0: heading breadcrumb propagation
+  it("attaches heading breadcrumb (H1 > H2 > H3 in scope) to each chunk", () => {
+    const md = `# Setup
+
+intro paragraph
+
+## Install
+
+run npm install
+
+### Requirements
+
+Node 20+
+
+## Configure
+
+set VAULT env`;
+    const chunks = chunkContent(md);
+    // Find chunk with body "intro paragraph"
+    const intro = chunks.find((c) => c.text === "intro paragraph");
+    expect(intro?.breadcrumb).toBe("Setup");
+    // Find chunk with body "run npm install"
+    const install = chunks.find((c) => c.text === "run npm install");
+    expect(install?.breadcrumb).toBe("Setup > Install");
+    // Find chunk with body "Node 20+"
+    const reqs = chunks.find((c) => c.text === "Node 20+");
+    expect(reqs?.breadcrumb).toBe("Setup > Install > Requirements");
+    // Find chunk with body "set VAULT env" — sibling H2 should pop the H3
+    const cfg = chunks.find((c) => c.text === "set VAULT env");
+    expect(cfg?.breadcrumb).toBe("Setup > Configure");
+  });
+
+  it("breadcrumb is empty for content before any heading (preamble)", () => {
+    const md = "intro line\n\n# First Heading\n\nbody";
+    const chunks = chunkContent(md);
+    const intro = chunks.find((c) => c.text === "intro line");
+    expect(intro?.breadcrumb).toBe("");
+  });
+
+  it("`#` inside a fenced code block is NOT treated as a heading", () => {
+    const md = `# Real Heading
+
+\`\`\`bash
+# this is a shell comment, not a heading
+echo hi
+\`\`\`
+
+after the fence`;
+    const chunks = chunkContent(md);
+    // The "after the fence" chunk should still have breadcrumb "Real Heading"
+    // (the # in the code block must not have hijacked the stack).
+    const after = chunks.find((c) => c.text === "after the fence");
+    expect(after?.breadcrumb).toBe("Real Heading");
+  });
 });
 
 describe("FtsIndex — full lifecycle", () => {

--- a/tests/semantic.test.ts
+++ b/tests/semantic.test.ts
@@ -170,3 +170,46 @@ describe("semanticSearch (v1.11.1 Unicode tokenizer)", () => {
     expect(result.matches[0]?.path).toBe("Αυθεντικοποίηση.md");
   });
 });
+
+// v2.1.0: CJK / Thai / Khmer / Lao segmentation via Intl.Segmenter
+describe("semanticSearch (v2.1.0 CJK/Thai segmentation)", () => {
+  let croot: string;
+
+  beforeAll(async () => {
+    croot = await fs.mkdtemp(path.join(os.tmpdir(), "obsidian-mcp-cjk-"));
+    await fs.writeFile(
+      path.join(croot, "认证.md"),
+      "JWT 令牌 OAuth 认证 流程。授权 服务器 颁发 访问 令牌 和 刷新 令牌。\n"
+    );
+    await fs.writeFile(
+      path.join(croot, "烹饪.md"),
+      "意大利面 培根 罗马诺 鸡蛋 黑胡椒。 与 热的 意大利面 一起 翻炒。\n"
+    );
+    await fs.writeFile(
+      path.join(croot, "認証.md"),
+      "JWT トークン を 使った OAuth 認証 フロー。 認可 サーバー が アクセス トークン を 発行 します。\n"
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(croot, { recursive: true, force: true });
+  });
+
+  it("indexes Chinese (Hanzi) content via Intl.Segmenter word-break", async () => {
+    const v = new Vault(croot);
+    const result = await semanticSearch(v, { query: "JWT 令牌 认证", limit: 5 });
+    expect(result.matches.length).toBeGreaterThan(0);
+    // Top hit should be the auth note, NOT the cooking note (which has no
+    // overlap with auth tokens).
+    expect(result.matches[0]?.path).toBe("认证.md");
+  });
+
+  it("indexes Japanese (kana + kanji) via Intl.Segmenter", async () => {
+    const v = new Vault(croot);
+    const result = await semanticSearch(v, { query: "OAuth 認証 トークン", limit: 5 });
+    expect(result.matches.length).toBeGreaterThan(0);
+    // Top hit should be the Japanese auth note (uses katakana for tokens
+    // and kanji for auth — Intl.Segmenter must word-break both correctly).
+    expect(result.matches[0]?.path).toBe("認証.md");
+  });
+});


### PR DESCRIPTION
Stacked on PRs #18 #19 #20. Strategic claim: enquire-mcp = open-source backend for Karpathy-style LLM Wikis. 4 new MCP prompts: vault_synth, vault_wiki_compile, vault_lint_extended, vault_capture. Tests 431 (prompts are pure templates, no test delta).