### PR TITLE
v3.5.13: README badges + stale CI claims cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.13] — 2026-05-13
+
+**Patch — README badges + stale CI claims.** Surface-only cleanup. No code changes.
+
+### Fixed
+
+- **npm badge label**: `npm @latest` → `npm`. The `@latest` suffix could be misread as the npm dist-tag (which is implicit when you query the latest version), so the badge was double-labeling. Plus the URL-encoded `%20%40` made the link ugly in raw markdown.
+- **`stable` badge version pointer**: `v3.0-stable` → `v3.5.x-stable`. Was last updated when v3.0.0 shipped (2026-05-09); 12 patch releases later it still pointed at v3.0.
+- **CI gate count + Node matrix in `#trust`** (README line 162): `**8 required** … test ×3 [Node 20/22/24]` → `**7 required** … test ×2 [Node 22/24]`. v3.5.11 dropped Node 20 from CI (EOL'd 2026-04, pdfjs v5 needs ≥22.13); this table was missed in that patch. Inline note added to explain the change.
+- **CI gate count in trust table** (line 92): `8 required + 4 advisory` → `7 required + 4 advisory`. Same drift class as above.
+- **Coverage row**: `branches ≥73% (gated)` → `branches ≥74% (gated)`. v3.5.10 raised the threshold from 72→74 after the coverage uplift work but missed this surface.
+
+### Tests
+
+712 unit tests pass · lint clean · tsc clean · version-consistency green at `3.5.13` across 5 surfaces.
+
+### Migration
+
+**No-op.** Documentation-only patch.
+
+### Method note
+
+This is exactly the class of drift the v3.5.9 docs-consistency invariants were designed to catch — the per-tool/prompt/test-count surfaces. But CI-config-claim drift (number of required checks, Node matrix in the trust table) is a NEW surface those invariants don't cover. Adding an invariant for "README claims about CI gates must match `.github/workflows/ci.yml` reality" would be the right class fix. Left as future work for the next audit cycle to flag — if it does, we know the class is worth chasing. Same applies to the `branches threshold` claim in the trust table vs `vitest.config.ts`.
+
 ## [3.5.12] — 2026-05-13
 
 **Patch — external audit #4 followup.** External re-audit measured v3.5.10 on disk and surfaced 5 LOW/INFO/COSMETIC findings (§3 of [REAUDIT_REPORT_v3.5.10]). Closes all 5 + applies root-cause-sweep methodology so the next audit doesn't find the same drift class again.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 **Every modern IR primitive. In one tool. For free.**
 
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp/latest.svg?label=npm%20%40latest&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
+[![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![tests](https://img.shields.io/badge/tests-712%20passing-brightgreen.svg)](#trust)
-[![stable](https://img.shields.io/badge/v3.0-stable-brightgreen.svg)](./STABILITY.md)
+[![stable](https://img.shields.io/badge/v3.5.x-stable-brightgreen.svg)](./STABILITY.md)
 [![SLSA-3](https://img.shields.io/badge/SLSA-3-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
@@ -89,7 +89,7 @@ enquire-mcp doctor --vault <path>    # color-coded ✓/⚠/✗ health check
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **712 unit tests · 8 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **712 unit tests · 7 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **SLSA-3 build provenance** | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -159,8 +159,8 @@ Plus 3 MCP resources (`obsidian://vault/info`, `obsidian://note/{path}`, `obsidi
 | **HTTP transport** | Bearer auth (constant-time SHA-256 + `timingSafeEqual`), per-token rate-limit, strict CORS |
 | **Frontmatter** | `gray-matter` (`js-yaml` safeLoad) — no code execution |
 | **Cache + index files** | chmod 0600, parent dir 0700 |
-| **CI** | **8 required** branch-protection gates (lint · test ×3 [Node 20/22/24] · smoke · audit · coverage · version-consistency) + **4 advisory** (test-macos · CodeQL ×2 · Analyze actions). Release workflow re-verifies all 8 required passed on tagged SHA before npm publish. |
-| **Coverage** | Lines ≥86% · statements ≥82% · functions ≥75% · branches ≥73% (gated) |
+| **CI** | **7 required** branch-protection gates (lint · test ×2 [Node 22/24] · smoke · audit · coverage · version-consistency) + **4 advisory** (test-macos · CodeQL ×2 · Analyze actions). Release workflow re-verifies all 7 required passed on tagged SHA before npm publish. _v3.5.11 — Node 20 dropped (EOL'd 2026-04, pdfjs v5 requires ≥22.13)._ |
+| **Coverage** | Lines ≥86% · statements ≥82% · functions ≥75% · branches ≥74% (gated) |
 | **Releases** | npm + GitHub release per tag · semver · **SLSA-3** build provenance |
 | **Stability** | v3.0+ semver-bound — every CLI flag, tool name, MCP resource, prompt, exported symbol is contract |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.5.12",
+      "version": "3.5.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "description": "The most advanced MCP server for Obsidian vaults. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW vector index, int8 quantization, late-chunking, HyDE-augmented retrieval, sub-question decomposition, PDFs (with OCR), Bases (.base query execution, standalone — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 712 tests, SLSA-3, semver-bound. Works with Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ import {
 import { Vault } from "./vault.js";
 import { VaultWatcher } from "./watcher.js";
 
-const VERSION = "3.5.12";
+const VERSION = "3.5.13";
 
 /** Default location for the persistent embedding index, alongside .fts5.db. */
 function embedDbPath(vaultRoot: string): string {


### PR DESCRIPTION
## Summary

User flagged that the npm badge displayed badly. Investigated the entire `#trust` section + badge block while at it. **Surface-only patch — no code changes.**

## Fixed

| Surface | Before | After |
|---|---|---|
| npm badge label | `npm @latest` (URL-encoded `%20%40`, double-labeled) | `npm` (clean) |
| stable badge version | `v3.0-stable` (frozen since 2026-05-09) | `v3.5.x-stable` |
| README #trust table CI row | `**8 required** ... test ×3 [Node 20/22/24]` | `**7 required** ... test ×2 [Node 22/24]` + inline note explaining v3.5.11 Node-20 drop |
| README #trust table coverage row | `branches ≥73% (gated)` | `branches ≥74% (gated)` (v3.5.10 raised threshold) |
| README trust-block summary | `8 required + 4 advisory` | `7 required + 4 advisory` |

## Validation

- 712 tests pass · lint clean · tsc clean
- `npm run check:changelog-coverage` — OK (no coverage claims in this entry → exits 0 as designed)
- Version-consistency green at `3.5.13` across 5 surfaces

## Method note

CI-config-claim drift (number of required checks, Node matrix in the trust table, branches threshold) is a NEW class of bug NOT covered by the v3.5.9 docs-consistency invariants (which cover tool/prompt/test counts). A targeted class fix would be: invariant that asserts README #trust claims about CI gates match `.github/workflows/ci.yml` + `vitest.config.ts` thresholds. Left as future work — the next external audit will likely flag it, and seeing the same drift twice confirms it's worth a class fix.

## Test plan

- [ ] CI: lint, test×2 (Node 22/24), test-macos, smoke, audit, coverage, version-consistency all green
- [ ] After merge: tag v3.5.13, push tag, release workflow publishes, mark GH release Latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)