### PR TITLE
v3.0.1: npm registry metadata refresh (no code changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] — 2026-05-09
+
+**Patch release: npm registry metadata refresh** so the most advanced Obsidian MCP server actually surfaces in AI/agent search and on npmjs.com.
+
+No code changes. No behavior changes. Identical to v3.0.0 functionally.
+
+### Changed
+
+- **`package.json` description rewritten** to lead with positioning ("The most advanced MCP server for Obsidian vaults") plus the concrete capability stack (BM25 + TF-IDF + multilingual ML embeddings via RRF + BGE cross-encoder reranking + HNSW + int8 quantization + late-chunking + PDFs + OCR + wikilinks + backlinks + Dataview + frontmatter + canvas). Includes the proof-points (39 tools, 606 tests, SLSA-3, semver-bound) and the client matrix (Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, any MCP client).
+- **npm keywords expanded 20 → 50** so AI agents and npm searchers actually find the package on every relevant query: `bm25`, `fts5`, `tf-idf`, `rrf`, `reciprocal-rank-fusion`, `hnsw`, `cross-encoder`, `bge`, `reranker`, `embeddings`, `vector-search`, `vector-database`, `rag`, `retrieval-augmented-generation`, `semantic-search`, `multilingual`, `pdf`, `ocr`, `tesseract`, `streamable-http`, `remote-mcp`, `slsa-3`, `obsidian-mcp`, `mcp-server`, `claude-desktop`, `chatgpt`, `canvas`, `ai-search`, `huggingface`, `transformers` (plus the existing 20 since v1.x).
+- **README.md** rewritten for AI-search indexability: 284 → 203 lines, leads with bold positioning, structured comparison table vs Smart Connections + other Obsidian-MCPs across 18 capabilities, 7-tier setup table, full 17-prompt list (satisfies docs-consistency invariant), `examples/` callout. Already merged into main pre-v3.0.1; this release is the matching npm publish so `npmjs.com` reflects the new metadata.
+
+### Why this exists
+
+v3.0.0 stable shipped to npm with the v2.x-era description + keyword set. AI agents and npm search look at the **registry** metadata, not the GitHub README. v3.0.1 is the registry refresh — same code, same behavior, just visible to discovery.
+
 ## [3.0.0] — 2026-05-09
 
 **v3.0.0 — stable channel.** The v2.x retrieval roadmap is complete. v3.0 promotes the v2.17 codebase to the v3.x stable line and commits to extended semver guarantees on every CLI flag, MCP tool name, MCP resource URI, MCP prompt, and exported TypeScript symbol — see [STABILITY.md](./STABILITY.md) for the full contract. **No new features and no breaking code changes vs v2.17.0** — this release is the semantic milestone confirming the retrieval API has stabilized.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, PDFs (with OCR), wikilinks, backlinks, Dataview, frontmatter, canvas. 39 tools, 606 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "3.0.0";
+const VERSION = "3.0.1";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {


### PR DESCRIPTION
## Summary

**Patch release — no code changes, no behavior changes.**

v3.0.0 was published to npm with the v2.x-era description + keyword set. AI agents and npm search look at the **registry** metadata, not the GitHub README — so the bold v3.0 positioning + 50 expanded keywords (already merged into main in PR #40) aren't visible to discovery yet. v3.0.1 is the matching republish that fixes that mismatch.

## What's in this PR

- Version bump 3.0.0 → 3.0.1 (5 surfaces synced)
- CHANGELOG entry documenting why this exists (registry refresh)

The actual metadata changes (`package.json` description + keywords + README rewrite) already shipped in PR #40 — this PR just bumps the version so the next `npm publish` propagates them.

## Test plan

- [x] `npm run lint` — biome zero warnings
- [x] `npx tsc --noEmit` — strict typecheck clean
- [x] `npm test` — 606/606 pass (unchanged from v3.0.0)
- [x] `npm run build` — dist/ builds clean
- [x] `node scripts/smoke.mjs` — both stdio + HTTP smoke pass
- [x] `node scripts/check-version-consistency.mjs` — version 3.0.1 across 5 surfaces
- [ ] CI — 12 required check-runs

## Why ship a patch release for metadata

AI agents and `npmjs.com` search expose pacages via the npm registry, which is frozen at publish-time. Unless we cut a new version, the bold v3.0 positioning + 30 newly-added high-signal keywords (`bm25`, `hnsw`, `reranker`, `rag`, `vector-search`, etc.) are invisible to discovery. The whole point of the keyword expansion was discoverability — so we need the publish to land it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)