### PR TITLE
v3.7.8: repo positioning — restore 'most advanced Obsidian MCP' + add OpenClaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.8] — 2026-05-16
+
+> **TL;DR:** Repo-page positioning patch. Restores **"The most advanced Obsidian MCP"** as the primary credential in the README hero (previously demoted to a secondary line in v3.6.3's "memory for AI agents" pivot, then dropped entirely in v3.7.7's visual refresh). Adds **OpenClaw** to all agent-list mentions (README hero, "What it is", Use cases, comparison matrix, npm description, image alt text). GitHub About description + Topics updated out-of-band via `gh api`: About now leads with "The most advanced Obsidian MCP — long-term memory for AI agents...", Topics list `openclaw` (dropped `context-engineering` from the 20-cap as the least-discoverable hype keyword). **Zero code changes.** 786 tests unchanged.
+
+**Patch — positioning restoration + OpenClaw discoverability.**
+
+### Changed — README hero (most-advanced credential restored)
+
+The v3.6.3 marketing pivot moved "The most advanced Obsidian MCP" from the primary headline to a secondary bold line ("Long-term memory for AI agents." became the lead). The v3.7.7 visual refresh dropped the secondary line entirely in favor of the pain-point hook ("Stop re-explaining context..."). **v3.7.8 restores the credential to the H3 subtitle** so visitors immediately see both positioning facets:
+
+```
+### The most advanced Obsidian MCP. Long-term memory for AI agents.
+```
+
+The bold pain-point hook below stays, so the structure is now: **credential + value prop** (H3) → **pain point + outcome** (bold).
+
+### Added — OpenClaw to all agent surfaces
+
+OpenClaw is a primary MCP client (reference deployment partner; see v3.5.x CHANGELOG for the SZBOX trading-system pairing). v3.6.3's Topics rebalance dropped `openclaw` to fit the 8 new hype keywords inside GitHub's 20-cap, but the README + npm description references also got trimmed. v3.7.8 restores OpenClaw discoverability:
+
+- **README** — added to 5 agent-list mentions: image alt text, hero bold line, "What it is" lead paragraph, Use case #1, comparison matrix "MCP-native" row.
+- **`package.json#description`** — agent list now reads "Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client". Also: the description NOW LEADS with "The most advanced Obsidian MCP — long-term memory for AI agents." (matching the GitHub About).
+- **GitHub About** (out-of-band via `gh api`): replaced with `"The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + ML + BGE rerank, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question), standalone Bases, PDFs+OCR. For Claude Code/Desktop, Cursor, ChatGPT, Codex, OpenClaw. MCP-native, MIT, SLSA-3."` (288 chars, fits the 350 limit).
+- **GitHub Topics** (out-of-band via `gh api`): swapped `context-engineering` → `openclaw`. New 20-topic set: `obsidian, obsidian-mcp, mcp-server, model-context-protocol, claude, claude-code, cursor, chatgpt, codex, openclaw, rag, agentic-rag, hybrid-search, semantic-search, ai-memory, agent-memory, llm-memory, long-term-memory, claude-memory, second-brain`.
+
+`context-engineering` was the safest drop from the 20-cap: it's the most jargon-heavy of the agent-memory keywords (low natural-search volume vs `ai-memory`, `agent-memory`, `llm-memory`, `long-term-memory`, `claude-memory` which it overlaps with). `openclaw` brings unique discoverability for the dedicated client community.
+
+### Tests
+
+**786 tests** — unchanged. No code paths touched, no test additions, no coverage delta. Lint clean, `tsc` strict + `noUncheckedIndexedAccess` clean, version-consistency green at `3.7.8` (5 surfaces), all K-1 invariants green.
+
+### Migration
+
+**No-op for every consumer.** Zero code/API/behavior/schema changes. Same npm install, same wire format. Visible surfaces:
+- GitHub About + Topics — updated instantly (out-of-band, already live)
+- README — instantly after merge
+- npm description — after `npm publish`
+
+OpenClaw users specifically benefit: the repo is now discoverable via the `openclaw` topic + README references → easier for the OpenClaw community to find the recommended Obsidian memory backend.
+
+### Method note
+
+Positioning continues to be a calibration exercise (per v3.6.3 method note: *"positioning isn't a one-time launch decision — it's continuous calibration"*). The "most advanced Obsidian MCP" credential and the "memory for AI agents" value-prop are **complementary**, not mutually-exclusive: this patch restores the both-and framing rather than the v3.7.7 either-or compromise. OpenClaw discoverability is a smaller-but-similar calibration — the v3.6.3 rebalance traded it for general-hype keywords; v3.7.8 trades back one of those (the least-discoverable one) to restore the dedicated-community pathway.
+
+---
+
 ## [3.7.7] — 2026-05-16
 
 > **TL;DR:** Visual + marketing refresh. New `assets/social-preview.png` leads with the emotional value prop ("Long-term memory for AI agents") and a visual flow showing vault → enquire-mcp → 5 AI agents — replaces the previous engineering-stats-heavy preview. README hero rewritten with **"The problem / The solution"** framing + sticky nav links + a clear 3-bullet differentiation block. **Zero code changes.** 786 tests unchanged. The visual + copy hierarchy is now optimized for first-time visitor conversion (3-second value-prop comprehension); technical depth is preserved but moved below the fold.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-<a href="https://github.com/oomkapwn/enquire-mcp"><img src="./assets/social-preview.png" alt="enquire-mcp — long-term memory for AI agents. Built on your Obsidian vault. Open-source, MCP-native, vendor-neutral. Hybrid retrieval, BGE reranker, HNSW, PDFs with OCR. For Claude Code, Claude Desktop, Cursor, ChatGPT, Codex." width="100%"></a>
+<a href="https://github.com/oomkapwn/enquire-mcp"><img src="./assets/social-preview.png" alt="enquire-mcp — the most advanced Obsidian MCP. Long-term memory for AI agents. Built on your Obsidian vault. Open-source, MCP-native, vendor-neutral. Hybrid retrieval, BGE reranker, HNSW, PDFs with OCR. For Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw." width="100%"></a>
 
 # enquire-mcp
 
-### Long-term memory for AI agents. Built on your Obsidian vault.
+### The most advanced Obsidian MCP. Long-term memory for AI agents.
 
-**Stop re-explaining context to Claude, Cursor, ChatGPT every session. Your Obsidian notes become shared, searchable memory across every MCP-compatible agent — your knowledge, every model, forever yours.**
+**Stop re-explaining context to Claude, Cursor, ChatGPT, Codex, OpenClaw every session. Your Obsidian notes become shared, searchable memory across every MCP-compatible agent — your knowledge, every model, forever yours.**
 
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
@@ -29,7 +29,7 @@ Every AI session starts from zero. You re-explain your project, your design deci
 
 ## The solution
 
-Your Obsidian vault becomes **persistent, queryable long-term memory** for any MCP-compatible agent. One install — your knowledge is instantly accessible from Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and every other MCP client. Plain markdown files **you own**, indexed locally, searched with the full modern IR stack, recalled across every session and every model.
+Your Obsidian vault becomes **persistent, queryable long-term memory** for any MCP-compatible agent. One install — your knowledge is instantly accessible from Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and every other MCP client. Plain markdown files **you own**, indexed locally, searched with the full modern IR stack, recalled across every session and every model.
 
 > **Three things make enquire-mcp different**:
 > 1. **Vendor-neutral.** Your memory lives in `.md` files. Switch from Claude to Cursor — your memory comes with you.
@@ -74,7 +74,7 @@ enquire-mcp doctor --vault <path>    # color-coded ✓/⚠/✗ health check
 
 ## 🧠 Use cases
 
-**1 — Long-term memory for AI agents.** Drop your Obsidian vault into any MCP-compatible agent (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex). The agent now has durable, semantic recall over every meeting note, journal entry, research log, and decision doc you've ever written — across sessions, models, and providers. Unlike `Claude Memory` or `ChatGPT Memory`, your knowledge isn't locked into one vendor's cloud; it lives in plain markdown you own and can migrate freely.
+**1 — Long-term memory for AI agents.** Drop your Obsidian vault into any MCP-compatible agent (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw). The agent now has durable, semantic recall over every meeting note, journal entry, research log, and decision doc you've ever written — across sessions, models, and providers. Unlike `Claude Memory` or `ChatGPT Memory`, your knowledge isn't locked into one vendor's cloud; it lives in plain markdown you own and can migrate freely.
 
 **2 — Personal knowledge base / second brain.** Hybrid retrieval surfaces the right note for *any* phrasing, in any of 50+ languages. Ask in English about a Russian-language journal entry from 2 years ago, get the right hit. Wikilink graph-boost reranks notes that sit at the centre of your knowledge graph. GraphRAG-light surfaces topical communities — discover connections you forgot you made. PDFs blend into search with `[page: N]` citations so research papers and meeting transcripts become first-class memory.
 
@@ -106,7 +106,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **Built-in retrieval-quality eval harness** (NDCG, Recall, MRR, A/B matrix) | ✅ | ❌ | ❌ |
 | **Remote MCP** over HTTP + bearer auth + stateful sessions | ✅ | ❌ | partial |
 | **Per-signal observability** per hit | ✅ | ❌ | ❌ |
-| **MCP-native** (Claude · Cursor · ChatGPT · Codex · any client) | ✅ | ❌ Obsidian-only | varies |
+| **MCP-native** (Claude · Cursor · ChatGPT · Codex · OpenClaw · any client) | ✅ | ❌ Obsidian-only | varies |
 | **Privacy filter** verified at every search + write path | ✅ | n/a | ❌ |
 | **44 production tools** (33 always-on read tools + 4 opt-in + 7 gated writes) | ✅ | n/a | varies |
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.7.7",
+      "version": "3.7.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.7.7",
-  "description": "Memory layer for AI agents over your Obsidian vault. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, and any MCP client. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 786 tests, SLSA-3, semver-bound, MIT.",
+  "version": "3.7.8",
+  "description": "The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client. 44 tools, 19 MCP prompts, 5 cross-encoder reranker models, 786 tests, SLSA-3, semver-bound, MIT.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.7.7";
+export const VERSION = "3.7.8";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below


### PR DESCRIPTION
## Summary

Two positioning calibrations from the v3.6.3 → v3.7.7 marketing cascade. Zero code changes.

### 1. \"The most advanced Obsidian MCP\" credential restored

- v3.6.3 demoted it from primary headline to secondary line
- v3.7.7 dropped the secondary line entirely (pain-point hook replaced it)
- **v3.7.8 restores it to the H3 subtitle**: `\"The most advanced Obsidian MCP. Long-term memory for AI agents.\"`

The pain-point bold below stays — both-and framing, not either-or.

### 2. OpenClaw discoverability restored

- v3.6.3 rebalanced GitHub Topics inside the 20-cap; `openclaw` was dropped to fit 8 hype keywords
- v3.7.8 adds OpenClaw back to:
  - 5 README surfaces (image alt text, hero bold line, \"What it is\", Use case #1, comparison matrix)
  - `package.json#description`
  - GitHub About (out-of-band via `gh api`)
  - GitHub Topics (out-of-band: swapped `context-engineering` for `openclaw` — least-discoverable hype keyword replaced)

## Updated GitHub repo metadata (already live)

**About**: `\"The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + ML + BGE rerank, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question), standalone Bases, PDFs+OCR. For Claude Code/Desktop, Cursor, ChatGPT, Codex, OpenClaw. MCP-native, MIT, SLSA-3.\"`

**Topics (20)**: `obsidian, obsidian-mcp, mcp-server, model-context-protocol, claude, claude-code, cursor, chatgpt, codex, openclaw, rag, agentic-rag, hybrid-search, semantic-search, ai-memory, agent-memory, llm-memory, long-term-memory, claude-memory, second-brain`

## Test plan

- [x] `npm test` — 785 passing + 1 skipped (786 total, unchanged)
- [x] `npx tsc --noEmit` — strict + noUncheckedIndexedAccess clean
- [x] `npx biome check` — clean (1 info pre-existing)
- [x] `node scripts/check-version-consistency.mjs` — green at 3.7.8
- [x] All K-1 invariants green
- [ ] 12/12 CI gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)