### PR TITLE
v3.5.7: privacy positioning in README hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.7] — 2026-05-12
+
+**Patch — privacy positioning surfaced in hero.** No code changes.
+
+Obsidian launched the [Obsidian Community](https://obsidian.md/blog/future-of-plugins/) directory on 2026-05-12, including automated reviews and an upcoming **disclosure system** that will tag every community plugin with what it accesses (network / filesystem / clipboard / etc). Plugins that hit cloud APIs for retrieval will be visibly flagged.
+
+`enquire-mcp` makes **zero outbound network calls during serve** — all retrieval (BM25, embeddings, reranker) runs locally; models cached after one-time `install-model` from HuggingFace; vault content never leaves the machine. This was always true but never called out in the README hero.
+
+Added a second hero callout under the existing "First and only..." line: *"Zero outbound network calls during serve. Embedding + reranker models cached locally. Your vault content never leaves your machine. The privacy-conscious complement to Obsidian plugins that hit cloud APIs for retrieval."*
+
+No version-consistency or invariant changes; pure marketing-copy adjustment to align with the Obsidian ecosystem's new disclosure direction.
+
 ## [3.5.6] — 2026-05-10
 
 **Patch — root-cause fixes for two issue classes surfaced by external reviews.** Closes the systemic gaps, not just the individual symptoms. No behavior changes.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 ---
 
 > **First and only Obsidian-MCP that ships hybrid retrieval, cross-encoder reranking, HNSW, int8 quantization, late-chunking, HyDE, GraphRAG-light community detection, standalone `.base` query execution, PDFs + OCR, and stateful remote MCP — together. In one binary. Under MIT. SLSA-3 signed.**
+>
+> **Zero outbound network calls during serve.** Embedding + reranker models cached locally (one-time `install-model` from HuggingFace). Your vault content never leaves your machine. The privacy-conscious complement to Obsidian plugins that hit cloud APIs for retrieval.
 
 ## What it is
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.5.6",
+      "version": "3.5.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, HyDE-augmented retrieval, sub-question decomposition, PDFs (with OCR), Bases (.base query execution, standalone — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 664 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "3.5.6";
+const VERSION = "3.5.7";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {


### PR DESCRIPTION
## Summary

No code changes. Aligns README hero copy with Obsidian's [new disclosure direction](https://obsidian.md/blog/future-of-plugins/) (2026-05-12 launch).

## Context

Obsidian launched the new Community directory with upcoming **disclosure labels** — every community plugin will be tagged with what it accesses (network / filesystem / clipboard / etc). Plugins that hit cloud APIs for retrieval will be visibly flagged.

`enquire-mcp` makes **zero outbound network calls during serve**. All retrieval (BM25, ML embeddings, reranker, HNSW, .base, communities) runs locally; models cached after one-time `install-model` from HuggingFace; vault content never leaves the machine. This was always the design but not surfaced in the hero.

## Change

Added a second hero callout under the existing 'First and only...' line:

> **Zero outbound network calls during serve.** Embedding + reranker models cached locally (one-time `install-model` from HuggingFace). Your vault content never leaves your machine. The privacy-conscious complement to Obsidian plugins that hit cloud APIs for retrieval.

## Migration

No-op. README copy only.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 664/664
- [x] `scripts/smoke.mjs` pass
- [x] `check-version-consistency.mjs` aligned at 3.5.7
- [ ] CI 12 gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)