### PR TITLE
v3.7.17: round-19 audit response + OIA methodology fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.17] — 2026-05-19
+
+> **TL;DR:** Round-19 external audit response — 6th independent external audit since v3.6.0, on the v3.7.5 codebase (4 days behind current main). Most findings were already closed by the v3.7.6 → v3.7.16 cascade; this patch addresses 5 **cheap stale-fragment findings** the auditor caught that my internal class-sweeps had missed (A: `src/index.ts` file-header reading as if 3.6.0-rc.2 is current, B: `CLAUDE.md` title + quality bar still saying "v3.6.0 sprint" + "712+ tests", C: `scripts/check-changelog-coverage.mjs` referencing non-existent `npm run check:coverage-drift`, D: `embeddings.ts` inline comment claiming `rerank-multilingual` is the default since v3.6.1 it's actually `rerank-bge`, E: README CI claim about CodeQL ×2 + Analyze actions — they DO run via GitHub default-setup, but the README didn't say so, looking like a workflow-file claim without evidence). **PLUS a meta-methodology fix:** the new `scripts/oia-walk.mjs` automates 5 state-driven outside-in checks that my change-driven sweeps systematically miss. **New CLAUDE.md rule** mandates `npm run check:oia` before claiming "no open audit items" in any release.
+
+**Patch — round-19 stale-fragment cleanup + Outside-In Audit (OIA) methodology fix.**
+
+### Cheap stale-fragment fixes (5)
+
+| # | Finding | File | Resolution |
+|---|---------|------|-----------|
+| A | `// Slim entry point for enquire-mcp. Version 3.6.0-rc.2 split the previous 3665-line monolith` — reads as currency claim | `src/index.ts:2` | Rewrote header to explicitly mark as History: rc.2 split, with current state separately. Same module description preserved as historical context. |
+| B | `# Project goal — v3.6.0 sprint` + `1. 712+ tests pass` — CLAUDE.md title locked at v3.6.0 sprint despite cascade running to v3.7.17 | `CLAUDE.md:1, 23` | Title now `v3.7.x maintenance + v3.8.0 architectural`; v3.6.0 sprint preserved as historical context section; test count claim re-phrased to "All tests pass (current count: 818+ at v3.7.17)" so future test additions don't require a CLAUDE.md edit. |
+| C | Docstring references `npm run check:coverage-drift` — never existed | `scripts/check-changelog-coverage.mjs:26` | Pointed to the real `npm run check:changelog-coverage`. The reference was a "would-be name" the original author never created. |
+| D | Inline comment near `rerank-multilingual-large` says `(rerank-multilingual default)` — but `DEFAULT_RERANKER_ALIAS = "rerank-bge"` since v3.6.1 CRIT-2 | `src/embeddings.ts:306` | Expanded comment to clarify `rerank-multilingual` is the MULTILINGUAL variant, NOT the project-wide default, and cross-referenced `DEFAULT_RERANKER_ALIAS`. |
+| E | README CI gates row claims `CodeQL ×2 · Analyze actions` but no matching `.github/workflows/*.yml` — auditor flagged as "claim without evidence" | `README.md:185` | Annotated the claim to clarify CodeQL/Analyze run via [GitHub default-setup](https://docs.github.com/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-default-setup-for-code-scanning) (the workflow-file route is one path; default-setup is the other). Both routes produce check-runs visible in `gh pr checks`. |
+
+### Outside-In Audit (OIA) methodology fix
+
+**The meta-finding from round-19:** every external auditor since v3.6.0 has found cheap stale fragments that my internal class-sweeps systematically miss. Root cause: my methodology is **change-driven** (look at what changed, fix the class, verify nearby) while external audits are **state-driven** (read every file as it exists today, verify each claim against reality). These find non-overlapping failure modes.
+
+**My methodology's specific blind spots** (catalogued from the 6 external audit cycles):
+
+1. **Recency bias** — files I haven't edited in N releases fall out of attention. `src/index.ts:2` was never touched in v3.7.x.
+2. **Trust my own ledger** — CHANGELOG says "v3.7.13 H3 bumped engines.node"; I treat as canonical without grep-verifying every file.
+3. **Class-pattern sweeps assume the class is in my mental model** — I sweep TOCTOU, TSDoc drift, hardcoded counts. I didn't enumerate "claim about CI workflows that don't exist" or "CLI subcommand referenced in docs but not in cli.ts" as classes until the auditor named them.
+4. **Pre-merge RCA sweep (v3.7.15 rule) is narrow** — it sweeps the patch's diff for class siblings. Doesn't sweep stale fragments NOT touched by this PR.
+5. **Marketing copy = read-only** — I update gated counts but don't routinely diff hero / tagline / badge against reality.
+6. **File-level vs function-level docstrings** — round-18 catch was function-level; file-level (first 30 lines) almost never re-read.
+7. **Project meta-docs not walked** — I update bodies (e.g. CLAUDE.md "Current phase status") but never re-read titles.
+8. **Utility scripts = black box** — I *run* `scripts/check-*.mjs`; I don't *read* their docstrings.
+9. **Historical vs current inline comments** — tombstones (`// v3.6.1 CRIT-2 — was X`) are legitimate history. Current-claim comments (`(rerank-multilingual default)`) drift silently. I don't distinguish.
+10. **Internal mental model becomes the lens** — I have a model of "current project state" (3.7.17, 818 tests, BGE default). When I look at code, I VALIDATE its conformance to my model. If code drifted but the model didn't, I can't see the drift.
+
+**Solution: `scripts/oia-walk.mjs`** (`npm run check:oia`). Five state-driven walks that automate what external auditors do manually:
+
+1. **STALE-CURRENCY-CLAIM** — scan first 30 lines of every `src/**/*.ts` for currency-claim patterns ("Version X.Y.Z", "rc.N", "alpha.N", "beta.N") not marked as historical (History:, Pre-, was, since, previously). Refined heuristic after a noisy first pass that flagged 21 legitimate tombstones — now only flags claims of currency, not feature-history notes.
+2. **WORKFLOW-CLAIM-WITHOUT-EVIDENCE** — README claims about CI workflows (CodeQL, Analyze) must have either a matching `.github/workflows/*.yml` OR a "default-setup" annotation.
+3. **CLI-SUBCMD-MISSING** — every `enquire-mcp <cmd>` reference in `docs/*.md` (excluding `docs/audits/`) must match a `program.command("<cmd>")` in `src/cli.ts`.
+4. **NPM-SCRIPT-MISSING** — every `npm run <script>` reference in `docs/*.md` and `scripts/*.mjs` docstrings must match `package.json#scripts`.
+5. **STALE-DEFAULT-CLAIM** — heuristic match: inline comments claiming `"X is the default"` are cross-checked against exported `DEFAULT_*` constants in the same file.
+
+**New CLAUDE.md rule (added in this patch):** *"Internal change-driven sweeps miss state-driven failure modes — run OIA before claiming 'no open findings'."* Sits alongside the v3.7.15 "pre-merge RCA sweep" rule. Together they cover both inside-out (RCA on the patch's classes) and outside-in (OIA on the whole repo) audit dimensions.
+
+### Architectural findings still OPEN at v3.7.17 (round-19 audit)
+
+These are documented v3.8+ deferrals — the round-19 auditor found them, and they remain open by design until the next minor:
+
+- **K-3 — Generalized `readOnlyHint: true` → no destructive operations invariant.** Per v3.7.5 CHANGELOG. Closes the K-1 sibling class structurally.
+- **Watcher doesn't sync embed-db on .md changes.** P1-5 (v3.7.16) closed PDF lifecycle in watcher; embed-db sync requires the embedder pipeline in the watcher process (architectural — adds ML deps to the watcher path).
+- **No per-file mutex in watcher.** Parallel chokidar events for the same file race; last-write-wins. Acceptable for now but not for high-frequency vault changes.
+- **CHANGELOG 469 KB** — historical noise. Open by design. Periodic compaction TBD.
+- **`docs/audits/*`** — internal finding notes; some have `fixed` status in the file body that doesn't match overall file framing. Excluded from npm tarball since v3.7.13 L7.
+- **Audit level inconsistency** — PR CI: `npm audit --audit-level=moderate` for prod deps; release.yml: `--audit-level=high`. Architectural choice — should be unified or explicitly documented.
+
+### Stats
+
+- **818 tests** (unchanged; v3.7.17 is a documentation + stale-fragment patch, no new code-paths to test).
+- **+0 docs-consistency invariants** added (the OIA script's STALE-DEFAULT-CLAIM check covers the heuristic; structural invariants are added incrementally when patterns recur).
+- **+1 new gate script**: `npm run check:oia` (advisory in this release; required CI gate scheduled for v3.7.18 once it's been validated in production for one release cycle).
+- All 8 required CI gates pass locally.
+
+### Method
+
+Round-19 closes the most important methodological gap of the v3.6.0 → v3.7.17 cascade: **external audits will always find what internal audits miss UNLESS the internal methodology explicitly includes state-driven walks.** Pre-3.7.17 my methodology was 100% change-driven (class sweeps, TSDoc verification on touched files, pre-merge RCA on the patch diff). Adding `oia-walk.mjs` + the CLAUDE.md rule introduces the missing state-driven dimension. **Net effect: round-20 should find significantly fewer stale fragments — if it still does, the OIA script needs another check pattern added.**
+
 ## [3.7.16] — 2026-05-18
 
 > **TL;DR:** Round-18 external audit response — 5th independent external audit since v3.6.0, run on the v3.7.5 codebase (commit `b9daf39`). The cascade v3.7.6 → v3.7.15 had already closed many findings; this patch addresses the still-open critical + high-impact items. **10 fixes** landed: 5 P1 High (OCR network disclosure + 200-page cap, persistent cache + privacy filters, PDF watcher lifecycle, macOS case-insensitive write bypass), 3 P2 Medium (title-based write ambiguity = silent data corruption, validateNoteProposal privacy check, FTS5 tag LIKE wildcard escape), 2 P3 Low (PDF install hint version, FTS5 reserved-word quoting, issue template ChatGPT). Plus 1 graph-boost path bug (P2-16, C# Notes.md). **+0 tests** (1 test contract change for P3-28). 4 architectural findings deferred to v3.8.0 (serve-http parity, FTS5/embedding chunking parity, search underfill, OCR timeout/concurrency).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,18 @@
-# Project goal — v3.6.0 sprint
+# Project goal — v3.7.x maintenance + v3.8.0 architectural
 
 This file is read by Claude Code sessions on this repo. It defines the current sprint goal, scope, quality bar, and anti-patterns so any session (continuation or new) shares the same North Star.
 
+**v3.6.0 stable shipped on 2026-05-15.** The current cascade (v3.6.0 → v3.7.17+) is the post-release maintenance + audit-driven hardening line. v3.8.0 is the architectural-changes milestone (HNSW filter-during-search, embed-db migrations, distributed rate-limit, watcher embed-db sync, K-3 readOnlyHint invariant, etc.).
+
 ---
 
-## Goal
+## Goal (historical — v3.6.0 sprint, shipped 2026-05-15)
 
-Release **enquire-mcp v3.6.0** per the planned RC sequence (or better — if mid-sprint observation reveals additional drift classes or quality improvements, extend scope, don't defer).
+Released **enquire-mcp v3.6.0** per the planned RC sequence. This section is preserved as historical context — the sprint is closed.
 
 Directive: **"Максимальное качество и уверенный топ-1 из всех Obsidian MCP по технологии и надёжности."**
 
-## Scope — RC sequence + promotion
+## Scope (closed) — v3.6.0 RC sequence + promotion
 
 - **v3.6.0-rc.1**: `tools.ts` (4252 lines) → 5 domain modules in `src/tools/` + barrel
 - **v3.6.0-rc.2**: `index.ts` (3665 lines) → `src/cli.ts` + `src/server.ts` + `src/prompts.ts` + `src/tool-registry.ts` + `src/tool-manifest.ts`
@@ -18,9 +20,9 @@ Directive: **"Максимальное качество и уверенный т
 - **v3.6.0-rc.4**: TypeDoc + GH Pages auto-generated API reference + Public benchmarks (`docs/benchmarks.md`, MRR/NDCG@10/Recall@K vs 3 main competitors)
 - **v3.6.0 (stable)**: promote rc.4 → npm `latest`, GH release marked Latest
 
-## Quality bar — required on every RC (no exceptions)
+## Quality bar — required on every release (no exceptions)
 
-1. 712+ tests pass (some RCs may add tests from coverage redistribution)
+1. All tests pass (current count: 818+ at v3.7.17; tests grow with each audit cycle — see CHANGELOG)
 2. Lint clean (biome 0 warnings/errors)
 3. `tsc` strict + `noUncheckedIndexedAccess` clean
 4. Coverage thresholds met (lines ≥86, statements ≥82, functions ≥75, branches ≥74)
@@ -73,6 +75,7 @@ Directive: **"Максимальное качество и уверенный т
 - **TSDoc header drifts from function body** — every overclaim instance since v3.6.1 (7 documented) has the same shape: code changed inside a function, but the function-level TSDoc / file-header / block-comment describing the behavior wasn't updated in the same commit. TypeDoc + IDE hover then publish the stale (lying) description. **Rule since v3.7.15**: every fix that changes function internals MUST include the matching TSDoc header update in the same commit; reviewers MUST diff the header alongside the body. Examples of the drift: v3.7.14 F1 (renameNote body fixed, header lied), v3.7.14 F2 inside the SAME patch (renameFile body fixed by F2, header still said "Atomic via fs.rename").
 - **Single class-sweep is not enough — same-release recursion happens** — v3.7.14 F1 fixed overclaim #6, and v3.7.14 F2 SHIPPED overclaim #7 inside the very same patch. The author of an audit-driven fix sees the immediate problem but doesn't apply the lesson to OTHER changes in the same diff. **Rule since v3.7.15**: after every audit-driven release that closes a "class" finding (overclaim, TSDoc drift, TOCTOU, etc.), run a post-merge re-sweep specifically scanning that patch's own diff for fresh instances of the same class. The recursion rate observed across v3.6.x-v3.7.x is high enough that this is a required step, not optional.
 - **Tag the SQUASH-MERGE commit on main, not the feature-branch HEAD** — v3.7.14 was tagged against the pre-merge branch SHA (orphan, not on main), and `.github/workflows/release.yml`'s "Assert tag is on main" guard correctly refused to publish (overclaim #8). The CHANGELOG implied the ship completed before it actually did. **Rule since v3.7.15**: the post-merge release procedure is *always*: `git checkout main` → `git pull origin main` → `git log -1 --oneline` (capture the squash-merge SHA) → `git tag vX.Y.Z <that-SHA>` → `git push origin vX.Y.Z`. Never tag from a feature branch — the squash-merge produces a NEW commit whose SHA differs from the branch HEAD.
+- **Internal change-driven sweeps miss state-driven failure modes — run OIA before claiming "no open findings"** — every external auditor since v3.6.0 has found stale fragments that internal class-sweeps missed: README badges, CLAUDE.md titles, file-header comments, stale CLI references in docs, stale npm-script references in script docstrings. Root cause: my methodology is CHANGE-DRIVEN (look at what changed, fix the class, verify nearby) while external audits are STATE-DRIVEN (read every file as it exists, verify each claim against reality). These find non-overlapping failure modes. **Rule since v3.7.17**: run `npm run check:oia` (`scripts/oia-walk.mjs`) before claiming "no open audit items" in any release. The script automates the 5 cheap state-driven walks: stale currency claims in file headers, CI workflow existence vs README claims, CLI subcommand existence vs docs references, npm script existence vs script-docstring references, and inline-comment default-value claims vs exported `DEFAULT_*` constants. Default mode exits 1 on any finding; `--allow` overrides for documented architectural deferrals. **Round-19 (v3.7.17) shipped the rule + the script after the 5th external audit caught 4 cheap stale fragments my v3.7.16 pre-merge RCA missed.**
 
 ## Method note
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Plus 3 MCP resources (`obsidian://vault/info`, `obsidian://note/{path}`, `obsidi
 | **HTTP transport** | Bearer auth (constant-time SHA-256 + `timingSafeEqual`), per-token rate-limit, strict CORS |
 | **Frontmatter** | `gray-matter` (`js-yaml` safeLoad) — no code execution |
 | **Cache + index files** | chmod 0600, parent dir 0700 |
-| **CI** | **8 required** branch-protection gates (lint · test ×2 [Node 22/24] · smoke · audit · coverage · version-consistency · docs) + **4 advisory** (test-macos · CodeQL ×2 · Analyze actions). Release workflow re-verifies all 8 required passed on tagged SHA before npm publish. _v3.7.10 — `docs` (TypeDoc generation gate) added to required set. v3.7.13 — `engines.node` floor bumped to `>=22.13.0` to match the CI matrix._ |
+| **CI** | **8 required** branch-protection gates (lint · test ×2 [Node 22/24] · smoke · audit · coverage · version-consistency · docs) + **4 advisory** (test-macos via `.github/workflows/ci.yml`; CodeQL ×2 + Analyze actions via [GitHub default-setup](https://docs.github.com/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-default-setup-for-code-scanning) — not workflow files in `.github/workflows/`). Release workflow re-verifies all 8 required passed on tagged SHA before npm publish. _v3.7.10 — `docs` (TypeDoc generation gate) added to required set. v3.7.13 — `engines.node` floor bumped to `>=22.13.0` to match the CI matrix._ |
 | **Coverage** | Lines ≥86% · statements ≥82% · functions ≥75% · branches ≥74% (gated) |
 | **Releases** | npm + GitHub release per tag · semver · **SLSA-3** build provenance |
 | **Stability** | v3.0+ semver-bound — every CLI flag, tool name, MCP resource, prompt, exported symbol is contract |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.7.16",
+  "version": "3.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.7.16",
+      "version": "3.7.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.7.16",
+  "version": "3.7.17",
   "description": "The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client. 44 tools, 19 MCP prompts, BGE cross-encoder reranker verified end-to-end (+4 aliases in catalog, transformers.js bump pending), 818 tests, SLSA-3, semver-bound, MIT.",
   "type": "module",
   "bin": {
@@ -72,6 +72,7 @@
     "test:coverage": "vitest run --coverage",
     "check:changelog-coverage": "node scripts/check-changelog-coverage.mjs",
     "check:per-file-coverage": "node scripts/check-per-file-coverage.mjs",
+    "check:oia": "node scripts/oia-walk.mjs",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "format": "biome format --write",

--- a/scripts/check-changelog-coverage.mjs
+++ b/scripts/check-changelog-coverage.mjs
@@ -23,7 +23,9 @@
  *
  * Integration:
  *   - CI `coverage` job runs both, fails on exit 1.
- *   - Local: `npm run check:coverage-drift` after `npm run test:coverage`.
+ *   - Local: `npm run check:changelog-coverage` (NOT `coverage-drift` — the
+ *     latter never existed; round-19 audit caught the stale reference).
+ *     Run after `npm run test:coverage` to refresh `coverage-summary.json`.
  *   - `prepublishOnly` adds it to the safety net (so we never publish a
  *     release tag whose CHANGELOG has wrong stats).
  */

--- a/scripts/oia-walk.mjs
+++ b/scripts/oia-walk.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// Outside-In Audit (OIA) walk.
+//
+// Added in v3.7.17 (round-19) to close the meta-finding: external
+// auditors consistently find stale fragments that internal class-sweeps
+// miss because the internal methodology is CHANGE-DRIVEN (look at what
+// changed, fix the class, verify nearby) while external audits are
+// STATE-DRIVEN (read every file as it exists today, verify each claim
+// against reality).
+//
+// The internal pre-merge RCA sweep (CLAUDE.md rule since v3.7.15) only
+// scans the current patch's diff for class siblings. It does NOT scan
+// stale fragments in files the patch didn't touch — those are the
+// auditor's hunting ground.
+//
+// This script automates the cheap state-driven walks. Run before claiming
+// "no open audit items" in any release.
+//
+// Usage:
+//   node scripts/oia-walk.mjs            # walk, print findings, exit 1 if any
+//   node scripts/oia-walk.mjs --allow    # walk, print findings, always exit 0
+//
+// Checks (all evidence-based — each finding includes file:line and the
+// matched fragment):
+//
+//   1. STALE VERSION TOMBSTONES — `vX.Y.Z` or `X.Y.Z-rc.N` references
+//      in file-header docstrings (first 30 lines of every src/*.ts file)
+//      that aren't tagged as historical context (no `History:` or
+//      `Pre-3.X` lead-in).
+//
+//   2. WORKFLOW EXISTENCE — every CI workflow name referenced in README /
+//      docs (e.g. "CodeQL", "Analyze") must exist as `.github/workflows/
+//      *.yml` OR be explicitly annotated as "via GitHub default-setup".
+//
+//   3. CLI SUBCOMMAND EXISTENCE — every backticked `enquire-mcp <cmd>`
+//      reference in docs/*.md must match a `program.command("<cmd>")`
+//      in `src/cli.ts`.
+//
+//   4. NPM SCRIPT EXISTENCE — every backticked `npm run <script>` in
+//      docs/*.md and scripts/*.mjs comments must match `package.json#scripts`.
+//
+//   5. CURRENT-CLAIM vs TOMBSTONE — comments referring to a "default"
+//      value (e.g. "rerank-multilingual default") must agree with the
+//      actual exported default constant in the same file.
+//
+// Exit codes:
+//   0 — no findings (or --allow flag passed)
+//   1 — at least one finding (full diagnostic to stderr)
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+const ALLOW_MODE = process.argv.includes("--allow");
+
+/** All findings as a flat array. Each entry: { file, line, kind, evidence, hint }. */
+const findings = [];
+
+function record(kind, file, line, evidence, hint) {
+  findings.push({ kind, file, line, evidence, hint });
+}
+
+function readLines(rel) {
+  return readFileSync(join(repoRoot, rel), "utf8").split("\n");
+}
+
+function walk(dir, ext, callback) {
+  for (const entry of readdirSync(join(repoRoot, dir), { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name.startsWith(".")) continue;
+      walk(join(dir, entry.name), ext, callback);
+    } else if (entry.name.endsWith(ext)) {
+      callback(join(dir, entry.name));
+    }
+  }
+}
+
+// ─── Check 1: STALE CURRENCY CLAIMS (not historical tombstones) ─────────
+//
+// The KEY DISTINCTION:
+//
+//   • `// v3.5.0 — link predicates added (uses outbound wikilink set)`
+//     → HISTORICAL TOMBSTONE (feature added in v3.5.0; legitimate)
+//
+//   • `// Version 3.6.0-rc.2 split the previous 3665-line monolith`
+//     → STALE CURRENCY CLAIM (reads as if 3.6.0-rc.2 is current)
+//
+// The first round-19 OIA run flagged 21 findings, 20 of which were
+// legitimate tombstones (the `vX.Y.Z — feature` pattern). Refined
+// heuristic now ONLY flags PATTERNS THAT CLAIM CURRENCY:
+//   - "Version X.Y.Z" (no em-dash following, no "was/since" qualifier)
+//   - "X.Y.Z-rc.N" / "X.Y.Z-alpha" / "X.Y.Z-beta" — pre-release tags
+//     should NEVER appear in a current-state claim
+//   - "current X.Y.Z" / "as of X.Y.Z"
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const currentVersion = pkg.version;
+
+// Currency-claim patterns. Each pattern is a regex that captures a
+// version number AND demonstrates a currency claim (not a history note).
+const CURRENCY_CLAIM_PATTERNS = [
+  // "Version X.Y.Z" without preceding "current is" / "was" / "Pre-"
+  /(?<!\w)Version\s+(\d+\.\d+\.\d+)\b(?!\s*[-—])/,
+  // "rc.N" or "alpha.N" or "beta.N" — pre-release tags only appear in
+  // current-state claims (legit history always says "vX.Y.Z added", not
+  // "vX.Y.Z-rc.N added").
+  /\b(\d+\.\d+\.\d+-(?:rc|alpha|beta)\.\d+)/
+];
+
+walk("src", ".ts", (file) => {
+  const lines = readLines(file).slice(0, 30);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!/^\s*\*|^\s*\/\/|^\s*\/\*/.test(line)) continue;
+    for (const pattern of CURRENCY_CLAIM_PATTERNS) {
+      const m = pattern.exec(line);
+      if (!m) continue;
+      const ver = m[1];
+      if (ver === currentVersion) continue; // current — OK
+      // Skip if surrounding lines provide history context.
+      const context = lines.slice(Math.max(0, i - 2), Math.min(lines.length, i + 3)).join(" ");
+      if (/\b(History|Pre-|was\s+|legacy|tombstone|previously)\b/i.test(context)) continue;
+      record(
+        "STALE-CURRENCY-CLAIM",
+        file,
+        i + 1,
+        line.trim(),
+        `Reads as currency claim for v${ver} but current is v${currentVersion}. Either prefix with "History:" / "Pre-" to mark as tombstone, or update.`
+      );
+    }
+  }
+});
+
+// ─── Check 2: Workflow existence ────────────────────────────────────────
+// Find every backticked "CodeQL", "Analyze", "smoke", etc. CI gate name
+// in README/docs and verify it exists either as a .github/workflows/*.yml
+// file OR is documented as "default-setup".
+const workflowDir = join(repoRoot, ".github", "workflows");
+const workflowFiles = existsSync(workflowDir) ? readdirSync(workflowDir).filter((f) => f.endsWith(".yml")) : [];
+const workflowJobs = new Set();
+for (const wf of workflowFiles) {
+  const yml = readFileSync(join(workflowDir, wf), "utf8");
+  // Job names like `lint:`, `test:`, etc. Detected by ^\s\s<name>:\n\s\s\sruns-on
+  for (const m of yml.matchAll(/^\s\s([a-z][a-z0-9-]*):\n[\s\S]*?runs-on:/gm)) {
+    workflowJobs.add(m[1]);
+  }
+}
+
+// Specific check from round-19: README claims "CodeQL ×2" + "Analyze actions"
+// in the advisory CI gates section. The actual CodeQL setup is via GitHub
+// default-setup (no workflow file). The README should mention this OR
+// the workflow files should exist. (Either path resolves the auditor's
+// "claim vs reality" finding.)
+const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
+const README_CI_CLAIMS = ["CodeQL", "Analyze actions"];
+for (const claim of README_CI_CLAIMS) {
+  if (readme.includes(claim)) {
+    const hasWorkflowFile = workflowFiles.some((f) =>
+      readFileSync(join(workflowDir, f), "utf8").toLowerCase().includes(claim.toLowerCase())
+    );
+    const hasDefaultSetupNote = readme.toLowerCase().includes("default-setup");
+    if (!hasWorkflowFile && !hasDefaultSetupNote) {
+      record(
+        "WORKFLOW-CLAIM-WITHOUT-EVIDENCE",
+        "README.md",
+        readme.split("\n").findIndex((l) => l.includes(claim)) + 1,
+        `Claims "${claim}" but no matching workflow file and no "default-setup" annotation.`,
+        `Either add the workflow YAML, or annotate the README to clarify the gate comes from GitHub default-setup.`
+      );
+    }
+  }
+}
+
+// ─── Check 3: CLI subcommand existence ──────────────────────────────────
+const cliSrc = readFileSync(join(repoRoot, "src", "cli.ts"), "utf8");
+const registeredSubs = new Set([...cliSrc.matchAll(/program\s*\n?\s*\.command\(\s*"([^"]+)"/g)].map((m) => m[1]));
+
+walk("docs", ".md", (file) => {
+  // Skip docs/audits — internal-only finding notes (excluded from npm
+  // tarball since v3.7.13 L7). These often contain HYPOTHETICAL references
+  // like "the `enquire-mcp dump-index` command if one exists" — flagging
+  // them produces false positives. The cost of skipping is that genuine
+  // stale audit-doc references slip through; we accept that for now since
+  // user-facing docs (docs/*.md root) are what end users see.
+  if (file.startsWith("docs/audits/") || file.startsWith("docs\\audits\\")) return;
+  const lines = readLines(file);
+  for (let i = 0; i < lines.length; i++) {
+    // Match `enquire-mcp <cmd>` and verify <cmd> exists in cli.ts.
+    for (const m of lines[i].matchAll(/`enquire-mcp\s+([a-z][a-z0-9-]*)\b/g)) {
+      const cmd = m[1];
+      if (!registeredSubs.has(cmd)) {
+        record(
+          "CLI-SUBCMD-MISSING",
+          file,
+          i + 1,
+          m[0],
+          `docs reference \`enquire-mcp ${cmd}\` but src/cli.ts has no program.command("${cmd}"). Either add the subcommand or drop the reference.`
+        );
+      }
+    }
+  }
+});
+
+// ─── Check 4: npm script existence ──────────────────────────────────────
+const npmScripts = new Set(Object.keys(pkg.scripts ?? {}));
+
+const npmRefSources = ["docs", "scripts"];
+for (const sourceDir of npmRefSources) {
+  walk(sourceDir, sourceDir === "scripts" ? ".mjs" : ".md", (file) => {
+    const lines = readLines(file);
+    for (let i = 0; i < lines.length; i++) {
+      for (const m of lines[i].matchAll(/`npm run\s+([a-z][a-z0-9:-]*)`/g)) {
+        const script = m[1];
+        if (!npmScripts.has(script)) {
+          record(
+            "NPM-SCRIPT-MISSING",
+            file,
+            i + 1,
+            m[0],
+            `Reference to \`npm run ${script}\` but package.json#scripts has no such entry. Either add the script or fix the reference.`
+          );
+        }
+      }
+    }
+  });
+}
+
+// ─── Check 5: Current-claim vs tombstone for "default" inline comments ──
+// Look for comments like "X is the default" / "(X default)" / "default X"
+// in src/*.ts and cross-check against exported DEFAULT_* constants in
+// the same file. This is a heuristic — false-positive-friendly.
+walk("src", ".ts", (file) => {
+  const src = readFileSync(join(repoRoot, file), "utf8");
+  const defaults = new Map();
+  for (const m of src.matchAll(/^export const (DEFAULT_[A-Z_]+)\s*=\s*"([^"]+)"/gm)) {
+    defaults.set(m[1], m[2]);
+  }
+  if (defaults.size === 0) return;
+  const lines = src.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!/^\s*\*|^\s*\/\/|^\s*\/\*/.test(line)) continue;
+    // Heuristic: comment mentions "<value> default" or "(<value> default)" — find quoted value.
+    for (const m of line.matchAll(/[`"']([a-z][a-z0-9-]*)[`"']\s+default\b/gi)) {
+      const claimedDefault = m[1];
+      // Check against every DEFAULT_* constant in the file.
+      for (const [constName, actualValue] of defaults) {
+        if (actualValue === claimedDefault) continue; // matches — OK
+        // Heuristic: only flag if the comment mentions the SAME alias prefix
+        // (e.g. comments about "rerank-multilingual default" near a DEFAULT_RERANKER_ALIAS).
+        const prefix = claimedDefault.split("-")[0];
+        if (!actualValue.startsWith(prefix)) continue;
+        record(
+          "STALE-DEFAULT-CLAIM",
+          file,
+          i + 1,
+          line.trim(),
+          `Comment claims "${claimedDefault}" is the default, but ${constName} = "${actualValue}". If the comment is historical, prefix with "Pre-vX.Y.Z, the default was..." to mark as tombstone.`
+        );
+      }
+    }
+  }
+});
+
+// ─── Report ─────────────────────────────────────────────────────────────
+if (findings.length === 0) {
+  console.log("[oia-walk] ✓ No outside-in findings.");
+  process.exit(0);
+}
+
+console.error(`[oia-walk] ${findings.length} finding(s):\n`);
+for (const f of findings) {
+  const relPath = f.file.startsWith(repoRoot) ? relative(repoRoot, f.file) : f.file;
+  console.error(`  • [${f.kind}] ${relPath}:${f.line}`);
+  console.error(`    > ${f.evidence}`);
+  console.error(`    hint: ${f.hint}`);
+  console.error("");
+}
+
+if (ALLOW_MODE) {
+  console.error("[oia-walk] --allow flag set; exiting 0 despite findings.");
+  process.exit(0);
+}
+console.error("[oia-walk] Pass --allow to override (CHANGELOG must document why findings are acceptable).");
+process.exit(1);

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -303,8 +303,12 @@ export const RERANKER_MODELS: Readonly<Record<string, RerankerModel>> = Object.f
     maxTokens: 512
   },
   // mxbai-rerank-large-v2 — multilingual, ~280 MB. Higher quality than
-  // the xsmall variant (rerank-multilingual default). Multi-language
-  // benchmark performance is solid; cost is the larger download.
+  // the xsmall `rerank-multilingual` (which is the multilingual variant,
+  // NOT the project-wide default — see `DEFAULT_RERANKER_ALIAS` below; it
+  // was bumped to `rerank-bge` in v3.6.1 CRIT-2 because 4 of 5 catalog
+  // aliases fail at `AutoTokenizer.from_pretrained` due to a
+  // transformers.js compat issue). Multi-language benchmark performance
+  // is solid; cost is the larger download.
   "rerank-multilingual-large": {
     alias: "rerank-multilingual-large",
     hfId: "Xenova/mxbai-rerank-large-v2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
-// Slim entry point for enquire-mcp. Version 3.6.0-rc.2 split the previous
-// 3665-line monolith into domain modules:
+// Slim entry point for enquire-mcp. The current `VERSION` constant below
+// is the authoritative version (see `scripts/check-version-consistency.mjs`).
+//
+// History: v3.6.0-rc.2 split the previous 3665-line monolith into the
+// domain modules listed below. v3.7.x continued the consolidation. The
+// file-header comment used to read as if rc.2 was current — round-19
+// audit (v3.7.17) caught this as the "tombstone vs current-claim"
+// stale-comment class. Now reads as historical context (clearer.)
+//
+// Domain modules:
 //   - cli.ts            : `main()` + commander program definition (CLI parsing).
 //   - server.ts         : ServeOptions / ServerDeps / prepareServerDeps / buildMcpServer /
 //                         startServer / formatReadyBanner / buildEmbedText / sync* fns.
@@ -34,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.7.16";
+export const VERSION = "3.7.17";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below


### PR DESCRIPTION
## Summary

6th independent external audit since v3.6.0, on the v3.7.5 codebase. Most findings were already closed by the v3.7.6 → v3.7.16 cascade. This patch addresses 5 cheap stale-fragments my internal class-sweeps missed PLUS adds the missing **state-driven audit dimension** that every external auditor has been exploiting since v3.6.0.

### Stale-fragment fixes (5)

| # | File | Issue |
|---|------|-------|
| A | `src/index.ts:2` | File-header read as if 3.6.0-rc.2 was current |
| B | `CLAUDE.md` | Title "v3.6.0 sprint" + "712+ tests" (cascade at v3.7.17) |
| C | `scripts/check-changelog-coverage.mjs:26` | Ref to non-existent `npm run check:coverage-drift` |
| D | `src/embeddings.ts:306` | Comment "(rerank-multilingual default)" but `DEFAULT_RERANKER_ALIAS = "rerank-bge"` since v3.6.1 |
| E | `README.md:185` | CodeQL claim annotated to clarify default-setup vs workflow file |

### Meta-methodology fix

**Root cause analysis (CHANGELOG enumerates 10 specific blind-spot types):** My methodology was 100% change-driven (look at what changed, fix the class, verify nearby). External audits are state-driven (read every file, verify each claim against reality). These find non-overlapping failure modes.

**New: `scripts/oia-walk.mjs`** automates 5 state-driven checks:
1. `STALE-CURRENCY-CLAIM` — file-header version claims
2. `WORKFLOW-CLAIM-WITHOUT-EVIDENCE` — README CI claims vs `.github/workflows/`
3. `CLI-SUBCMD-MISSING` — docs vs `src/cli.ts` `program.command()`
4. `NPM-SCRIPT-MISSING` — docs vs `package.json#scripts`
5. `STALE-DEFAULT-CLAIM` — inline default-value comments vs exported `DEFAULT_*`

**New CLAUDE.md rule:** *"Run OIA before claiming 'no open findings' in any release."* Sits alongside the v3.7.15 pre-merge RCA rule — together they cover inside-out (RCA on patch's classes) and outside-in (OIA on whole repo).

`npm run check:oia` — advisory in v3.7.17; required CI gate in v3.7.18+ once validated.

## Test plan

- [ ] 8 required CI gates green
- [ ] CodeQL clean
- [ ] `npm run check:oia` returns clean
- [ ] F5 release automation works (3rd consecutive end-to-end test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)