### PR TITLE
v3.0.0: stable channel — v2.x retrieval roadmap complete, public surface semver-bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] — 2026-05-09
+
+**v3.0.0 — stable channel.** The v2.x retrieval roadmap is complete. v3.0 promotes the v2.17 codebase to the v3.x stable line and commits to extended semver guarantees on every CLI flag, MCP tool name, MCP resource URI, MCP prompt, and exported TypeScript symbol — see [STABILITY.md](./STABILITY.md) for the full contract. **No new features and no breaking code changes vs v2.17.0** — this release is the semantic milestone confirming the retrieval API has stabilized.
+
+### What landed across v2.0 → v2.17 (now v3.0)
+
+The v2.x line shipped 18 minor releases over ~3 days that turned the project from a v1-era keyword-search server into a feature-complete hybrid retrieval stack. Four pillars:
+
+| Pillar | Sprints | What it gives you |
+|---|---|---|
+| **Quality** | v2.0 (RRF) · v2.9 (reranker) · v2.15 (late chunking) | +5-10 NDCG@10 vs single-ranker / vanilla embeddings |
+| **Latency** | v2.13 (HNSW) · v2.16 (HNSW persistence) | sub-10ms top-K at million-chunk scale, ~50ms serve boot |
+| **Storage** | v2.17 (int8 quantization) | ~4× smaller embed-db (~12 MB → ~3.4 MB on real 8K-chunk vault) |
+| **Operability** | v2.6 (HTTP) · v2.7-2.10 (PDFs + OCR) · v2.11 (doctor/setup) · v2.12 (eval harness) · v2.14 (stateful sessions) | Remote MCP, PDFs blended into search, zero-touch onboarding, built-in retrieval benchmarking, ChatGPT custom GPT support |
+
+### Added — examples directory
+
+[`examples/`](./examples/) ships drop-in MCP configs for the most common clients:
+
+- `claude-desktop.json` / `claude-desktop-hybrid.json` — Claude Desktop stdio configs (TF-IDF and full-hybrid)
+- `cursor-mcp.json` — Cursor MCP stdio config
+- `chatgpt-actions.md` — ChatGPT custom GPT actions over remote MCP (HTTP + bearer + tunnel)
+- `queries.jsonl` — sample query set for `enquire-mcp eval`
+
+### Added — STABILITY.md
+
+The exact list of semver-bound surfaces, what's not covered, deprecation policy, and how to report unintentional compatibility breaks. See [STABILITY.md](./STABILITY.md).
+
+### Migration from v2.17.0
+
+**No-op.** The code is identical to v2.17.0. The major bump signals the stability commitment, not a breaking change. `npm install @oomkapwn/enquire-mcp` continues to resolve to the latest version exactly as before.
+
+### Migration from v2.16- (any earlier v2.x)
+
+You'll see one stderr line on first open of an existing embed-db: `enquire: rebuilding embed index (schema_version 2 → 3)` — that's the v2.17 schema bump auto-rebuilding incrementally. No manual migration. Default `--quantize-embeddings f32` is bit-identical to your prior storage layout.
+
+### Tests, CI/CD, security
+
+- **606 unit tests** pass across 29 test files (was 408 at v2.0.0 stable).
+- **12 required CI gates per PR**: lint · test ×3 (Node 20/22/24) · test-macos · smoke · audit · coverage · version-consistency · CodeQL × 2.
+- Coverage thresholds enforced (lines ≥86, statements ≥82, functions ≥75, branches ≥73).
+- Branch protection: `bypass_mode: pull_request` — every change goes through PR with audit trail.
+- Release pipeline integrity: tagged SHA must be reachable from `main` AND all 12 CI checks must have reported `success` on it.
+- SLSA-3 provenance attached to every npm release.
+
+### Roadmap
+
+The v2.x retrieval-stack roadmap is complete. Future v3.x minor releases will be **additive** (new tools, new flags, performance improvements). The next major (v4.0) is reserved for any future breaking change — none currently planned.
+
+Possible v3.x minor directions (not committed):
+- Multi-vault federation (single MCP server fronting >1 vault)
+- LLM-augmented retrieval (sub-question decomposition, query rewriting)
+- GraphRAG (community detection on the wikilink graph + hierarchical summaries)
+- Additional MCP prompts for vault wiki workflows
+
+### Acknowledgments
+
+The v2.x line was 18 minor releases of compounding work — every sprint built on the prior one's invariants. The CI gates that grew alongside (privacy boundary at every search path, version consistency across 5 surfaces, contamination guard on the embed-db meta table) are what made it possible to ship daily without regressions. Everyone who tried alphas / betas, filed audit findings, and stress-tested the privacy filter on real vaults — thank you.
+
 ## [2.17.0] — 2026-05-09
 
 **Sprint 17 — int8 vector quantization (~4× storage, ≈1-2% recall@10 cost).** v2.16.0 cut HNSW boot to ~50ms. v2.17.0 cuts the on-disk size of the embed-db itself: each Float32 vector (1536 bytes for 384-dim multilingual) becomes a per-vector `(min, scale)` Float32 tuple plus dim×int8 bytes (392 bytes for 384-dim) — **3.92× smaller** at the storage layer. Retrieval quality drops by ≈1-2% recall@10 in our internal eval and is invisible at K=20+; the order of the top hits is preserved on >99% of queries.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The most advanced Obsidian-MCP you can run today — drop into Claude Code, Clau
 
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/latest.svg?label=npm%20%40latest&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-502%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-606%20passing-brightgreen.svg)](#trust)
+[![stable](https://img.shields.io/badge/v3.0-stable-brightgreen.svg)](./STABILITY.md)
 [![SLSA-3](https://img.shields.io/badge/SLSA-3-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
@@ -41,6 +42,8 @@ That's it. Your AI now has structured access to wikilinks, backlinks, frontmatte
   }
 }
 ```
+
+📂 Drop-in configs in [`examples/`](./examples/) — Claude Desktop (TF-IDF and full-hybrid variants), Cursor, ChatGPT custom GPT actions over remote MCP, plus a sample query set for the eval harness.
 
 **Want hybrid retrieval at full power?** One command (v2.11.0):
 
@@ -221,8 +224,9 @@ enquire-mcp serve-http \
 | Language | TypeScript strict + `noUncheckedIndexedAccess` |
 | Runtime deps | 5 mandatory, 3 optional (FTS5 + ML embeddings + PDF parser — markdown-only path stays zero-cost) |
 | Releases | npm + GitHub release per tag · semver · SLSA-3 provenance |
+| Stability | v3.0+ semver-bound — every CLI flag, tool name, MCP resource, prompt, and exported symbol is contract |
 
-Full posture: **[SECURITY.md](./SECURITY.md)**. Report vulnerabilities to `oomkapwn@gmail.com`.
+Full posture: **[SECURITY.md](./SECURITY.md)**. Stability promise: **[STABILITY.md](./STABILITY.md)**. Report vulnerabilities to `oomkapwn@gmail.com`.
 
 ---
 
@@ -253,9 +257,11 @@ Yes. `serve-http` exposes the same server over [Streamable HTTP](https://modelco
 
 ## 🚀 Releases
 
-`v2.0.0` (stable) · `v2.5.0` (5-sprint roadmap consolidated) · `v2.6.0` (remote MCP) · `v2.7.0` (PDF read tools) · `v2.8.0` (PDFs blended into hybrid search) · `v2.9.0` (BGE cross-encoder reranking) · `v2.13.0` (HNSW vector index) · `v2.14.0` (stateful HTTP sessions) · `v2.15.0` (late-chunking) · `v2.16.0` (HNSW persistence) · `v2.17.0` (int8 quantization)
+**v3.0.0 — stable channel** (the v2.x retrieval roadmap is complete and the public surface is now [semver-bound](./STABILITY.md)). Highlight reel of the v2.x line that landed in v3.0:
 
-Channel: `npm install @oomkapwn/enquire-mcp` → latest stable. Full changelog: [CHANGELOG.md](./CHANGELOG.md).
+- `v2.0` hybrid retrieval (BM25 + TF-IDF + ML embeddings, RRF) · `v2.6` remote MCP / HTTP · `v2.7-2.8` PDFs blended into hybrid search · `v2.9` BGE cross-encoder reranking · `v2.10` OCR for scanned PDFs · `v2.11` doctor + setup zero-touch onboarding · `v2.12` built-in retrieval-quality eval harness · `v2.13` HNSW vector index · `v2.14` stateful HTTP sessions · `v2.15` late-chunking embeddings · `v2.16` HNSW persistence (~50ms boot) · `v2.17` int8 vector quantization (~4× smaller embed-db)
+
+Channel: `npm install @oomkapwn/enquire-mcp` → latest stable. Full changelog: [CHANGELOG.md](./CHANGELOG.md). Stability surface: [STABILITY.md](./STABILITY.md).
 
 ---
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,83 @@
+# Stability promise
+
+`enquire-mcp` follows [SemVer 2.0](https://semver.org/spec/v2.0.0.html) strictly. This document spells out exactly what counts as a "public surface" — what a major-version bump (`X.0.0`) is required to break.
+
+## TL;DR
+
+After **v3.0.0** every CLI flag, MCP tool name, MCP resource URI, MCP prompt name, and exported TypeScript symbol below is **semver-bound**. Breaking changes require a major bump. Additive minor releases (`v3.x.0`) and patches (`v3.x.y`) keep these contracts intact.
+
+## v3.x stable surfaces
+
+### MCP tool names (39 tools)
+
+The umbrella search tool plus 38 specialized tools. Names + argument shapes are stable:
+
+**Read (28 always-on):**
+
+`obsidian_search`, `obsidian_search_text`, `obsidian_full_text_search`, `obsidian_semantic_search`, `obsidian_embeddings_search`, `obsidian_read_note`, `obsidian_list_notes`, `obsidian_list_tags`, `obsidian_list_canvases`, `obsidian_list_pdfs`, `obsidian_resolve_wikilink`, `obsidian_get_backlinks`, `obsidian_get_outbound_links`, `obsidian_get_note_neighbors`, `obsidian_get_recent_edits`, `obsidian_get_unresolved_wikilinks`, `obsidian_open_questions`, `obsidian_dataview_query`, `obsidian_frontmatter_get`, `obsidian_frontmatter_search`, `obsidian_find_path`, `obsidian_find_similar`, `obsidian_read_canvas`, `obsidian_read_pdf`, `obsidian_ocr_pdf`, `obsidian_context_pack`, `obsidian_chat_thread_read`, `obsidian_stats`.
+
+**Read (4 opt-in via `--diagnostic-search-tools`):** registered alongside `obsidian_search` for diagnostic / A/B benchmarking.
+
+**Write (7, gated by `--enable-write`):** `obsidian_create_note`, `obsidian_append_to_note`, `obsidian_rename_note`, `obsidian_replace_in_notes`, `obsidian_archive_note`, `obsidian_frontmatter_set`, `obsidian_chat_thread_append`, `obsidian_lint_wiki`, `obsidian_open_in_ui`, `obsidian_paper_audit`, `obsidian_validate_note_proposal`.
+
+### MCP resource URIs
+
+- `obsidian://vault/info`
+- `obsidian://note/{path}`
+- `obsidian://chunk/{n}/{path}` (FTS5-backed; only registered when `--persistent-index` is set)
+
+### MCP prompts
+
+`summarize_recent_edits`, `weekly_review`, `find_orphans`, `extract_todos`, `process_inbox`, `review_tag`, plus the v2.x additions for vault wiki workflows.
+
+### CLI flags
+
+Every flag accepted by `enquire-mcp serve` / `serve-http` / `index` / `build-embeddings` / `setup` / `eval` / `doctor` / `clear-cache` / `clear-index` / `clear-embeddings` / `gen-token` / `install-model` is stable. New flags will be added in minor releases (additive); existing flag names + accepted values + defaults will not change without a major bump.
+
+Notable defaults that are part of the contract:
+- `serve` is read-only by default — `--enable-write` required for the write tools.
+- `--persistent-index` is **off** by default (TF-IDF works zero-setup).
+- `--use-hnsw` is **off** by default (HNSW persistence is on once `--use-hnsw` is set; opt out with `--no-hnsw-persist`).
+- `--quantize-embeddings` defaults to `f32` (bit-identical to v2.16- behavior).
+- `--host 127.0.0.1` for `serve-http` (explicit local binding; remote access requires a tunnel).
+
+### Exported TypeScript symbols
+
+The package exports a few symbols for advanced embedding / programmatic use. These are stable in v3.x:
+
+- `EmbedDb` / `EmbedDbOptions` / `EmbedQuantization` / `encodeInt8Vector` / `decodeInt8Vector` (`src/embed-db.ts`)
+- `FtsIndex` / `chunkContent` / `defaultIndexFile` (`src/fts5.ts`)
+- `Vault` (`src/vault.ts`)
+- `ServeOptions` / `parsePositiveInt` / `parseQuantizationMode` / `startServer` / `main` / `buildMcpServer` / `prepareServerDeps` / `formatReadyBanner` / `buildEmbedText` (`src/index.ts`)
+- `HnswIndex` / `loadHnswFromDisk` / `HnswPersistedMeta` (`src/hnsw.ts`)
+
+Anything not listed here (private fields, internal helpers, test fixtures) is **not** semver-bound.
+
+## What's NOT in the stability promise
+
+- **Stderr log format.** We add diagnostic lines, change wording, and adjust verbosity in minor releases. Don't grep stderr for control flow.
+- **On-disk file formats.** SQLite schemas, HNSW sidecar layouts, embedding model versions, and persistent-cache shapes can evolve. v2.17 demonstrated the policy: schema bumps trigger automatic rebuild via the meta-table contamination guard. You don't need to migrate manually.
+- **Default models.** `--embedding-model` and `--reranker-model` default aliases (`multilingual` / `rerank-multilingual`) point at the recommended HuggingFace repos for the current release. We may change which underlying repo a default alias resolves to in a minor release if a better one becomes available; the alias name itself is stable.
+- **Internal HTTP routes** other than `/mcp` and `/health` (which are configurable via `--mcp-path` / `--health-path`).
+- **Test infrastructure** under `tests/` and helper scripts under `scripts/`.
+
+## Deprecation policy
+
+When a flag, tool, or symbol is deprecated:
+
+1. We add a runtime warning (stderr) on first use, in the next minor release.
+2. The deprecated surface continues to work for at least one minor release cycle.
+3. We document the replacement in CHANGELOG.md.
+4. Removal happens at the next major bump.
+
+No surface in v3.0.0 is currently deprecated.
+
+## Reporting compatibility breaks
+
+If you find a behavior that breaks between minor / patch versions and isn't explicitly documented in the changelog, open an issue at <https://github.com/oomkapwn/enquire-mcp/issues> with the prior + new version numbers. We treat unintentional breakage as a bug.
+
+## Why v3.0.0?
+
+v3.0.0 is the **stable channel promotion** release that finalizes the v2.x retrieval roadmap. The v2.x line shipped 18 minor releases (v2.0 → v2.17) over ~3 days that turned the project from a v1-era keyword-search server into a feature-complete hybrid retrieval stack: BM25 + TF-IDF + ML embeddings (RRF-fused) + cross-encoder reranking + HNSW vector index (persisted) + late-chunking embeddings + int8 quantization + stateful HTTP + zero-touch onboarding + built-in eval harness.
+
+There are no breaking code changes in v3.0.0 — it's a semantic milestone confirming the retrieval API has stabilized and committing to extended semver guarantees on the surfaces above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,32 @@
+# Examples
+
+Drop-in configs and recipes for connecting `enquire-mcp` to common MCP clients.
+
+| File | Use case |
+|---|---|
+| [`claude-desktop.json`](./claude-desktop.json) | Tier-1 Claude Desktop config (TF-IDF only, zero setup) |
+| [`claude-desktop-hybrid.json`](./claude-desktop-hybrid.json) | Full hybrid stack — BM25 + TF-IDF + ML embeddings + reranker + HNSW |
+| [`cursor-mcp.json`](./cursor-mcp.json) | Cursor MCP stdio config |
+| [`chatgpt-actions.md`](./chatgpt-actions.md) | ChatGPT custom GPT — remote MCP over HTTP with bearer auth + tunnel |
+| [`queries.jsonl`](./queries.jsonl) | Sample query set for the eval harness (`enquire-mcp eval --queries examples/queries.jsonl`) |
+
+## Workflow
+
+1. **Edit the absolute path** in the JSON config to point at your vault and (for Claude Desktop / Cursor) drop the file at the client's MCP config location.
+2. **Restart the client** so it picks up the new server.
+3. (Optional, hybrid only) Run `enquire-mcp setup --vault <path>` once to download the embedding model and build the FTS5 + embed-db indexes.
+4. (Optional) Run `enquire-mcp doctor --vault <path>` to confirm everything is wired up — color-coded ✓/⚠/✗ output.
+
+## Recommended starting config
+
+Most users want the hybrid stack — it's strictly better than TF-IDF alone (better paraphrase / synonym / cross-language matching) at the cost of one `setup` command and ~120 MB of disk for the embedding model. Start with [`claude-desktop-hybrid.json`](./claude-desktop-hybrid.json) unless you specifically want the zero-setup tier.
+
+## Eval harness
+
+The [`queries.jsonl`](./queries.jsonl) file is a tiny synthetic example for the `enquire-mcp eval` retrieval-quality benchmark. Replace the paths with real notes from your vault, then:
+
+```bash
+enquire-mcp eval --vault ~/Vault --queries examples/queries.jsonl --persistent-index --reranker
+```
+
+Output: a pretty table with NDCG@K, Recall@K, MRR, and per-query latency. Pass `--matrix` to A/B-test (graph_boost ± reranker) side by side.

--- a/examples/chatgpt-actions.md
+++ b/examples/chatgpt-actions.md
@@ -1,0 +1,71 @@
+# ChatGPT custom GPT — using enquire over remote MCP
+
+ChatGPT custom GPT actions speak HTTP, not stdio. Use `enquire-mcp serve-http` with `--stateful` (required for ChatGPT) and a bearer token, then expose the local server through a TLS tunnel (Tailscale Funnel or Cloudflare Tunnel).
+
+## 1. Generate a bearer token
+
+```bash
+enquire-mcp gen-token > ~/.config/enquire/token
+chmod 600 ~/.config/enquire/token
+```
+
+## 2. Start the HTTP server (stateful mode)
+
+```bash
+enquire-mcp serve-http \
+  --vault "/path/to/Obsidian Vault" \
+  --port 3030 \
+  --bearer-token-env ENQUIRE_TOKEN \
+  --stateful \
+  --persistent-index \
+  --enable-reranker \
+  --use-hnsw \
+  --include-pdfs \
+  --cors-origin https://chat.openai.com \
+  --cors-origin https://chatgpt.com
+```
+
+Set the env var first: `export ENQUIRE_TOKEN=$(cat ~/.config/enquire/token)`.
+
+## 3. Expose via TLS tunnel
+
+### Tailscale Funnel (free, requires Tailscale)
+
+```bash
+tailscale funnel --bg 3030
+# Prints: https://your-machine.tailnet.ts.net/
+```
+
+### Cloudflare Tunnel (free, requires Cloudflare account)
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:3030
+# Prints: https://random-name.trycloudflare.com
+```
+
+## 4. Wire into ChatGPT custom GPT actions
+
+In the GPT builder → "Add actions":
+
+1. **Schema:** import the OpenAPI 3.0 spec at `https://your-tunnel-host/.well-known/openapi.json` if the gateway serves one, OR hand-author a minimal spec for the `/mcp` endpoint (see [docs/http-transport.md](../docs/http-transport.md)).
+2. **Authentication:** Bearer Token, paste the value of `~/.config/enquire/token`.
+3. **Privacy policy URL:** point at any URL you control (e.g. your GitHub README); ChatGPT requires it for actions.
+
+## 5. Test
+
+In the GPT preview, ask: *"Search my vault for notes about prompt engineering. Use the enquire action."*
+
+The GPT should call `obsidian_search` over MCP and return ranked hits with `per_signal` observability.
+
+## Why `--stateful` matters
+
+ChatGPT custom GPTs treat the MCP server as a long-lived session — they expect to reuse `Mcp-Session-Id` across calls and may issue `GET /mcp` for server-initiated notifications. Stateless mode (the default for security reasons) returns a fresh session per request, which ChatGPT misinterprets as connection failures.
+
+Side benefit: stateful mode opens up server-push patterns (notifications, sampling, elicitations) that other clients can use too.
+
+## Privacy / safety
+
+- The bearer token is the only auth — treat it like an SSH key. Rotate with `enquire-mcp gen-token` and restart the server.
+- `--cors-origin` allowlist is enforced; never use `--cors-origin '*'` with a credentialed token.
+- Pair with `--exclude-glob` and/or `--read-paths` to keep private folders out of search results — ChatGPT will see only what those filters allow.
+- Default `--host 127.0.0.1` keeps the server bound locally; the tunnel is what makes it reachable. If you bind to `0.0.0.0` you skip the tunnel — but then *anyone* on your network can hit it. Pick one trust boundary.

--- a/examples/claude-desktop-hybrid.json
+++ b/examples/claude-desktop-hybrid.json
@@ -1,0 +1,22 @@
+{
+  "_comment_purpose": "Full hybrid retrieval config for Claude Desktop — BM25 (FTS5) + TF-IDF + ML embeddings (multilingual MiniLM) fused via RRF, plus BGE cross-encoder reranking and HNSW vector index for sub-10ms top-K queries at million-chunk scale.",
+  "_comment_setup": "Before this works you must run setup once: `enquire-mcp setup --vault /ABS/PATH/TO/Obsidian Vault` (downloads ~120MB embedding model + builds FTS5 + embed-db). Idempotent — re-running on a fully indexed vault is a fast no-op.",
+  "_comment_flags": "Flags explained: --persistent-index = BM25 via SQLite FTS5; --enable-reranker = BGE cross-encoder on top of RRF (+5-10 NDCG@10, ~30-50ms latency); --use-hnsw = sub-10ms semantic top-K, persisted to disk after first build (v2.16+); --include-pdfs = blend PDF chunks into hybrid search with [page: N] citation markers (requires pdfjs-dist optionalDependency); --watch = incremental rebuild on .md changes so you don't restart after editing in Obsidian.",
+  "mcpServers": {
+    "enquire": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@oomkapwn/enquire-mcp@latest",
+        "serve",
+        "--vault", "/ABSOLUTE/PATH/TO/YOUR/Obsidian Vault",
+        "--persistent-index",
+        "--enable-reranker",
+        "--use-hnsw",
+        "--include-pdfs",
+        "--watch"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/examples/claude-desktop.json
+++ b/examples/claude-desktop.json
@@ -1,0 +1,12 @@
+{
+  "_comment_purpose": "Drop-in MCP server config for Claude Desktop. Edit the absolute paths to point at your enquire-mcp install + your Obsidian vault, then merge this into ~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %AppData%\\Claude\\claude_desktop_config.json (Windows).",
+  "_comment_tier1": "Tier 1 — TF-IDF only, zero setup. Just point at the vault and go. Recall is fine for ~1k-note vaults; sub-200ms typical query latency.",
+  "_comment_tier3": "For the full hybrid stack (BM25 + TF-IDF + ML embeddings + HNSW + reranker), see `claude-desktop-hybrid.json` next to this file.",
+  "mcpServers": {
+    "enquire": {
+      "command": "npx",
+      "args": ["-y", "@oomkapwn/enquire-mcp@latest", "serve", "--vault", "/ABSOLUTE/PATH/TO/YOUR/Obsidian Vault"],
+      "env": {}
+    }
+  }
+}

--- a/examples/cursor-mcp.json
+++ b/examples/cursor-mcp.json
@@ -1,0 +1,18 @@
+{
+  "_comment_purpose": "Cursor MCP config (stdio transport). Place at ~/.cursor/mcp.json (or your editor's MCP config location). Cursor reloads MCP servers automatically when this file changes.",
+  "_comment_docs": "https://docs.cursor.com/context/model-context-protocol",
+  "mcpServers": {
+    "enquire": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@oomkapwn/enquire-mcp@latest",
+        "serve",
+        "--vault", "/ABSOLUTE/PATH/TO/YOUR/Obsidian Vault",
+        "--persistent-index",
+        "--enable-reranker",
+        "--use-hnsw"
+      ]
+    }
+  }
+}

--- a/examples/queries.jsonl
+++ b/examples/queries.jsonl
@@ -1,0 +1,10 @@
+{"id": "q01", "query": "Apollo program", "relevant": ["Reference/Apollo Program.md", "Reference/NASA history.md"]}
+{"id": "q02", "query": "obsidian plugin development", "relevant": ["Notes/Plugin Dev Notes.md", "Reference/Obsidian API.md"]}
+{"id": "q03", "query": "wikilink graph algorithms", "relevant": ["Reference/PageRank.md", "Notes/Graph Boost Retrieval.md"]}
+{"id": "q04", "query": "BM25 ranking explained", "relevant": ["Reference/BM25.md", "Notes/IR Basics.md"]}
+{"id": "q05", "query": "cross-encoder reranking BGE", "relevant": ["Reference/Reranker Models.md", "Notes/RRF Pipeline.md"]}
+{"id": "q06", "query": "HNSW approximate nearest neighbor", "relevant": ["Reference/HNSW Paper.md", "Notes/Vector Index Choices.md"]}
+{"id": "q07", "query": "late chunking embeddings", "relevant": ["Reference/Late Chunking.md", "Notes/Context Windowing.md"]}
+{"id": "q08", "query": "int8 vector quantization", "relevant": ["Reference/Scalar Quantization.md", "Notes/Storage Optimization.md"]}
+{"id": "q09", "query": "MCP stateful sessions", "relevant": ["Reference/MCP Spec.md", "Notes/Streamable HTTP.md"]}
+{"id": "q10", "query": "Reciprocal Rank Fusion", "relevant": ["Reference/RRF Cormack.md", "Notes/Hybrid Retrieval.md"]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.17.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "2.17.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "2.17.0",
+  "version": "3.0.0",
   "description": "Drop-in MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + ML embeddings via RRF), wikilinks resolved with aliases and sections, backlinks ranked with snippets, frontmatter typed, Dataview-style queries first-class. Read-only by default; opt-in writes. Works with Claude Code, Cursor, OpenClaw, Codex, Devin, and any MCP-compatible client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "2.17.0";
+const VERSION = "3.0.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {


### PR DESCRIPTION
## Summary

**v3.0.0 — stable channel.** The v2.x retrieval roadmap is complete. v3.0 promotes the v2.17 codebase to the v3.x stable line and commits to extended semver guarantees on every CLI flag, MCP tool name, MCP resource URI, MCP prompt, and exported TypeScript symbol.

**No new features and no breaking code changes vs v2.17.0** — this is the semantic milestone, not a feature drop.

## What's in this PR

- **STABILITY.md** — exact list of semver-bound surfaces (39 tool names, 3 MCP resource URIs, MCP prompts, every CLI flag, exported TS symbols), deprecation policy, and what's explicitly NOT covered (stderr format, on-disk schemas, default model resolution).
- **examples/** — drop-in MCP configs:
  - `claude-desktop.json` (TF-IDF only) + `claude-desktop-hybrid.json` (full hybrid stack)
  - `cursor-mcp.json`
  - `chatgpt-actions.md` — recipe for ChatGPT custom GPT actions over remote MCP (HTTP + bearer + Tailscale/Cloudflare tunnel)
  - `queries.jsonl` — sample query set for `enquire-mcp eval`
- **README** — v3.0 stable badge, examples callout, link to STABILITY.md, refreshed release section with the full v2.x → v3.0 highlight reel.
- **CHANGELOG** — comprehensive v3.0.0 entry summarizing the four-pillar feature-completeness across the v2.x line.
- Version bump 2.17.0 → 3.0.0 (5 surfaces synced).

## What landed across v2.0 → v2.17 (now v3.0)

| Pillar | Sprints | Result |
|---|---|---|
| **Quality** | v2.0 (RRF) · v2.9 (reranker) · v2.15 (late chunking) | +5-10 NDCG@10 vs single-ranker / vanilla embeddings |
| **Latency** | v2.13 (HNSW) · v2.16 (HNSW persistence) | sub-10ms top-K at million-chunk scale, ~50ms serve boot |
| **Storage** | v2.17 (int8 quantization) | ~4× smaller embed-db (~12 MB → ~3.4 MB on real 8K-chunk vault) |
| **Operability** | v2.6 (HTTP) · v2.7-2.10 (PDFs + OCR) · v2.11 (doctor/setup) · v2.12 (eval harness) · v2.14 (stateful sessions) | Remote MCP, PDFs blended into search, zero-touch onboarding, built-in benchmarking, ChatGPT custom GPT |

## Migration

**No-op.** Code is identical to v2.17.0. Major bump signals stability commitment, not a breaking change. `npm install @oomkapwn/enquire-mcp` continues to resolve to the latest version exactly as before.

## Test plan

- [x] `npm run lint` — biome zero warnings
- [x] `npx tsc --noEmit` — strict typecheck clean
- [x] `npm test` — 606/606 pass (unchanged from v2.17)
- [x] `npm run build` — dist/ builds clean
- [x] `node scripts/smoke.mjs` — both stdio + HTTP smoke pass
- [x] `node scripts/check-version-consistency.mjs` — version 3.0.0 across 5 surfaces
- [ ] CI — 12 required check-runs (lint, test×3, smoke, audit, coverage, version-consistency, CodeQL ×2, test-macos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)