### PR TITLE
v3.5.0: Bases DSL — linksTo() + file.path/file.name (closes v3.2 deferral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] — 2026-05-09
+
+**Sprint 22 — closes the v3.2 Bases DSL deferral.** v3.4.0's wikilink-graph infrastructure unlocks `linksTo()` evaluation in `.base` files. v3.5.0 also adds two related shorthand predicates Obsidian's canonical syntax uses (`file.path`, `file.name`).
+
+### Why this release exists
+
+When v3.2.0 shipped Bases support, the README and tool description listed `linksTo(file.file, "Target")` as **unevaluated** — treated as `true` (most permissive) and surfaced in `unevaluated_predicates`. Reason: the structural wikilink-graph code didn't exist yet. v3.4.0 shipped that infrastructure for community detection. v3.5.0 connects them.
+
+This is **not feature padding** — it's a documented deferral being closed correctly.
+
+### Added — `linksTo(file.file, "Target")`
+
+```yaml
+filters:
+  and:
+    - 'tag == "research"'
+    - 'linksTo(file.file, "Hub Note")'
+```
+
+Resolution mirrors Obsidian's: basename match, case-insensitive, `.md` stripped, section/block refs (`#heading`, `^block`) ignored. Implementation: per-note outbound set computed during `queryBase`'s walk (we already extract `[[wikilinks]]` for tag detection).
+
+Was: `unevaluated_predicates: ["linksTo(file.file, ...)"]`.
+Now: precise membership check.
+
+### Added — `file.path` / `file.name` shorthands
+
+Obsidian's canonical syntax uses the `file.` prefix. v3.5 accepts:
+
+- `file.path startsWith "Notes/"` — alias for `path startsWith "Notes/"`
+- `file.path contains "research"` — alias for `path contains "research"`
+- `file.name == "RAG"` — basename equality, case-insensitive, `.md` stripped
+- `file.name != "Inbox"` — basename inequality
+
+All four are alias-only — they don't change the behavior of the existing `path` / unprefixed predicates. Closes a small UX papercut where a user copying a `.base` file from another vault would see `file.path` predicates fall into `unevaluated`.
+
+### API changes
+
+`src/bases.ts`:
+- `EvalContext.outbound: Set<string>` — new field, populated during `queryBase` per-note walk
+- `evalPredicate` extended to handle `linksTo`, `file.path`, `file.name`
+
+No public API breakage. `EvalContext` is internal.
+
+### Tests
+
+656 unit tests pass (was 650 in v3.4.0, +6 new in `tests/bases.test.ts`):
+- `linksTo` is case-insensitive, strips `.md` / sections / blocks
+- `linksTo` returns false on no-link
+- `file.path startsWith` aliases `path startsWith`
+- `file.path contains` aliases `path contains`
+- `file.name ==` matches basename case-insensitively (no .md)
+- `file.name !=` excludes the basename
+
+Plus the existing v3.2 test that asserted `linksTo` was unevaluated has been **flipped** — it now locks in that `linksTo` IS evaluated and `unevaluated_predicates` is empty for the closed case.
+
+### Migration
+
+**No-op for default users.** A `.base` file that previously got `linksTo` over-included will now get an exact match (which is what the user intended). If anyone built a workflow that relied on `linksTo` being permissively-true, they'd see fewer matches now — but this is a correctness improvement, not a regression.
+
+### Surface counts
+
+44 tools, 19 prompts, 3 resources — unchanged. No new tools/prompts/resources; v3.5 deepens an existing tool's capability.
+
+### Backlog status
+
+Bases DSL closures so far:
+- ✅ `tag` / `taggedWith` predicates (v3.2)
+- ✅ `path startsWith` / `path contains` (v3.2)
+- ✅ Frontmatter equality + contains (v3.2)
+- ✅ `and` / `or` / `not` combinators (v3.2)
+- ✅ `linksTo(file.file, ...)` (v3.5)
+- ✅ `file.path` / `file.name` shorthands (v3.5)
+- ⏳ Date arithmetic (`inDate`, etc) — needs date parser
+- ⏳ Formula evaluator (`concat`, arithmetic) — needs expression engine
+- ⏳ Summaries — would require aggregation pass
+
+The remaining 3 deferrals each need their own focused sprint and are explicitly tracked.
+
 ## [3.4.0] — 2026-05-09
 
 **Sprint 21 — GraphRAG-light: wikilink community detection.** Closes the v3.0 audit's largest deferred item. Adds structural community detection over the vault's wikilink graph via greedy modularity optimization (single-phase Louvain). **First MCP server with native vault community detection.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.4.0",
-  "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, HyDE-augmented retrieval, sub-question decomposition, PDFs (with OCR), Bases (.base query execution, standalone — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 650 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
+  "version": "3.5.0",
+  "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, HyDE-augmented retrieval, sub-question decomposition, PDFs (with OCR), Bases (.base query execution, standalone — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 656 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/src/bases.ts
+++ b/src/bases.ts
@@ -8,14 +8,19 @@
 //   - Parse .base YAML files (read-only).
 //   - Execute a SUBSET of the filter DSL against vault notes:
 //       * tag predicates: `tag == "x"`, `tag != "x"`, `taggedWith(file.file, "x")`
-//       * path predicates: `path startsWith "X"`, `path contains "X"`
+//       * path predicates: `path startsWith "X"`, `path contains "X"`,
+//         `file.path startsWith "X"`, `file.name == "X"` (v3.5.0)
+//       * link predicates: `linksTo(file.file, "Target")` (v3.5.0 — uses
+//         the per-note outbound wikilink set; basename-resolved, case-insensitive)
 //       * frontmatter equality: `<key> == <value>`, `<key> != <value>`,
 //         `<key> contains "<substr>"`
 //       * combinators: `and`, `or`, `not`
 //       * boolean literals + bare-word property paths
 //
 // Out of scope (deferred):
-//   - Full DSL (linksTo / inDate range / formula evaluator / summaries)
+//   - Date arithmetic (`inDate`, `> 6mo`, etc) — needs a date parser
+//   - Formula evaluator (`concat`, `price / age`) — needs an expression engine
+//   - Summaries — would require aggregation pass
 //   - View rendering (we surface views as metadata, agent decides how to use them)
 //
 // Why this scope: covers the ~90% case (most user-authored .base filters
@@ -24,6 +29,7 @@
 
 import * as path from "node:path";
 import { z } from "zod";
+import { extractWikilinks } from "./parser.js";
 import type { Vault } from "./vault.js";
 
 /** Top-level shape of a parsed `.base` file. Mirrors the Obsidian schema. */
@@ -280,10 +286,24 @@ export async function queryBase(vault: Vault, args: QueryBaseArgs): Promise<Base
       continue;
     }
     const tags = collectTags(fm, body);
+    // v3.5.0 — collect outbound wikilink targets (basename-normalized,
+    // lowercased) for `linksTo()` predicate evaluation. We don't resolve
+    // against the vault's basename index here — `linksTo("Foo")` just
+    // checks whether the note has a `[[Foo]]` (or `[[foo]]`, `[[Foo.md]]`,
+    // `[[Foo#section]]`) outbound link; matching the basename is the
+    // semantic Obsidian uses too.
+    const outbound = new Set<string>();
+    for (const link of extractWikilinks(body)) {
+      const t = link.target.split(/[#^]/)[0]?.trim();
+      if (!t) continue;
+      const norm = (t.split("/").pop() ?? t).replace(/\.md$/i, "").toLowerCase();
+      if (norm) outbound.add(norm);
+    }
     const ctx: EvalContext = {
       path: e.relPath.replace(/\\/g, "/"),
       tags,
       frontmatter: fm,
+      outbound,
       unevaluated
     };
     const matched = effectiveFilter === undefined ? true : evalFilter(effectiveFilter, ctx);
@@ -309,6 +329,13 @@ interface EvalContext {
   path: string;
   tags: string[];
   frontmatter: Record<string, unknown>;
+  /**
+   * v3.5.0 — outbound wikilink targets (basename, lowercased, no .md
+   * extension, no section/block refs). Powers the `linksTo(file.file, "X")`
+   * predicate. Set rather than array because membership lookup is the
+   * only operation we need.
+   */
+  outbound: Set<string>;
   /** Predicates we couldn't evaluate get pushed here. Treated as `true`
    *  (most permissive) so the rest of the filter still works. */
   unevaluated: Set<string>;
@@ -325,7 +352,10 @@ function evalFilter(f: BaseFilter, ctx: EvalContext): boolean {
 /**
  * Evaluate a single predicate string against the eval context. Subset:
  *   - `taggedWith(file.file, "x")` / `tag == "x"` / `tag != "x"`
+ *   - v3.5.0: `linksTo(file.file, "Target")` (basename, case-insensitive)
  *   - `path startsWith "X"` / `path contains "X"`
+ *   - v3.5.0: `file.path startsWith "X"` / `file.path contains "X"` (alias)
+ *   - v3.5.0: `file.name == "X"` / `file.name != "X"` (basename eq, case-insensitive)
  *   - `<key> == <value>` / `<key> != <value>` / `<key> contains "<substr>"`
  *   - boolean literals: `true`, `false`
  *
@@ -347,6 +377,17 @@ function evalPredicate(raw: string, ctx: EvalContext): boolean {
     return ctx.tags.includes(tag);
   }
 
+  // v3.5.0 — linksTo(file.file, "Target") — outbound wikilink check.
+  // Resolution mirrors Obsidian: basename match (case-insensitive),
+  // strips .md extension and section/block refs from the target.
+  const linksTo = /^linksTo\(\s*file\.file\s*,\s*(["'])([^"']+)\1\s*\)$/.exec(expr);
+  if (linksTo) {
+    const target = (linksTo[2] ?? "").trim();
+    if (!target) return false;
+    const norm = (target.split("/").pop() ?? target).split(/[#^]/)[0]?.replace(/\.md$/i, "").toLowerCase();
+    return norm ? ctx.outbound.has(norm) : false;
+  }
+
   // tag == "x" / tag != "x"
   const tagEq = /^tag\s*(==|!=)\s*(["'])([^"']+)\2$/.exec(expr);
   if (tagEq) {
@@ -357,11 +398,24 @@ function evalPredicate(raw: string, ctx: EvalContext): boolean {
   }
 
   // path startsWith "X" / path contains "X"
-  const pathOp = /^path\s+(startsWith|contains)\s+(["'])([^"']+)\2$/.exec(expr);
+  // v3.5.0 — also accept `file.path startsWith` / `file.path contains` as
+  // aliases (Obsidian's canonical syntax uses the `file.` prefix).
+  const pathOp = /^(?:file\.)?path\s+(startsWith|contains)\s+(["'])([^"']+)\2$/.exec(expr);
   if (pathOp) {
     const op = pathOp[1];
     const needle = pathOp[3] ?? "";
     return op === "startsWith" ? ctx.path.startsWith(needle) : ctx.path.includes(needle);
+  }
+
+  // v3.5.0 — file.name == "X" / file.name != "X". Basename equality
+  // (case-insensitive, .md stripped).
+  const fileNameEq = /^file\.name\s*(==|!=)\s*(["'])([^"']+)\2$/.exec(expr);
+  if (fileNameEq) {
+    const op = fileNameEq[1];
+    const want = (fileNameEq[3] ?? "").replace(/\.md$/i, "").toLowerCase();
+    const got = (ctx.path.split("/").pop() ?? ctx.path).replace(/\.md$/i, "").toLowerCase();
+    const eq = got === want;
+    return op === "==" ? eq : !eq;
   }
 
   // <key> contains "<substr>"  — e.g. `status contains "doing"`

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "3.4.0";
+const VERSION = "3.5.0";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {
@@ -2203,7 +2203,7 @@ function registerReadTools(
     {
       title: "Execute an Obsidian Base — return matching notes",
       description:
-        'v3.2.0 — Runs a `.base` file\'s filter against the vault\'s markdown notes, returning matching paths + the frontmatter values that contributed to the match. Supports a SUBSET of the Obsidian DSL: `tag == "x"`, `taggedWith(file.file, "x")`, `path startsWith "X"`, `path contains "X"`, `<frontmatter_key> == <value>`, `<key> != <value>`, `<key> contains "<substr>"`, plus `and` / `or` / `not` combinators. Anything else (formula calls, `linksTo`, date arithmetic) is treated as `true` (most permissive) and returned in `unevaluated_predicates` so callers know what was ignored. Pair with `obsidian_search` for retrieval-quality search; this is for explicit saved queries.',
+        'v3.2.0 (extended in v3.5.0) — Runs a `.base` file\'s filter against the vault\'s markdown notes, returning matching paths + the frontmatter values that contributed to the match. Supported DSL: `tag == "x"`, `taggedWith(file.file, "x")`, `linksTo(file.file, "Target")` (v3.5.0 — outbound wikilink check, basename-resolved, case-insensitive), `path startsWith "X"` / `path contains "X"` / `file.path startsWith "X"` (v3.5.0 — `file.` prefix accepted), `file.name == "X"` / `file.name != "X"` (v3.5.0 — basename equality, .md stripped), `<frontmatter_key> == <value>`, `<key> != <value>`, `<key> contains "<substr>"`, plus `and` / `or` / `not` combinators. Anything else (formula evaluation, date arithmetic, summaries) is treated as `true` (most permissive) and returned in `unevaluated_predicates`. Pair with `obsidian_search` for retrieval-quality search; this is for explicit saved queries.',
       annotations: { ...READ_ONLY, title: "Query base" },
       inputSchema: {
         path: z.string().describe("Vault-relative path of the .base file"),

--- a/tests/bases.test.ts
+++ b/tests/bases.test.ts
@@ -299,8 +299,16 @@ views:
     expect(allBooks.view).toBe("All books");
   });
 
-  it("collects unevaluated predicates without crashing (e.g. linksTo)", async () => {
+  // v3.5.0 — linksTo() is now evaluated (no longer in unevaluated_predicates).
+  // We keep this test to lock in the closed deferral.
+  it("v3.5.0 evaluates linksTo() (no longer unevaluated)", async () => {
     const { root, vault } = await makeBaseVault();
+    // Add a note that explicitly links to Textbook + a Textbook target.
+    await fs.writeFile(
+      path.join(root, "links-textbook.md"),
+      "---\nstatus: open\ntags: [book]\n---\nsee [[Textbook]] for details\n"
+    );
+    await fs.writeFile(path.join(root, "Textbook.md"), "the textbook\n");
     await fs.writeFile(
       path.join(root, "q.base"),
       `filters:
@@ -312,9 +320,11 @@ views:
 `
     );
     const out = await queryBase(vault, { path: "q.base" });
-    expect(out.unevaluated_predicates).toContain('linksTo(file.file, "Textbook")');
-    // linksTo treated as `true` (most permissive) → matches both books.
-    expect(out.matches.length).toBeGreaterThanOrEqual(2);
+    expect(out.unevaluated_predicates).toEqual([]); // linksTo is now evaluated
+    const paths = out.matches.map((m) => m.path);
+    expect(paths).toContain("links-textbook.md");
+    // open.md has tag=book but does NOT link to Textbook → excluded.
+    expect(paths).not.toContain("open.md");
   });
 
   it("collects inline #tags from body for taggedWith() matching", async () => {
@@ -352,5 +362,93 @@ views:
     );
     const out = await queryBase(vault, { path: "q.base", limit: 2 });
     expect(out.matches.length).toBeLessThanOrEqual(2);
+  });
+
+  // v3.5.0 — newly-supported predicates. Lock in closed deferrals.
+  describe("v3.5.0 — linksTo + file.path/file.name", () => {
+    it("linksTo is case-insensitive and strips .md / sections / blocks", async () => {
+      const { root, vault } = await makeBaseVault();
+      await fs.writeFile(
+        path.join(root, "linker.md"),
+        "links to [[TEXTBOOK#chapter-1]] and [[textbook.md|alias]] and [[textbook^block]]\n"
+      );
+      await fs.writeFile(path.join(root, "Textbook.md"), "the book");
+      await fs.writeFile(
+        path.join(root, "q.base"),
+        `filters: 'linksTo(file.file, "Textbook")'
+views:
+  - type: table
+`
+      );
+      const out = await queryBase(vault, { path: "q.base" });
+      expect(out.matches.map((m) => m.path)).toContain("linker.md");
+    });
+
+    it("linksTo returns false when no outbound link to target", async () => {
+      const { root, vault } = await makeBaseVault();
+      await fs.writeFile(
+        path.join(root, "q.base"),
+        `filters: 'linksTo(file.file, "NonExistentTarget")'
+views:
+  - type: table
+`
+      );
+      const out = await queryBase(vault, { path: "q.base" });
+      expect(out.matches).toHaveLength(0);
+    });
+
+    it("file.path startsWith is an alias for path startsWith", async () => {
+      const { root, vault } = await makeBaseVault();
+      await fs.writeFile(
+        path.join(root, "q.base"),
+        `filters: 'file.path startsWith "Notes/"'
+views:
+  - type: table
+`
+      );
+      const out = await queryBase(vault, { path: "q.base" });
+      expect(out.matches.map((m) => m.path)).toEqual(["Notes/inline.md"]);
+    });
+
+    it("file.path contains is an alias for path contains", async () => {
+      const { root, vault } = await makeBaseVault();
+      await fs.writeFile(
+        path.join(root, "q.base"),
+        `filters: 'file.path contains "inline"'
+views:
+  - type: table
+`
+      );
+      const out = await queryBase(vault, { path: "q.base" });
+      expect(out.matches.map((m) => m.path)).toEqual(["Notes/inline.md"]);
+    });
+
+    it("file.name == matches basename case-insensitively (no .md)", async () => {
+      const { root, vault } = await makeBaseVault();
+      await fs.writeFile(
+        path.join(root, "q.base"),
+        `filters: 'file.name == "Inline"'
+views:
+  - type: table
+`
+      );
+      const out = await queryBase(vault, { path: "q.base" });
+      expect(out.matches.map((m) => m.path)).toEqual(["Notes/inline.md"]);
+    });
+
+    it("file.name != excludes the basename", async () => {
+      const { root, vault } = await makeBaseVault();
+      await fs.writeFile(
+        path.join(root, "q.base"),
+        `filters: 'file.name != "open"'
+views:
+  - type: table
+`
+      );
+      const out = await queryBase(vault, { path: "q.base" });
+      const paths = out.matches.map((m) => m.path);
+      expect(paths).not.toContain("open.md");
+      expect(paths).toContain("done.md");
+    });
   });
 });


### PR DESCRIPTION
## Summary

**Sprint 22.** v3.4.0's wikilink-graph infrastructure unlocked `linksTo()` evaluation in `.base` files. v3.5.0 closes that explicit deferral from v3.2 + adds two related shorthand predicates (`file.path`, `file.name`).

**Not padding** — closes a deferral documented in v3.2.0 CHANGELOG: *"anything else (formula calls, `linksTo`, date arithmetic) is treated as `true`"*.

## Added

### `linksTo(file.file, "Target")`

Resolution mirrors Obsidian's: basename match, case-insensitive, `.md` stripped, section/block refs (`#heading`, `^block`) ignored. Implementation: per-note outbound set computed during `queryBase`'s walk (we already extract `[[wikilinks]]` for tag detection; this reuses that pass).

```yaml
filters:
  and:
    - 'tag == "research"'
    - 'linksTo(file.file, "Hub Note")'
```

### `file.path` / `file.name` shorthands

Obsidian's canonical syntax uses the `file.` prefix. v3.5 accepts:
- `file.path startsWith "Notes/"` — alias for `path startsWith "Notes/"`
- `file.path contains "research"` — alias for `path contains "research"`
- `file.name == "RAG"` — basename equality, case-insensitive, `.md` stripped
- `file.name != "Inbox"` — basename inequality

## Tests

656 (was 650, **+6** new in `tests/bases.test.ts`):
- `linksTo` case-insensitivity + extension/section/block stripping
- `linksTo` returns false on no-link
- `file.path startsWith` / `file.path contains` aliases
- `file.name ==` / `file.name !=` basename equality

Plus the existing v3.2 test `"collects unevaluated predicates without crashing (e.g. linksTo)"` has been **flipped** — it now locks in that `linksTo` IS evaluated and `unevaluated_predicates` is empty for the closed case. Lock-in for the closed deferral.

## Migration

**No-op for default users.** A `.base` file that previously got `linksTo` over-included (treated as `true`) will now get an exact match. This is a correctness improvement, not a regression.

## Surface unchanged

44 tools / 19 prompts / 3 resources. v3.5 deepens an existing tool's capability.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` — 656/656
- [x] `npm run build`
- [x] `node scripts/smoke.mjs`
- [x] `node scripts/check-version-consistency.mjs`
- [ ] CI 12 required gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)