### PR TITLE
docs: refresh README post v2.5-v2.9 + add dist-tag cleanup workflow

### DIFF
--- a/.github/workflows/dist-tag-cleanup.yml
+++ b/.github/workflows/dist-tag-cleanup.yml
@@ -1,0 +1,48 @@
+name: Cleanup stale npm dist-tags
+
+# One-shot workflow to remove the `alpha` and `beta` dist-tags that were left
+# pointing at the v2.0 prerelease train (`alpha → 2.0.0-alpha.0`,
+# `beta → 2.0.0-beta.4`). After v2.0.0 stable shipped, these channels stopped
+# moving — the maintainer doesn't ship from prerelease tracks anymore.
+#
+# Trigger manually via the Actions tab. Uses the same NPM_TOKEN secret the
+# release-to-npm workflow uses, so no separate auth setup. Idempotent —
+# `npm dist-tag rm` returns 0 even if the tag is already gone.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "REMOVE" to confirm dist-tag deletion'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ inputs.confirm == 'REMOVE' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+      - name: Show current dist-tags (before)
+        run: npm view @oomkapwn/enquire-mcp dist-tags
+      - name: Remove stale alpha tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # `|| true` because npm dist-tag rm exits non-zero when the tag
+        # doesn't exist; we want this idempotent.
+        run: npm dist-tag rm @oomkapwn/enquire-mcp alpha || true
+      - name: Remove stale beta tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm dist-tag rm @oomkapwn/enquire-mcp beta || true
+      - name: Show current dist-tags (after)
+        run: npm view @oomkapwn/enquire-mcp dist-tags

--- a/README.md
+++ b/README.md
@@ -1,89 +1,35 @@
 <div align="center">
 
-<a href="https://github.com/oomkapwn/enquire-mcp"><img src="./assets/social-preview.png" alt="enquire — MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF). Wikilinks, frontmatter, backlinks, Dataview, multilingual semantic search. For Claude Code, Cursor, Codex." width="100%"></a>
+<a href="https://github.com/oomkapwn/enquire-mcp"><img src="./assets/social-preview.png" alt="enquire — MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF + cross-encoder reranking). Wikilinks, frontmatter, backlinks, Dataview, multilingual semantic search, PDFs, remote MCP. For Claude Code, Cursor, Codex." width="100%"></a>
 
-# enquire — MCP server for Obsidian
+# enquire — give your AI a search engine for your Obsidian vault
 
-**Hybrid retrieval (BM25 + TF-IDF + ML embeddings, RRF-fused) for your Obsidian vault.** Drop-in for Claude Code, Cursor, OpenClaw 🦞, Codex, Devin, and any MCP-compatible agent. Free. Multilingual (50+ languages). Offline-capable. No Obsidian plugin required.
+**Hybrid retrieval. Cross-encoder reranking. PDFs. Multilingual. Remote MCP. Free.**
+
+The most advanced Obsidian-MCP you can run today — drop into Claude Code, Claude.ai web, Cursor, ChatGPT, or any MCP client and your agent gets a single `obsidian_search` tool that fuses BM25 + TF-IDF + ML embeddings, reranks with a BGE cross-encoder, and surfaces blended markdown + PDF hits with page citations.
 
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/latest.svg?label=npm)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![beta](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/beta.svg?label=beta)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp/v/beta)
-[![Tests](https://img.shields.io/badge/tests-408_passing-brightgreen.svg)](#engineering)
-[![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
-[![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
+[![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/latest.svg?label=npm%20%40latest&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
+[![tests](https://img.shields.io/badge/tests-502%20passing-brightgreen.svg)](#trust)
 [![SLSA-3](https://img.shields.io/badge/SLSA-3-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
+[![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
+[![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A520-3c873a.svg)](https://nodejs.org)
 
 </div>
+
+---
+
+## ⚡ 30-second quick start
 
 ```bash
 npm install -g @oomkapwn/enquire-mcp
 enquire-mcp serve --vault ~/Documents/Obsidian\ Vault
 ```
 
-That's it. Your AI now has structured access to wikilinks, backlinks, frontmatter, Dataview queries, and **`obsidian_search`** — a single hybrid-retrieval tool that auto-fuses BM25 + TF-IDF + ML embeddings.
+That's it. Your AI now has structured access to wikilinks, backlinks, frontmatter, Dataview, and **`obsidian_search`** — the umbrella retrieval tool.
 
----
-
-## Why enquire (vs alternatives)
-
-| | Other Obsidian-MCPs | Smart Connections (paid plugin) | **enquire** |
-|---|:---:|:---:|:---:|
-| Read-only by default | varies | n/a | ✅ |
-| Resolves wikilinks (alias / section / block) | partial | n/a | ✅ full |
-| Backlinks ranked + snippeted | rare | n/a | ✅ |
-| Dataview-style queries | needs plugin | n/a | ✅ first-class |
-| Canvas (`.canvas`) read | rare | n/a | ✅ typed nodes + edges |
-| BM25 full-text search | rare | ❌ | ✅ FTS5 SQLite |
-| TF-IDF semantic search | ❌ | ❌ | ✅ |
-| **ML embeddings (multilingual)** | ❌ | ✅ paid | ✅ **free** |
-| **Hybrid (BM25+TF-IDF+embeddings, RRF)** | ❌ | ❌ | ✅ **only here** |
-| **PDFs blended into hybrid search** | ❌ | ❌ | ✅ **only here** (v2.8.0) |
-| **Cross-encoder reranking on top of RRF** | ❌ | ❌ | ✅ **only here** (v2.9.0) |
-| Per-signal observability on each hit | ❌ | ❌ | ✅ |
-| Privacy filter (`--exclude-glob` / `--read-paths`) | ❌ | n/a | ✅ verified at search + write paths |
-| Standalone (no Obsidian plugin) | varies | ❌ requires Obsidian | ✅ direct vault read |
-| MCP-native (any agent) | varies | ❌ Obsidian-only | ✅ stdio JSON-RPC |
-| **Remote MCP (HTTP transport, bearer auth)** | ❌ | ❌ | ✅ **only here** (v2.6.0) |
-| SLSA-3 provenance | ❌ | n/a | ✅ |
-| Test suite | rare | n/a | ✅ 502 unit tests |
-
----
-
-## Architecture
-
-```mermaid
-graph LR
-    Q[Query]
-    Q --> S[obsidian_search]
-    S --> BM25[BM25 / FTS5<br/>opt-in: --persistent-index]
-    S --> TFIDF[TF-IDF<br/>always on]
-    S --> EMB[ML embeddings<br/>opt-in: build-embeddings]
-    BM25 --> RRF{RRF fusion<br/>k=60}
-    TFIDF --> RRF
-    EMB --> RRF
-    RRF --> R[Ranked hits<br/>per_signal observability]
-```
-
-`obsidian_search` auto-detects available signals and fuses them via Reciprocal Rank Fusion (Cormack et al, 2009). Returns per-signal contributions on every hit so agents can see WHY each result ranked.
-
-```
-Tier 1: serve --vault <path>                      → TF-IDF (zero setup, instant)
-Tier 2: serve --vault <path> --persistent-index   → + BM25 (sub-100ms top-10)
-Tier 3: + install-model + build-embeddings        → + ML embeddings (multilingual)
-Tier 4: serve-http --bearer-token <token>         → remote MCP (v2.6.0)
-        same retrieval stack, exposed over HTTP for Claude.ai web,
-        ChatGPT, Cursor HTTP, mobile. Tailscale Funnel / Cloudflare
-        Tunnel for HTTPS. See docs/http-transport.md.
-```
-
----
-
-## Quick start
-
-> **Two channels:** `npm install @oomkapwn/enquire-mcp` → **v2.0** (stable, hybrid retrieval). `@beta` → preview track. `@1` → legacy v1.x line.
-
-**Claude Desktop / Claude Code / Cursor / Codex / any MCP client**:
+**For Claude Code / Cursor / Codex / any MCP client:**
 
 ```json
 {
@@ -96,189 +42,222 @@ Tier 4: serve-http --bearer-token <token>         → remote MCP (v2.6.0)
 }
 ```
 
-| Client | Config file |
-|---|---|
-| Claude Desktop | macOS `~/Library/Application Support/Claude/claude_desktop_config.json` · Windows `%APPDATA%\Claude\claude_desktop_config.json` |
-| Claude Code (CLI) | `~/.claude.json` (global) or `.mcp.json` (per-project) |
-| Cursor | `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project) |
-| Codex / OpenClaw / Devin | per-tool MCP config |
-
-**Enable hybrid retrieval** (one-time setup, ~10 min for a 100-note vault):
+**Want hybrid retrieval at full power?** One-time setup, ~10 min for a 100-note vault:
 
 ```bash
 enquire-mcp install-model multilingual          # ~120MB, 50+ languages
 enquire-mcp build-embeddings --vault <path>     # ~30ms/chunk on M1
-# Add --persistent-index to your serve invocation for BM25.
+# then: serve --persistent-index for BM25 + --enable-reranker for cross-encoder
 ```
 
-**Remote MCP** (v2.6.0 — Claude.ai web, ChatGPT, Cursor HTTP, mobile):
+---
+
+## 🎯 The only Obsidian-MCP with…
+
+- ✅ **Hybrid retrieval** (BM25 + TF-IDF + ML embeddings, RRF-fused)
+- ✅ **Cross-encoder reranking** on top of RRF (+5-10 NDCG@10) — `v2.9.0`
+- ✅ **PDFs blended into hybrid search** with `[page: N]` citation markers — `v2.8.0`
+- ✅ **Wikilink graph-boost** as a retrieval signal (1-step personalised PageRank seeded by RRF top-K)
+- ✅ **Remote MCP** over HTTP with bearer auth + rate-limit + CORS — `v2.6.0`
+- ✅ **Multilingual** semantic search (50+ languages, runs on CPU, free)
+- ✅ **Note-tethered AI chat threads** persisted as markdown — Smart Connections' #1 paid feature, free here
+
+**Read-only by default.** All 7 write tools gated behind `--enable-write`. Privacy filter (`--exclude-glob` / `--read-paths`) verified at every search + write path. SLSA-3 release provenance.
+
+---
+
+## 🏗️ How retrieval works
+
+```mermaid
+graph LR
+    Q[Query]
+    Q --> S[obsidian_search]
+    S --> BM25[BM25 / FTS5<br/>--persistent-index]
+    S --> TFIDF[TF-IDF<br/>always on]
+    S --> EMB[ML embeddings<br/>build-embeddings]
+    BM25 --> RRF{RRF fusion<br/>k=60}
+    TFIDF --> RRF
+    EMB --> RRF
+    RRF --> GB[Graph boost<br/>α × in-degree]
+    GB --> RR[Cross-encoder<br/>reranker<br/>--enable-reranker]
+    RR --> R[Ranked hits<br/>per_signal observability]
+```
+
+`obsidian_search` auto-detects available signals and fuses them via Reciprocal Rank Fusion (Cormack et al, 2009). Wikilink graph-boost reranks top-K by 1-step personalised PageRank. Optional cross-encoder reranking (BGE) re-scores top-N for +5-10 NDCG@10. Every hit returns `per_signal` observability so you see WHY each result ranked.
+
+| Tier | Setup | What you get |
+|---|---|---|
+| **1** | `serve --vault <path>` | TF-IDF (zero setup, instant) |
+| **2** | + `--persistent-index` | + BM25 (sub-100ms top-10) |
+| **3** | + `install-model` + `build-embeddings` | + multilingual ML embeddings |
+| **4** | + `--enable-reranker` | + BGE cross-encoder reranking |
+| **5** | + `--include-pdfs` | + PDFs blended into all of the above |
+| **6** | `serve-http --bearer-token …` | + remote MCP for Claude.ai web, ChatGPT, Cursor HTTP, mobile |
+
+---
+
+## 🆚 vs alternatives
+
+| | Other Obsidian-MCPs | Smart Connections (paid) | **enquire** |
+|---|:---:|:---:|:---:|
+| Wikilinks (alias / section / block) | partial | n/a | ✅ full |
+| Backlinks ranked + snippeted | rare | n/a | ✅ |
+| Dataview-style queries | needs plugin | n/a | ✅ first-class |
+| Canvas (`.canvas`) read | rare | n/a | ✅ typed nodes + edges |
+| BM25 full-text | rare | ❌ | ✅ FTS5 SQLite |
+| TF-IDF semantic | ❌ | ❌ | ✅ |
+| ML embeddings (multilingual) | ❌ | 💰 paid | ✅ **free** |
+| **Hybrid (BM25+TF-IDF+embeddings, RRF)** | ❌ | ❌ | ✅ **only here** |
+| **Wikilink graph-boost retrieval signal** | ❌ | ❌ | ✅ **only here** |
+| **PDFs blended into hybrid search** | ❌ | ❌ | ✅ **only here** |
+| **Cross-encoder reranking** | ❌ | ❌ | ✅ **only here** |
+| **Remote MCP (HTTP + bearer auth)** | ❌ | ❌ | ✅ **only here** |
+| Per-signal observability per hit | ❌ | ❌ | ✅ |
+| Privacy filter (exclude/allow globs) | ❌ | n/a | ✅ verified at search + write paths |
+| Standalone (no Obsidian plugin) | varies | ❌ requires Obsidian | ✅ direct vault read |
+| MCP-native (any agent) | varies | ❌ Obsidian-only | ✅ stdio + HTTP |
+| SLSA-3 release provenance | ❌ | n/a | ✅ |
+| Test suite | rare | n/a | ✅ 502 unit tests |
+
+> **Strategic claim:** enquire is the open-source backend for [Karpathy-style LLM Wikis](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) on top of your existing Obsidian vault. The `vault_synth` / `vault_wiki_compile` / `vault_lint_extended` prompts implement the ingest → query → lint → compile workflow natively over `.md` + `[[wikilinks]]`. Knowledge that compounds, traceable to sources.
+
+---
+
+## 🛠️ All 38 tools at a glance
+
+The umbrella `obsidian_search` plus 37 specialized tools for wikilinks, backlinks, Dataview, frontmatter, canvas, PDFs, vault stats, graph navigation, and writes.
+
+<details>
+<summary><b>27 always-on read tools</b> — click to expand</summary>
+
+`obsidian_search` · `obsidian_context_pack` · `obsidian_chat_thread_read` · `obsidian_frontmatter_get` · `obsidian_frontmatter_search` · `obsidian_read_note` · `obsidian_list_notes` · `obsidian_resolve_wikilink` · `obsidian_get_backlinks` · `obsidian_get_outbound_links` · `obsidian_get_unresolved_wikilinks` · `obsidian_get_recent_edits` · `obsidian_list_tags` · `obsidian_dataview_query` · `obsidian_find_path` · `obsidian_find_similar` · `obsidian_get_note_neighbors` · `obsidian_stats` · `obsidian_lint_wiki` · `obsidian_open_questions` · `obsidian_paper_audit` · `obsidian_validate_note_proposal` · `obsidian_list_canvases` · `obsidian_read_canvas` · `obsidian_list_pdfs` · `obsidian_read_pdf` · `obsidian_open_in_ui`
+
+</details>
+
+<details>
+<summary><b>4 opt-in read tools</b> (diagnostic single-rankers) — click to expand</summary>
+
+`obsidian_full_text_search` (`--persistent-index`) · `obsidian_search_text` · `obsidian_semantic_search` · `obsidian_embeddings_search` (all 3 require `--diagnostic-search-tools`)
+
+</details>
+
+<details>
+<summary><b>7 opt-in write tools</b> (require <code>--enable-write</code>) — click to expand</summary>
+
+`obsidian_create_note` · `obsidian_append_to_note` · `obsidian_rename_note` (rewrites every wikilink across vault, code-fence-aware) · `obsidian_replace_in_notes` (bulk find/replace) · `obsidian_archive_note` · `obsidian_chat_thread_append` · `obsidian_frontmatter_set` (atomic YAML manipulation, `dry_run` supported)
+
+</details>
+
+**Plus:** 2 + 1 opt-in MCP resources, and **17 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`, `vault_synth`, `vault_wiki_compile`, `vault_lint_extended`, `vault_capture`, `vault_persona_search`, `vault_automation_setup`).
+
+📖 Full reference: **[docs/api.md](./docs/api.md)** · Remote-MCP deployment guide: **[docs/http-transport.md](./docs/http-transport.md)**
+
+---
+
+## ⚙️ Configuration
+
+The flags you'll actually use:
+
+| Flag | Default | What it does |
+|---|---|---|
+| `--vault <path>` | required | Path to Obsidian vault root |
+| `--persistent-index` | off | SQLite FTS5 BM25, sub-100ms top-10 |
+| `--include-pdfs` | off | Index PDFs into FTS5 + embeddings |
+| `--enable-reranker` | off | BGE cross-encoder reranking on RRF top-N |
+| `--enable-write` | off | Register the 7 write tools |
+| `--exclude-glob <pat...>` | none | Privacy denylist (e.g. `'02_Personal/**'`) |
+| `--read-paths <pat...>` | none | Privacy allowlist (only matching paths visible) |
+| `--watch` | off | Live invalidation on `.md` add/change/unlink |
+| `--persistent-cache` | off | Survive cold starts |
+
+Subcommands: `serve` · `serve-http` · `gen-token` · `clear-cache` · `clear-index` · `clear-embeddings` · `index` · `install-model` · `build-embeddings`.
+
+**Remote MCP** for Claude.ai web / ChatGPT / Cursor HTTP / mobile:
 
 ```bash
-enquire-mcp gen-token > ~/.enquire/token        # 256-bit bearer
+enquire-mcp gen-token > ~/.enquire/token        # one-time
 enquire-mcp serve-http \
   --vault ~/Obsidian \
   --bearer-token "$(cat ~/.enquire/token)" \
-  --persistent-index
-# Front with Tailscale Funnel / Cloudflare Tunnel for HTTPS — see
-# docs/http-transport.md.
+  --persistent-index --include-pdfs --enable-reranker
+# Front with Tailscale Funnel / Cloudflare Tunnel for HTTPS.
 ```
 
-No other Obsidian-MCP currently ships a remote-HTTP transport. Same vault, same tools, same hybrid retrieval — just over HTTPS instead of stdio.
-
 ---
 
-## Tools (38 total)
+## 🛡️ Trust
 
-### 27 always-on read tools
-
-| Tool | What it does |
-|---|---|
-| `obsidian_search` | **Hybrid retrieval** — fuses BM25 + TF-IDF + ML embeddings via RRF. The default search tool. Auto-detects available signals. v2.2.0: `granularity: "block"` arg returns chunks instead of notes. **v2.8.0:** with `--include-pdfs`, PDF chunks blend in alongside markdown — every hit carries `kind: "md" \| "pdf"` and PDF snippets include `[page: N]` markers for citation. **v2.9.0:** with `--enable-reranker`, top-N RRF candidates are re-scored by a BGE cross-encoder for +5-10 NDCG@10 typical retrieval quality. |
-| `obsidian_context_pack` | **v2.2.0.** Token-budgeted context bundling: takes a question, runs hybrid search, gathers note bodies + backlinks + optionally recent dailies, returns one ready-to-paste markdown bundle. Saves ~5 tool calls. |
-| `obsidian_chat_thread_read` | **v2.2.0.** Parse a note's `## Chat: <title>` block into structured messages (role/timestamp/content/line-range). Pair with `_append` (write) for note-tethered AI conversations. |
-| `obsidian_frontmatter_get` | **v2.3.0.** Read parsed YAML frontmatter for a note. With `key`, returns just that field. |
-| `obsidian_frontmatter_search` | **v2.3.0.** Find notes by frontmatter predicate (`equals` / `exists` / `contains`). Useful as a precursor to bulk `_set`. |
-| `obsidian_read_note` | Full content + frontmatter + wikilinks + embeds + tags. Also accepts periodic-note aliases (`title: "today"` / `"weekly"` / `"monthly"`). |
-| `obsidian_list_notes` | Vault-wide or folder-scoped. Includes title + tags + mtime + counts. |
-| `obsidian_resolve_wikilink` | Resolves `[[Note]]`, `[[Note\|Alias]]`, `[[Note#Section]]`, `[[Note#^block]]`, with did-you-mean on near-miss. |
-| `obsidian_get_backlinks` | Every note linking to X, ranked + snippeted. |
-| `obsidian_get_outbound_links` | Outbound `[[wikilinks]]` from one note, with resolution status. |
-| `obsidian_get_unresolved_wikilinks` | Vault-wide broken-link audit. |
-| `obsidian_get_recent_edits` | Notes modified in the last N minutes. |
-| `obsidian_list_tags` | Tag census across vault (frontmatter + inline). |
-| `obsidian_dataview_query` | First-class Dataview-style queries (`LIST` / `TABLE`, `WHERE`, `AND` / `OR` / `LIKE` / `contains`). |
-| `obsidian_find_path` | Multi-hop graph BFS between two notes (with alternatives). |
-| `obsidian_find_similar` | Note-to-note similarity (tag + folder + content signals). |
-| `obsidian_get_note_neighbors` | Outbound + inbound + tag-sibling for one note. |
-| `obsidian_stats` | Vault dashboard: note count, tag count, broken links. |
-| `obsidian_lint_wiki` | Karpathy LLM-Wiki `/lint` workflow (orphans / broken / stubs / stale). |
-| `obsidian_open_questions` | Find open `?` questions across the vault. |
-| `obsidian_paper_audit` | Track arXiv references and read-status. |
-| `obsidian_validate_note_proposal` | Lint a draft note before writing (closes the #1 LLM-write pain). |
-| `obsidian_list_canvases` | List `.canvas` files with node + edge counts. |
-| `obsidian_read_canvas` | Parse `.canvas` into typed nodes (text/file/link/group) + edges. |
-| `obsidian_list_pdfs` | **v2.7.0.** List `.pdf` files with size + mtime. PDFs are the #1 non-markdown content kind in real vaults; no other Obsidian-MCP indexes them. |
-| `obsidian_read_pdf` | **v2.7.0.** Extract page-by-page text + doc metadata (title/author/etc) from a PDF. Optional 1-indexed page-range slice. Image-only / scanned PDFs surface `has_text: false`. Powered by Mozilla PDF.js (Apache-2.0, pinned to `optionalDependencies` so the markdown-only path stays zero-cost). |
-| `obsidian_open_in_ui` | Emit `obsidian://open?vault=...` URI. |
-
-### 4 opt-in read tools
-
-| Tool | Flag | Notes |
-|---|---|---|
-| `obsidian_full_text_search` | `--persistent-index` + `--diagnostic-search-tools` | BM25 ranking, sub-100ms. |
-| `obsidian_search_text` | `--diagnostic-search-tools` | Token search (all/any/phrase modes). |
-| `obsidian_semantic_search` | `--diagnostic-search-tools` | TF-IDF cosine standalone. |
-| `obsidian_embeddings_search` | `--diagnostic-search-tools` | ML embeddings standalone. |
-
-### 7 opt-in write tools (`--enable-write`)
-
-| Tool | Notes |
-|---|---|
-| `obsidian_create_note` | Refuses overwrite without `overwrite=true`. Empty path rejected. |
-| `obsidian_append_to_note` | Symlink-safe; respects `--max-file-bytes`. |
-| `obsidian_rename_note` | Rewrites every wikilink across vault. Code-fence-aware. `dry_run` available. |
-| `obsidian_replace_in_notes` | Bulk find/replace. Per-file errors collected; `partial: true` on mid-loop fail. |
-| `obsidian_archive_note` | Wraps rename to `Archive/`. Preserves backlinks. |
-| `obsidian_chat_thread_append` | **v2.2.0.** Append a user/assistant/system message to a note's `## Chat:` block. Creates note + heading if absent. Threads stored as markdown — searchable, version-controllable, survive sessions. |
-| `obsidian_frontmatter_set` | **v2.3.0.** Surgical YAML manipulation — set/unset keys on a note atomically. Pass `null` as value to delete. Round-trips through gray-matter so YAML formatting stays consistent. `dry_run` supported. |
-
-Plus **2 + 1 opt-in MCP resources** (`obsidian://note/...`, `obsidian://vault-info`, `obsidian://chunk/...`) and **17 MCP prompts** (`summarize_recent_edits`, `weekly_review`, `monthly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, `consolidate_tags`, `find_duplicates`, `lint_wiki`, `search_with_query_expansion`, `vault_synth`, `vault_wiki_compile`, `vault_lint_extended`, `vault_capture`, `vault_persona_search`, `vault_automation_setup`).
-
-> **v2.4.0 strategic position:** enquire-mcp is the open-source backend for **Karpathy-style LLM Wikis** on top of your existing Obsidian vault. The `vault_synth` + `vault_wiki_compile` + `vault_lint_extended` prompts implement the [Karpathy LLM-Wiki workflow](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (ingest → query → lint → compile) natively over Obsidian's `.md` + `[[wikilinks]]` substrate. Knowledge that compounds, traceable to sources.
-
----
-
-## Configuration
-
-| Flag | Default | Notes |
-|---|---|---|
-| `--vault <path>` | required | Path to Obsidian vault root. |
-| `--enable-write` | off | Register the 5 write tools. |
-| `--exclude-glob <pat...>` | none | Privacy denylist. Repeatable. Example: `'02_Personal/**'`. |
-| `--read-paths <pat...>` | none | Privacy allowlist (only matching paths visible). Repeatable. |
-| `--persistent-index` | off | SQLite FTS5 BM25. Enables `obsidian_full_text_search` (with `--diagnostic-search-tools`). |
-| `--persistent-cache` | off | Persist parsed-note cache across restarts. |
-| `--watch` | off | Live invalidation on `.md` add/change/unlink. |
-| `--diagnostic-search-tools` | off | Register 4 single-ranker search tools (defaults: hybrid `obsidian_search` only). |
-| `--enabled-tools <name...>` | all | Strict allowlist (gate to a subset). |
-| `--disabled-tools <name...>` | none | Denylist. |
-| `--max-file-bytes <n>` | 5 MB | Per-file read/write cap. |
-| `--cache-size <n>` | 1024 | LRU cap for parsed-note cache. |
-
-Subcommands: `serve` · `serve-http` (v2.6.0 — remote MCP) · `gen-token` (v2.6.0) · `clear-cache` · `clear-index` · `index` (cold-build FTS5) · `install-model` · `build-embeddings` · `clear-embeddings`.
-
-Full reference: [docs/api.md](./docs/api.md). Remote-MCP deployment guide: [docs/http-transport.md](./docs/http-transport.md).
-
----
-
-## Security
-
-- **Read-only by default.** Write tools require `--enable-write`.
-- **Path traversal blocked.** Realpath check on every read+write target. Symlinks inside the vault that resolve outside are rejected.
-- **Privacy boundary verified across all paths**, including persistent indexes (FTS5 / embed-db search-time filter) and the `obsidian://chunk/...` resource. Privacy fail-closed: empty `--read-paths` / `--exclude-glob` patterns refuse to start.
+- **Read-only by default.** Every write tool requires `--enable-write`.
+- **Path traversal blocked.** Realpath check on every read+write target. Symlinks resolving outside the vault are rejected.
+- **Privacy boundary verified across all paths** including persistent FTS5 + embed indexes and the `obsidian://chunk/...` resource. Privacy fail-closed: empty `--read-paths` / `--exclude-glob` patterns refuse to start.
+- **HTTP transport hardened.** Bearer auth (constant-time SHA-256 + `timingSafeEqual`), per-token sliding rate-limit, strict CORS allowlist with credential-leak guard.
 - **`gray-matter` (`js-yaml` safeLoad)** — no code execution via frontmatter.
-- **DQL parser** — no shell, no `eval`, no template expansion.
 - **Cache + index files** — chmod 0600, parent dir 0700.
 - **SLSA-3 provenance** on every npm release.
-- **Branch protection ruleset** with `bypass_mode: pull_request` — every change goes through PR with audit trail. Release pipeline verifies SHA-on-main + 8 required CI checks before publishing.
-
-Full posture: [SECURITY.md](./SECURITY.md). Report vulnerabilities to `oomkapwn@gmail.com`.
-
----
-
-## Engineering
+- **Branch protection** with `bypass_mode: pull_request` — every change goes through PR review. Release pipeline verifies tagged SHA is on `main` AND all 8 required CI checks reported `success` on it.
 
 | Surface | Posture |
 |---|---|
-| Language | TypeScript strict + `noUncheckedIndexedAccess` |
-| Lint | Biome 2 (zero-warning policy) |
-| Tests | 502 unit tests across 24 files |
-| CI | ubuntu × {Node 20, 22, 24} required + macOS advisory job |
+| Tests | 502 unit tests across 24 files, 8 required CI gates per PR |
 | Coverage | Lines ≥86%, statements ≥82%, functions ≥75%, branches ≥73% (gated) |
 | Audit | `npm audit --audit-level=moderate` for prod; high for dev |
-| Runtime deps | 5 mandatory (`@modelcontextprotocol/sdk`, `chokidar`, `commander`, `gray-matter`, `zod`) + 2 optional (`better-sqlite3` for FTS5 / embed-db; `@huggingface/transformers` for ML embeddings) |
-| Releases | npm + GitHub release per tag · semver · provenance attached · channels: `latest` (stable), `beta`, `alpha` |
+| CI | Ubuntu × {Node 20, 22, 24} required + macOS advisory job |
+| Lint | Biome 2 (zero-warning policy) |
+| Language | TypeScript strict + `noUncheckedIndexedAccess` |
+| Runtime deps | 5 mandatory, 3 optional (FTS5 + ML embeddings + PDF parser — markdown-only path stays zero-cost) |
+| Releases | npm + GitHub release per tag · semver · SLSA-3 provenance |
+
+Full posture: **[SECURITY.md](./SECURITY.md)**. Report vulnerabilities to `oomkapwn@gmail.com`.
+
+---
+
+## ❓ FAQ
+
+**Do I need Obsidian installed?**
+No. enquire reads `.md` + `.canvas` + `.pdf` files directly. Works against any Obsidian-format vault.
+
+**Will this write to my vault?**
+Not unless you start with `--enable-write`. Even then, all 7 write tools are gated by privacy filters and refuse to overwrite without `overwrite: true`. `dry_run` modes available on the destructive ones.
+
+**Is my data sent anywhere?**
+Only on `enquire-mcp install-model` (downloads ONNX weights from HuggingFace, one-time). Serve mode itself never makes outbound HTTP. Embeddings + reranker run on CPU locally.
+
+**How is this different from Smart Connections?**
+Smart Connections is a paid Obsidian plugin that runs ML embeddings inside Obsidian. enquire is a standalone MCP server: free, MCP-native (works with Claude / Cursor / Codex / any agent), and fuses 3 retrieval signals + cross-encoder reranking for higher recall + precision than embeddings alone. PDFs index too.
+
+**Performance on large vaults?**
+Cold-build of FTS5 on a 1k-note vault: ~5s. Warm BM25 top-10: sub-100ms. Embedding build: ~30ms/chunk on M1 (~8min for 8k chunks). Hybrid query latency: <200ms typical. Reranker adds ~30-50ms at top-50. Maintainer dogfoods on a 128-note bilingual vault with all of the above on.
+
+**Languages?**
+Default embedding model is `paraphrase-multilingual-MiniLM-L12-v2` (50+ languages). Multilingual cross-encoder reranker (`mxbai-rerank-xsmall-v1`) is the default too. Validated end-to-end on Russian + English bilingual vaults. CJK / Thai / Khmer / Lao tokenization via `Intl.Segmenter` (Node 16+ ICU).
+
+**Can I run it remotely?**
+Yes. `serve-http` exposes the same server over [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) with bearer auth. Front with Tailscale Funnel or Cloudflare Tunnel for HTTPS — works with claude.ai web, ChatGPT custom GPT, Cursor HTTP mode, mobile MCP clients. See [docs/http-transport.md](./docs/http-transport.md).
+
+---
+
+## 🚀 Releases
+
+`v2.0.0` (stable) · `v2.5.0` (5-sprint roadmap consolidated) · `v2.6.0` (remote MCP) · `v2.7.0` (PDF read tools) · `v2.8.0` (PDFs blended into hybrid search) · `v2.9.0` (BGE cross-encoder reranking)
+
+Channel: `npm install @oomkapwn/enquire-mcp` → latest stable. Full changelog: [CHANGELOG.md](./CHANGELOG.md).
+
+---
+
+## 🤝 Contributing
 
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test          # full suite
-npm run lint      # zero warnings
-npm run build     # tsc → dist/
+npm test       # full suite (502 tests, ~5s)
+npm run lint   # zero warnings
+npm run build  # tsc → dist/
 ```
 
----
-
-## FAQ
-
-**Q: Do I need Obsidian installed?**
-No. enquire reads `.md` + `.canvas` files directly. Works against any Obsidian-format vault.
-
-**Q: Will this write to my vault?**
-No, unless you explicitly start with `--enable-write`. Even then, all 5 write tools are gated by privacy filters and refuse to overwrite without `overwrite: true`.
-
-**Q: Is my data sent anywhere?**
-Only on `enquire-mcp install-model` (downloads ONNX weights from HuggingFace). The serve mode itself never makes outbound HTTP. Embeddings run on CPU locally.
-
-**Q: How is this different from Smart Connections?**
-Smart Connections is a paid Obsidian plugin that does ML embeddings inside Obsidian. enquire-mcp is a standalone MCP server: free, MCP-native (works with Claude / Cursor / Codex / any agent), and adds hybrid retrieval (BM25 + TF-IDF + embeddings via RRF) for higher recall than embeddings alone.
-
-**Q: Performance on large vaults?**
-Cold-build of FTS5 on a 1k-note vault: ~5s. Warm BM25 top-10: sub-100ms. Embedding build: ~30ms/chunk on M1 (8s for 256 chunks, ~8min for 8k chunks). Hybrid query latency: <200ms typical.
-
-**Q: Does it support languages other than English?**
-Yes. Default embedding model is `paraphrase-multilingual-MiniLM-L12-v2` (50+ languages). Validated end-to-end on Russian + English bilingual vaults. CJK requires the upcoming Intl.Segmenter pre-pass (v2.1 backlog).
+Issues, PRs, and ideas welcome. Branch protection requires PR review on `main`.
 
 ---
 
-## Contributing
+## 📜 License & credits
 
-Issues and PRs welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md). All changes go through PR review per branch protection ruleset.
-
-## License & credits
-
-[MIT](./LICENSE). Built by Alex — [GitHub `@oomkapwn`](https://github.com/oomkapwn) · [X `@OomkaBear`](https://x.com/OomkaBear).
-
-Named after [ENQUIRE](https://en.wikipedia.org/wiki/ENQUIRE) — Tim Berners-Lee's 1980 hypertext prototype of the World Wide Web.
-
-> **Not affiliated with Obsidian.md.** Obsidian and the Obsidian logo are trademarks of Dynalist Inc. enquire-mcp is an independent open-source project that reads Obsidian-format vaults.
+MIT. Built by [Alex (@OomkaBear)](https://github.com/oomkapwn). Named after [Tim Berners-Lee's 1980 prototype of the WWW](https://en.wikipedia.org/wiki/ENQUIRE) — the original hypertext system, before the web. The original spec was that you could ask the system anything; this brings that to your vault.


### PR DESCRIPTION
## Summary

After shipping **v2.5 → v2.9 in one day** (PDF retrieval, remote MCP, cross-encoder reranking), the README was lagging — stale test count, channel claims, and the new "only here" features buried in a comparison table cell.

## What this rewrites

**Stronger sales-y opener.** The new headline is _"give your AI a search engine for your Obsidian vault"_ — outcome-led, not feature-led.

**New `🎯 The only Obsidian-MCP with…` section** pulled forward to the top. Lists the 7 unique-to-enquire claims at-a-glance with version tags (cross-encoder reranking, PDFs in hybrid, wikilink graph-boost retrieval signal, remote MCP, multilingual, note-tethered chat threads).

**Tier ladder as a scannable table** — was a code block; now 6 rows each showing the setup + capability gain.

**Mermaid diagram updated** to show graph-boost + reranker stages alongside RRF fusion.

**Tools section uses `<details>` collapsibles** — keeps visual density low while preserving the static-analysis-driven docs-consistency tests. Every registered tool name still appears in the README in inline code, just folded by default. The 17 prompts cell stays inline (it's a one-line list).

**FAQ tightened**, pulled "Can I run it remotely?" forward, dropped stale "@beta → preview track" + "@1 → legacy v1.x line" claims (those channels haven't been meaningfully active since v2.0 stable).

**Releases section condensed** into a one-liner with versioned chips: `v2.0` · `v2.5` · `v2.6` · `v2.7` · `v2.8` · `v2.9`.

**Footer adds the ENQUIRE etymology** — Tim Berners-Lee's 1980 hypertext prototype, before the web. The original spec was that you could ask the system anything; this brings that to your vault.

**Badge cleanup:**
- Test count badge: `408` → `502` (real number)
- Removed stale `[![beta](...)]` badge — no active beta channel
- Added Node `≥20` requirement badge
- npm latest badge gets the `cb3837` brand color for visibility

## What this adds — `dist-tag-cleanup.yml` workflow

Removes the stale `alpha` (`2.0.0-alpha.0`) and `beta` (`2.0.0-beta.4`) dist-tags from npm using the existing `NPM_TOKEN` secret. Manually triggered via Actions tab (`workflow_dispatch` with `confirm: REMOVE` input).

Local `npm dist-tag rm` fails with E401 because there's no interactive npm login on the maintainer's machine — this workflow does it via the same auth path the release pipeline uses.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 502 / 502 pass (docs-consistency tests verify the README still mentions every registered tool/prompt + the always-on count claim matches)
- [x] `npm run build && node scripts/smoke.mjs` — stdio + HTTP smoke variants both green
- [ ] CI required check-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)