### PR TITLE
v3.5.5: doctor.test cold-import flake + SECURITY.md stateful-HTTP sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.5] — 2026-05-10
+
+**Patch — fixes from external review #2.** Two issues: test flakiness on cold I/O + a documentation drift between SECURITY.md and the v2.14.0 stateful-HTTP code path. No behavior changes.
+
+### Fixed — `tests/doctor.test.ts` cold-import flake
+
+The first test in `runDoctor (v2.11.0)` calls `runDoctor()`, which probes optional deps via `await import(...)` — including `@huggingface/transformers` (~100 MB + ONNX runtime). On a slow disk / cold module cache, the first import in a fresh Vitest process can take 5-30 seconds, tripping the default 5 s test timeout. Subsequent tests in the same describe block reuse Node's module cache and finish in <100 ms each — the flake only ever hits the first test.
+
+Fix: per-test `30_000 ms` timeout on the offending case, with a comment explaining why. Lighter than mocking the import (which would hide real "transformers actually loads" regressions), heavier than wishing-it-away.
+
+### Fixed — SECURITY.md: stateful-HTTP posture (v2.14.0+) now documented
+
+Pre-v3.5.5 `SECURITY.md` said:
+
+> v2.6.0 ships **stateless** mode only [...] Stateful sessions with `Mcp-Session-Id` + persistent SSE streams are tracked for v2.7+ if there's demand.
+
+That document hadn't been updated since v2.6 — but v2.14.0 (2026-05-09) shipped the stateful path with `Mcp-Session-Id` + persistent SSE via `GET /mcp` + `DELETE /mcp` termination + idle eviction + max-sessions cap. The security posture was real in code but missing from SECURITY.md, leaving consumers without the threat model for a path they could already enable via `--stateful`.
+
+Fix: rewrote the `### Stateful sessions` section to cover the actual v2.14 surface:
+- Off by default (`--stateful` is opt-in)
+- Session ID = 128-bit random hex, allocated at `initialize`
+- Max concurrent sessions cap via `--max-sessions <n>` (default 100); overflow → 503 + Retry-After
+- Idle eviction via `--session-idle-timeout-ms <n>` (default 30 min)
+- Explicit termination via `DELETE /mcp` (idempotent — 404 on unknown ID)
+- Persistent SSE via `GET /mcp` with the same auth + rate-limit predicates
+- Privacy filter parity with stateless
+- Graceful shutdown drains the session map
+- Out-of-scope: session takeover on bearer-token leak, cross-session shared-state leakage (single-tenant tool by design)
+
+### Tests
+
+664 unit tests pass (unchanged count). The flake is now ABSENT on slow-I/O machines — the test gets up to 30 s headroom for the cold transformers.js import.
+
+### Migration
+
+**No-op for default users.** Pure test stability + docs sync.
+
 ## [3.5.4] — 2026-05-10
 
 **Patch — quick wins from external review.** Two single-line config tightenings, no behavior changes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -190,9 +190,23 @@ The `serve-http` subcommand (added v2.6.0) exposes the same MCP server over [Str
 - **Multi-tenant cross-token attacks.** This is a single-tenant tool. A small team should run **one process per user** (e.g. systemd template unit) and not share tokens. We don't do tenant isolation in-process beyond the per-token rate-limit.
 - **OAuth.** No OAuth flow, no token minting, no refresh logic. Static long-lived bearer is by design — generated with `enquire-mcp gen-token`, rotated manually. OAuth is tracked for v2.7+ if a user explicitly needs it.
 
-### Stateful sessions
+### Stateful sessions (v2.14.0+)
 
-v2.6.0 ships **stateless** mode only (`sessionIdGenerator: undefined`) — fresh `McpServer` per request over the SHARED vault + FTS5 + embedding handles. No long-lived session map; no SSE persistent streams. This is the right default for our short-running tools (search, read, frontmatter ops) and avoids the persistence-aware shutdown complexity. Stateful sessions with `Mcp-Session-Id` + persistent SSE streams are tracked for v2.7+ if there's demand.
+v2.6.0 initially shipped **stateless** mode only (fresh `McpServer` per request over the SHARED vault + FTS5 + embedding handles). v2.14.0 added an **opt-in stateful** mode via `--stateful` for clients that need persistent state across requests (notably ChatGPT custom GPT actions). Stateful posture:
+
+- **Off by default.** `--stateful` is explicit opt-in; stateless remains the default for minimum attack surface. Short-running tools (search, read, frontmatter ops) work fine stateless and don't need the persistence-aware shutdown complexity.
+- **Session ID generation.** `Mcp-Session-Id` is `randomBytes(16).toString("hex")` — 128 bits, allocated at `initialize` time, returned in response header. Clients must echo it on subsequent requests; unknown IDs return 404 (no info leak about whether the ID was ever valid).
+- **Per-token + per-session rate limit.** The bearer-token rate limit still applies. Sessions are anchored to a bearer token; one token holding multiple sessions is allowed, but each session is bound to the token that initialized it.
+- **Max concurrent sessions cap.** `--max-sessions <n>` (default **100**). New sessions beyond the cap return **503 + `Retry-After`**. Prevents memory exhaustion via session-spam.
+- **Idle eviction.** `--session-idle-timeout-ms <n>` (default **1,800,000 ms = 30 min**). A periodic sweep terminates transports idle longer than the timeout. Memory bounded.
+- **Explicit termination.** `DELETE /mcp` with a valid `Mcp-Session-Id` tears down the transport immediately. Idempotent — repeat DELETE on a no-longer-existing ID returns 404, not 500.
+- **GET /mcp for persistent SSE.** A `GET /mcp` with a valid `Mcp-Session-Id` opens a server-sent-events stream for server-initiated notifications. Same auth + rate-limit predicates as POST. Stream closes on DELETE or idle eviction.
+- **Privacy filter parity.** `--exclude-glob` / `--read-paths` apply identically to stateful and stateless paths. There is no codepath where a stateful session bypasses the privacy filter.
+- **Graceful shutdown.** SIGINT / SIGTERM / `beforeExit` trigger session-map drain — all transports are closed before the process exits. No leaked SSE streams.
+
+Out of scope (stateful mode specifically):
+- **Session takeover** if a bearer token leaks. The session-id is in a response header, not a secret — possession of the bearer token is sufficient to initialize new sessions OR (if the attacker captured a previous `Mcp-Session-Id`) re-attach to an existing one. Treat the bearer token as the trust boundary; don't share it.
+- **Cross-session leakage.** Each session has its own `McpServer` instance but shares the vault + FTS5 + embedding handles. A misbehaving tool that mutates shared state could affect other sessions. Write tools (`--enable-write`) are still atomic per-file; read tools don't mutate. We don't run per-session sandboxing — single-tenant tool, see "Multi-tenant cross-token attacks" above.
 
 ### Observability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.5.4",
+      "version": "3.5.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, HyDE-augmented retrieval, sub-question decomposition, PDFs (with OCR), Bases (.base query execution, standalone — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 664 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "3.5.4";
+const VERSION = "3.5.5";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -35,6 +35,14 @@ afterEach(async () => {
 });
 
 describe("runDoctor (v2.11.0)", () => {
+  // v3.5.5 — external audit flagged this test as flaky under cold I/O:
+  // runDoctor probes optional deps via `await import(...)` including
+  // `@huggingface/transformers` (~100MB + ONNX runtime). First import in
+  // a fresh Vitest process can take 5-30s on slow disks / cold caches,
+  // tripping the default 5s timeout. We bump to 30s on the FIRST test
+  // in the describe block (the only one that pays the cold-import cost
+  // — subsequent tests in this file reuse Node's module cache and run
+  // in <100ms each).
   it("returns the expected DoctorResult shape", async () => {
     const result = await runDoctor({ vault: root, modelCacheRoot: cacheRoot });
     expect(result.vault).toBe(root);
@@ -50,7 +58,7 @@ describe("runDoctor (v2.11.0)", () => {
     // Summary tally adds up to check count.
     const total = result.summary.ok + result.summary.warn + result.summary.missing + result.summary.error;
     expect(total).toBe(result.checks.length);
-  });
+  }, 30_000); // see comment above the it() — cold transformers.js import can dominate.
 
   it("vault check is ok for a real directory", async () => {
     await fs.writeFile(path.join(root, "note.md"), "# Hello\n");


### PR DESCRIPTION
## Summary

External review #2 surfaced two real issues. No code-behavior changes.

### Fixed — `tests/doctor.test.ts` cold-import flake

The first test in `runDoctor (v2.11.0)` loads `@huggingface/transformers` (~100 MB + ONNX runtime) via `probeOptionalDep`'s `await import(...)`. On a slow disk / cold module cache, the first import in a fresh Vitest process can take 5-30 s, tripping the default 5 s timeout. Subsequent tests in the same describe block reuse Node's module cache and complete in <100 ms.

Fix: per-test `30_000` ms timeout on the offending case, comment explaining the reasoning. Lighter than `vi.mock` (which would hide real "transformers actually loads" regressions), cleaner than wishing-it-away.

### Fixed — SECURITY.md: stateful-HTTP posture documented

Pre-v3.5.5 SECURITY.md said:

> v2.6.0 ships **stateless** mode only [...] Stateful sessions with `Mcp-Session-Id` + persistent SSE streams are tracked for v2.7+ if there's demand.

Reality: v2.14.0 (2026-05-09) shipped the stateful path — `Mcp-Session-Id` + persistent SSE via `GET /mcp` + `DELETE /mcp` termination + idle eviction + max-sessions cap. The doc was 8 versions stale. The security posture was real in code but missing from SECURITY.md.

Fix: rewrote the `### Stateful sessions` section to cover the actual v2.14 surface — opt-in via `--stateful`, 128-bit random session IDs, `--max-sessions` cap (overflow → 503), `--session-idle-timeout-ms` sweep, idempotent `DELETE`, persistent SSE on `GET`, privacy-filter parity, graceful shutdown drain, plus explicit out-of-scope (session takeover on bearer-token leak, cross-session shared-state — single-tenant by design).

## Tests

664 unit tests pass (unchanged). The doctor flake is now absent on slow-I/O machines — first test gets 30 s headroom for cold transformers.js import.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 664/664
- [x] `npm run build` clean
- [x] `scripts/smoke.mjs` pass
- [x] `check-version-consistency.mjs` aligned at 3.5.5
- [ ] CI 12 gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)