### PR TITLE
v3.5.4: external-audit quick wins (Biome strict + package.json $schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.4] — 2026-05-10
+
+**Patch — quick wins from external review.** Two single-line config tightenings, no behavior changes.
+
+### Changed
+
+- **Biome:** `noUnusedVariables` and `noUnusedImports` upgraded from `warn` → `error`. Lint already passes with the stricter level (no dead code currently in tree); the upgrade is purely defensive to prevent future drift past CI. Catches unused imports / variables before they accumulate.
+- **`package.json`:** added `$schema: "https://json.schemastore.org/package.json"`. Enables IDE validation + autocomplete on the manifest. No effect on npm publish or runtime.
+
+### Tests
+
+664 unit tests pass (unchanged). Lint still clean under stricter rules.
+
+### Migration
+
+**No-op.** Pure config tightening.
+
 ## [3.5.3] — 2026-05-09
 
 **Patch — CHANGELOG cleanup.** No code or config changes. Removes references to internal operational notes from the v3.5.1 / v3.5.2 entries that are not relevant to consumers of the package. Repository-level admin items are tracked privately, not in the public CHANGELOG.

--- a/biome.json
+++ b/biome.json
@@ -31,8 +31,8 @@
         "useNodejsImportProtocol": "error"
       },
       "correctness": {
-        "noUnusedVariables": "warn",
-        "noUnusedImports": "warn"
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
       },
       "complexity": {
         "noUselessConstructor": "off"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, HyDE-augmented retrieval, sub-question decomposition, PDFs (with OCR), Bases (.base query execution, standalone — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 664 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "3.5.3";
+const VERSION = "3.5.4";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {


### PR DESCRIPTION
## Summary

Two single-line config tightenings from external review. No behavior changes, no code changes.

## Changed

- **`biome.json`:** `noUnusedVariables` + `noUnusedImports` upgraded `warn` → `error`. Lint already passes with the stricter level (no dead code in tree); the upgrade is purely defensive — prevents future drift past CI.
- **`package.json`:** added `"$schema": "https://json.schemastore.org/package.json"`. Enables IDE validation + autocomplete on the manifest. No effect on npm publish or runtime.

## Tests

664 unit tests pass (unchanged). Lint clean under the stricter rules.

## Migration

**No-op.** Pure config tightening.

## Test plan

- [x] `npm run lint` clean (stricter rules pass)
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 664/664
- [x] `npm run build` clean
- [x] `scripts/smoke.mjs` pass
- [x] `check-version-consistency.mjs` aligned at 3.5.4
- [ ] CI 12 gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)