### PR TITLE
chore: bump hono via npm audit fix (3 fresh moderate advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,9 +2819,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Three fresh advisories landed in the GHSA database overnight against `hono`:

- [GHSA-qp7p-654g-cw7p](https://github.com/advisories/GHSA-qp7p-654g-cw7p) — CSS Declaration Injection via Style Object Values in JSX SSR
- [GHSA-hm8q-7f3q-5f36](https://github.com/advisories/GHSA-hm8q-7f3q-5f36) — improper validation of NumericDate claims in JWT verify()
- [GHSA-p77w-8qqv-26rm](https://github.com/advisories/GHSA-p77w-8qqv-26rm) — Cache Middleware ignores Vary: Authorization / Cookie

Transitive dep path: `@modelcontextprotocol/sdk → @hono/node-server → hono`.

We don't directly use hono's JSX SSR, JWT verify, or cache middleware — the SDK's HTTP transport just uses `@hono/node-server` for the HTTP adapter. But shipping the patched version on every release keeps the SBOM clean and the release-pipeline audit gate green.

## What changed

`npm audit fix` upgraded hono past the affected version range. **Lockfile-only diff** — no `package.json` change.

## Test plan

- [x] `npm audit --audit-level=moderate` → 0 vulnerabilities
- [x] `npm test` → 522 / 522 pass
- [ ] CI required check-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)