### PR TITLE
v3.8.0-rc.2: watcher → embed-db sync (R-7 closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0-rc.2] — 2026-05-20
+
+> **TL;DR:** Second v3.8.0 release candidate. Closes **R-7 watcher → embed-db sync** (multiple audit rounds, biggest user-visible gap). Pre-3.8.0 the `--watch` flag only kept FTS5 in sync; embed-db drifted silently until manual `enquire-mcp build-embeddings` rebuild, slowly degrading semantic-search quality across a session. Now: when `--watch` is on AND the embed-db file exists, the watcher re-embeds + upserts changed `.md` files in real-time. Ships under `@rc` dist-tag.
+
+**Minor — second v3.8.0 release candidate.**
+
+### R-7 — Watcher → embed-db sync (multi-audit round backlog)
+
+**Background**: this was the largest open architectural item in the round-14 → round-22 cascade. Users on `--use-hnsw` or persistent semantic search edited their vault, saw FTS5 results update via the watcher, but semantic-search results stayed frozen at the last `build-embeddings` snapshot. The drift was invisible until the user noticed a search result not finding a recently-edited note.
+
+**Implementation**:
+
+1. **Extracted `embedSingleNote(vault, embedder, entry, opts)` helper** in `src/server.ts`. Pre-3.8.0 the chunk + embed + row-build logic lived inline inside `syncEmbedDb`'s loop; not reusable. Now shared between bulk sync + watcher.
+
+2. **Added `VaultWatcher.attachEmbed(embedDb, embedder, lateChunkContext)`** method in `src/watcher.ts`. Allows post-construction wiring of the embed-db + embedder pair (necessary because the watcher boots BEFORE HNSW init completes — HNSW build can take 25s+; the watcher needs to be capturing file events the moment serve starts).
+
+3. **`prepareServerDeps` opens a watcher-owned embed-db handle** when `--watch` is on AND the embed-db file exists. Separate handle from the HNSW init's short-lived rebuild scan handle. SQLite WAL mode allows concurrent opens; MVCC keeps state consistent. Peek-before-open pattern (CRIT-1 v3.6.1) honored: existing meta drives model alias + dim + quantization to avoid DROP TABLE on mismatch.
+
+4. **Watcher's `handle()` dispatches embed-sync after FTS5 update**:
+   - `unlink` event on `.md` → `embedDb.deleteNote(relPath)`
+   - `add` / `change` on `.md` → `embedSingleNote(...)` → `embedDb.upsertNote(relPath, mtime, rows)` (or `deleteNote` if note becomes empty)
+   - Failures are LOGGED but DON'T fail the watcher — FTS5 update already succeeded; embed-db will resync on next bulk build. Same fail-soft posture as existing FTS5 path.
+
+5. **Shutdown handler closes the watcher-owned embed-db** via SIGINT / SIGTERM / beforeExit — both stdio path (`server.ts`) and HTTP path (`http-transport.ts`).
+
+### What's NOT in rc.2 (deferred to rc.3)
+
+- **PDF embed-db sync via watcher**: rc.2 handles only `.md` for embed-sync. PDF embed updates need to also re-chunk via pdf.ts + embed each chunk — slightly larger refactor. Markdown is the higher-value first cut (most user vaults are markdown-heavy).
+- **OCR'd PDF embed sync**: same as above + the OCR path is opt-in.
+- **HNSW signature mismatch on individual upsert**: rc.2 leaves HNSW signature stale after watcher updates. On next serve start, the signature-mismatch detection triggers a rebuild. Real-time HNSW index update would require maintaining the in-memory HNSW alongside upserts (architectural).
+
+### Test coverage
+
+`tests/watcher.test.ts` — 2 new R-7 tests:
+- **Positive**: `.md` add → embed-db chunks appear (uses MOCK embedder, no 120MB model download in CI). Subsequent `.md` unlink → chunks dropped.
+- **Negative-control**: PDF events DO NOT touch embed-db (md-only for rc.2).
+
+Plus the existing 4 watcher tests still pass.
+
+### How to use
+
+```bash
+enquire-mcp serve \
+  --vault ~/Obsidian/MyVault \
+  --persistent-index \
+  --use-hnsw \
+  --watch
+```
+
+(or `serve-http` with same flags via the v3.8.0-rc.1 R-3 fix.)
+
+Now editing a note in Obsidian → ~250-500ms later → embeddings auto-update → next semantic search includes the latest changes.
+
+### Stats
+
+- **822 tests** (+2 from R-7 tests). Was 820 in v3.8.0-rc.1.
+- Dist-tag: `@rc` (v3.7.20 stays `@latest`).
+- All required CI gates pass locally.
+
+### v3.8.0 remaining backlog (next RCs)
+
+- **K-3** — `readOnlyHint: true` → no destructive operations structural invariant.
+- **R-10** — HNSW + privacy under-return fix (over-fetch margin tuning).
+- **T-1..T-5** — test coverage gaps (`contextPack`, `get_communities` handler E2E, `hyde_search` E2E, `serve-http` cli.test E2E).
+- **4/5 reranker E2E in CI** with model-cache strategy.
+- PDF embed-sync via watcher (deferred from rc.2).
+
 ## [3.8.0-rc.1] — 2026-05-20
 
 > **TL;DR:** First release candidate for the v3.8.0 architectural milestone. Closes **R-3 serve-http feature parity** (round-20 audit) — 8 advanced retrieval flags that were silently missing from `serve-http` are now available, with a CLI-parity invariant test to prevent future drift. Ships under `@rc` dist-tag; v3.7.x remains `@latest` until v3.8.0 stable.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-820%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-822%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.7.x-stable-brightgreen.svg)](./STABILITY.md)
 [![SLSA-3](https://img.shields.io/badge/SLSA-3-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -36,7 +36,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 2. **Best-in-class retrieval.** Hybrid BM25 + multilingual embeddings + BGE cross-encoder reranker fused via RRF, scaled with HNSW + int8 quantization. The same IR stack a search startup would build — open-sourced, in one binary.
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 
-**44 tools · 19 MCP prompts · 820 unit tests · 50+ languages · v3.7.x stable · semver-bound · MIT · SLSA-3 signed.**
+**44 tools · 19 MCP prompts · 822 unit tests · 50+ languages · v3.7.x stable · semver-bound · MIT · SLSA-3 signed.**
 
 ---
 
@@ -112,7 +112,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **820 unit tests · 8 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **822 unit tests · 8 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **SLSA-3 build provenance** | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -222,7 +222,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable. Full changelog: 
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (820 tests, ~5s)
+npm test       # full suite (822 tests, ~5s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -43,7 +43,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Read open editor state, active note, etc.     | **No**              | **Yes**          | Limited          | No               | No               |
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | SLSA-3 build provenance on releases           | **Yes**             | No               | No               | No               | No               |
-| Test count (public)                           | **820**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **822**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.8.0-rc.1",
+  "version": "3.8.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.8.0-rc.1",
+      "version": "3.8.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.8.0-rc.1",
-  "description": "The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client. 44 tools, 19 MCP prompts, BGE cross-encoder reranker verified end-to-end (+4 aliases in catalog, transformers.js bump pending), 820 tests, SLSA-3, semver-bound, MIT.",
+  "version": "3.8.0-rc.2",
+  "description": "The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client. 44 tools, 19 MCP prompts, BGE cross-encoder reranker verified end-to-end (+4 aliases in catalog, transformers.js bump pending), 822 tests, SLSA-3, semver-bound, MIT.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -703,7 +703,11 @@ export async function startHttpServer(opts: HttpServeOptions): Promise<HttpServe
       });
     }
     if (deps.watcher) {
-      const closeWatcher = () => void deps.watcher?.close();
+      const closeWatcher = () => {
+        void deps.watcher?.close();
+        // v3.8.0-rc.2 R-7 — close watcher-owned embed-db handle (HTTP path).
+        deps.watcherEmbedDb?.close();
+      };
       process.once("SIGINT", closeWatcher);
       process.once("SIGTERM", closeWatcher);
       process.on("beforeExit", closeWatcher);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.8.0-rc.1";
+export const VERSION = "3.8.0-rc.2";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,6 +110,16 @@ export interface ServerDeps {
   vault: Vault;
   ftsIndex: FtsIndex | null;
   watcher: VaultWatcher | null;
+  /**
+   * v3.8.0-rc.2 R-7 — embed-db handle owned by the watcher for runtime
+   * incremental sync. Opened in `prepareServerDeps` when `--watch` is
+   * on AND the embed-db file exists, separate from the HNSW init path
+   * (which opens its own short-lived handle for the rebuild scan).
+   * SQLite WAL mode allows concurrent opens to the same file; the two
+   * handles see consistent state via MVCC. Closed by the shutdown
+   * handler in {@link startServer}.
+   */
+  watcherEmbedDb: EmbedDb | null;
   disabledTools: Set<string>;
   enabledTools: Set<string>;
   warningTracker: { printed: boolean };
@@ -226,9 +236,61 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
   // adds/changes/deletes. Pre-3.7.16 only .md events were handled, so
   // PDF moves/deletes left stale rows until restart.
   let watcher: VaultWatcher | null = null;
+  // v3.8.0-rc.2 R-7 — watcher-owned embed-db handle (separate from HNSW
+  // init's short-lived handle). Opened below if `--watch` + the embed-db
+  // file exists; closed by startServer's shutdown handler.
+  let watcherEmbedDb: EmbedDb | null = null;
   if (opts.watch) {
     watcher = new VaultWatcher({ vault, ftsIndex, includePdfs: opts.includePdfs === true });
     await watcher.start();
+    // v3.8.0-rc.2 R-7 — wire embed-db sync. Pre-3.8.0 the watcher only
+    // updated FTS5 on .md edits; embed-db drifted silently until manual
+    // `enquire-mcp build-embeddings` ran. Users on `--use-hnsw` or
+    // semantic search saw retrieval quality slowly degrade across a
+    // session. Now: if the embed-db file exists, open a watcher-owned
+    // handle (WAL mode safe alongside HNSW init's separate handle),
+    // load the embedder lazily, attach to the watcher. Failures are
+    // logged as warnings — the FTS5-only watcher continues working.
+    try {
+      const embedFile = embedDbPath(vault.root);
+      const fsMod = await import("node:fs");
+      if (fsMod.existsSync(embedFile)) {
+        // Peek the existing embed-db meta to match the model alias +
+        // dim + quantization the file was built with. Same posture as
+        // HNSW init (CRIT-1 v3.6.1) — never DROP TABLE on mismatch.
+        const existingMeta = await peekEmbedDbMeta(embedFile);
+        const model = resolveModel(existingMeta?.model_alias);
+        const quantization =
+          (existingMeta?.quantization as "f32" | "int8" | undefined) ?? opts.quantizeEmbeddings ?? "f32";
+        watcherEmbedDb = new EmbedDb({
+          file: embedFile,
+          vaultRoot: vault.root,
+          modelAlias: model.alias,
+          dim: model.dim,
+          quantization
+        });
+        await watcherEmbedDb.open();
+        // Lazy-load the embedder. ~120MB multilingual model first call
+        // (~2-5s warm); subsequent calls reuse the cached transformers.js
+        // pipeline. Done synchronously here so any failure surfaces
+        // BEFORE watcher events start arriving.
+        const { loadEmbedder } = await import("./embeddings.js");
+        const embedder = await loadEmbedder(model.alias);
+        const lateChunk = opts.lateChunkContext ? parsePositiveInt(opts.lateChunkContext, "--late-chunk-context") : 0;
+        watcher.attachEmbed(watcherEmbedDb, embedder, lateChunk);
+        process.stderr.write(
+          `enquire: watcher embed-db sync enabled (model=${model.alias}, dim=${model.dim}, quantization=${quantization}, late-chunk-context=${lateChunk})\n`
+        );
+      }
+    } catch (err) {
+      process.stderr.write(
+        `enquire: watcher embed-db sync DISABLED (will continue with fts5-only) — ${err instanceof Error ? err.message : String(err)}\n`
+      );
+      if (watcherEmbedDb) {
+        watcherEmbedDb.close();
+        watcherEmbedDb = null;
+      }
+    }
   }
 
   // v2.13.0 — opt-in HNSW vector index. Built in-memory on serve start
@@ -389,6 +451,7 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
     vault,
     ftsIndex,
     watcher,
+    watcherEmbedDb,
     disabledTools: new Set(opts.disabledTools ?? []),
     enabledTools: new Set(opts.enabledTools ?? []),
     warningTracker: { printed: false },
@@ -542,6 +605,10 @@ export async function startServer(opts: ServeOptions): Promise<void> {
   if (watcher) {
     const closeWatcher = () => {
       void watcher?.close();
+      // v3.8.0-rc.2 R-7 — close the watcher-owned embed-db handle too.
+      // Safe to call multiple times (idempotent close); WAL checkpoint
+      // happens at close time so no data loss on graceful shutdown.
+      deps.watcherEmbedDb?.close();
     };
     process.once("SIGINT", closeWatcher);
     process.once("SIGTERM", closeWatcher);
@@ -629,6 +696,58 @@ export function buildEmbedText(
 // pattern as syncFtsIndex (mtime tracked in source_state); we only re-embed
 // notes whose mtime changed. Embedding is the bottleneck (~5-30ms per chunk
 // CPU on M1), so incremental updates are critical for vaults of any size.
+/**
+ * v3.8.0-rc.2 R-7 — embed-vector pipeline for a single markdown note.
+ * Extracted from the inner loop of {@link syncEmbedDb} so both the bulk
+ * sync and the runtime watcher can use the same chunking + embedding +
+ * upsert path without duplicating logic.
+ *
+ * Returns null if the note has no body chunks (empty / whitespace-only —
+ * caller should `db.deleteNote(relPath)` to drop any stale rows).
+ *
+ * @internal
+ */
+export async function embedSingleNote(
+  vault: Vault,
+  embedder: Awaited<ReturnType<typeof loadEmbedder>>,
+  entry: { relPath: string; absPath: string; mtimeMs: number },
+  opts: { lateChunkContext?: number } = {}
+): Promise<{
+  chunks: number;
+  rows: Array<{
+    chunkIndex: number;
+    lineStart: number;
+    lineEnd: number;
+    textPreview: string;
+    vector: Float32Array;
+  }>;
+} | null> {
+  const contextChars = opts.lateChunkContext ?? 0;
+  const note = await vault.readNote(entry.absPath, entry.mtimeMs);
+  const chunks = chunkContent(note.parsed.body);
+  if (chunks.length === 0) return null;
+  const docTitle = note.parsed.frontmatter?.title || path.basename(entry.relPath, ".md");
+  const embedTexts = chunks.map((_c, i) =>
+    buildEmbedText(chunks, i, {
+      docTitle: typeof docTitle === "string" ? docTitle : undefined,
+      contextChars
+    })
+  );
+  const vectors = await embedder.embed(embedTexts);
+  const rows = chunks.map((c, i) => {
+    const vector = vectors[i];
+    if (!vector) throw new Error(`embedder returned no vector for chunk ${i} of ${entry.relPath}`);
+    return {
+      chunkIndex: i,
+      lineStart: c.lineStart,
+      lineEnd: c.lineEnd,
+      textPreview: c.text.slice(0, 480),
+      vector
+    };
+  });
+  return { chunks: chunks.length, rows };
+}
+
 export async function syncEmbedDb(
   vault: Vault,
   db: EmbedDb,
@@ -665,48 +784,22 @@ export async function syncEmbedDb(
       continue;
     }
     try {
-      const note = await vault.readNote(e.absPath, e.mtimeMs);
-      const chunks = chunkContent(note.parsed.body);
-      if (chunks.length === 0) {
+      // v3.8.0-rc.2 R-7 — delegate single-note chunk+embed work to the
+      // shared helper so the watcher can use the same pipeline. The
+      // many-chunks warning stays here (bulk-sync context only).
+      const result = await embedSingleNote(vault, embedder, e, { lateChunkContext: contextChars });
+      if (result === null) {
         // No body — drop any stale entries.
         db.deleteNote(e.relPath);
         processed += 1;
         continue;
       }
-      // v2.0.0-beta.4: warn when a single note produces many chunks, so the
-      // user knows WHY their build is slow on this specific file.
-      if (chunks.length >= 30) {
+      if (result.chunks >= 30) {
         process.stderr.write(
-          `enquire: ${e.relPath} → ${chunks.length} chunks (this one will be slow; consider splitting the note)\n`
+          `enquire: ${e.relPath} → ${result.chunks} chunks (this one will be slow; consider splitting the note)\n`
         );
       }
-      // v2.1.0: prepend heading breadcrumb to embedded text so the model sees
-      // structural context. Free win at zero token cost — Chroma 2024 +
-      // NAACL 2025 show +2-5 NDCG@10 from breadcrumb prepending.
-      // v2.15.0: when `--late-chunk-context <n>` is set, also include
-      // doc title + neighbor-chunk tails so the embedding captures
-      // cross-paragraph context. The text stored in `text_preview`
-      // (for snippets) stays clean.
-      const docTitle = note.parsed.frontmatter?.title || path.basename(e.relPath, ".md");
-      const embedTexts = chunks.map((_c, i) =>
-        buildEmbedText(chunks, i, {
-          docTitle: typeof docTitle === "string" ? docTitle : undefined,
-          contextChars
-        })
-      );
-      const vectors = await embedder.embed(embedTexts);
-      const rows = chunks.map((c, i) => {
-        const vector = vectors[i];
-        if (!vector) throw new Error(`embedder returned no vector for chunk ${i} of ${e.relPath}`);
-        return {
-          chunkIndex: i,
-          lineStart: c.lineStart,
-          lineEnd: c.lineEnd,
-          textPreview: c.text.slice(0, 480),
-          vector
-        };
-      });
-      db.upsertNote(e.relPath, e.mtimeMs, rows);
+      db.upsertNote(e.relPath, e.mtimeMs, result.rows);
       if (prevMtime === undefined) added += 1;
       else updated += 1;
     } catch (err) {

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -11,6 +11,8 @@
 
 import * as path from "node:path";
 import chokidar, { type FSWatcher } from "chokidar";
+import type { EmbedDb } from "./embed-db.js";
+import type { loadEmbedder } from "./embeddings.js";
 import type { FtsIndex } from "./fts5.js";
 import type { Vault } from "./vault.js";
 
@@ -37,6 +39,34 @@ export interface WatcherOptions {
    * `--include-pdfs` for full PDF coverage at runtime.
    */
   includePdfs?: boolean;
+  /**
+   * v3.8.0-rc.2 R-7 — optional embed-db handle. When provided alongside
+   * `embedder`, the watcher re-embeds + upserts on `.md` add/change events
+   * and `deleteNote()`s on unlink. Pre-3.8.0 the embed-db drifted on every
+   * vault edit until a manual `enquire-mcp build-embeddings` rebuild —
+   * search-quality slowly degraded across the session for users on
+   * `--use-hnsw` or `--persistent-index` with embeddings.
+   *
+   * Cost per `.md` change: 1 read + chunkContent + embedder.embed (~50-200ms
+   * per chunk on M1 CPU, batched 8x) + db.upsertNote. For a typical
+   * 5-paragraph note (~5 chunks), watcher overhead is ~250-500ms — usually
+   * invisible against Obsidian's autosave-debounce window. For very long
+   * notes the per-edit cost can spike to seconds.
+   */
+  embedDb?: EmbedDb | null;
+  /**
+   * v3.8.0-rc.2 R-7 — embedder handle. Same instance used at bulk-sync
+   * time so model/dim/late-chunking config stays consistent. Required
+   * if `embedDb` is provided.
+   */
+  embedder?: Awaited<ReturnType<typeof loadEmbedder>> | null;
+  /**
+   * v3.8.0-rc.2 R-7 — propagate `--late-chunk-context <n>` to per-file
+   * re-embeds. Without this, runtime updates would use 0-context while
+   * the bulk-built index used n-context — embeddings would diverge in
+   * vector space and search recall would drift over the session.
+   */
+  lateChunkContext?: number;
 }
 
 export class VaultWatcher {
@@ -45,6 +75,13 @@ export class VaultWatcher {
   private readonly ftsIndex: FtsIndex | null;
   private readonly silent: boolean;
   private readonly includePdfs: boolean;
+  // v3.8.0-rc.2 R-7 — mutable so server.ts can `attachEmbed()` after
+  // HNSW context init populates embedDb + embedder. Watcher boots BEFORE
+  // HNSW (so file events from boot-time edits are captured) but the
+  // embed-sync feature engages once handles are available.
+  private embedDb: EmbedDb | null;
+  private embedder: Awaited<ReturnType<typeof loadEmbedder>> | null;
+  private lateChunkContext: number;
   private closed = false;
 
   constructor(opts: WatcherOptions) {
@@ -52,6 +89,38 @@ export class VaultWatcher {
     this.ftsIndex = opts.ftsIndex ?? null;
     this.silent = opts.silent ?? false;
     this.includePdfs = opts.includePdfs ?? false;
+    this.embedDb = opts.embedDb ?? null;
+    this.embedder = opts.embedder ?? null;
+    this.lateChunkContext = opts.lateChunkContext ?? 0;
+    // v3.8.0-rc.2 R-7 — fail loud if embedDb is wired without embedder.
+    // Pre-flight check vs silently no-op'ing the embed sync.
+    if (this.embedDb && !this.embedder) {
+      throw new Error("VaultWatcher: embedDb wired without embedder — both must be set together");
+    }
+  }
+
+  /**
+   * v3.8.0-rc.2 R-7 — attach an embed-db handle + embedder after the
+   * watcher has started. Used by `prepareServerDeps` when HNSW context
+   * init completes after the watcher's initial `start()` call (HNSW
+   * build can take 25s+; watcher needs to be running before that to
+   * capture file edits during the boot window).
+   *
+   * Calling this is idempotent — if you pass the same handle twice,
+   * the watcher uses the most recent one. Pass `null` for both to
+   * detach (the FTS5-only sync continues).
+   */
+  attachEmbed(
+    embedDb: EmbedDb | null,
+    embedder: Awaited<ReturnType<typeof loadEmbedder>> | null,
+    lateChunkContext = 0
+  ): void {
+    if (embedDb && !embedder) {
+      throw new Error("VaultWatcher.attachEmbed: embedDb passed without embedder");
+    }
+    this.embedDb = embedDb;
+    this.embedder = embedder;
+    this.lateChunkContext = lateChunkContext;
   }
 
   /** Start watching. Resolves once the watcher has reported `ready`. */
@@ -137,8 +206,22 @@ export class VaultWatcher {
 
     if (kind === "unlink") {
       this.ftsIndex.dropFile(relPath);
+      // v3.8.0-rc.2 R-7 — also drop embed-db rows so search results
+      // don't surface vectors for deleted notes.
+      if (!isPdf && this.embedDb) {
+        try {
+          this.embedDb.deleteNote(relPath);
+        } catch (err) {
+          if (!this.silent) {
+            process.stderr.write(
+              `enquire: watcher embed-db delete failed for ${relPath} — ${err instanceof Error ? err.message : String(err)}\n`
+            );
+          }
+        }
+      }
       if (!this.silent) {
-        process.stderr.write(`enquire: watcher unlink ${relPath} (fts5 dropped)\n`);
+        const embedNote = !isPdf && this.embedDb ? " + embed-db dropped" : "";
+        process.stderr.write(`enquire: watcher unlink ${relPath} (fts5 dropped${embedNote})\n`);
       }
       return;
     }
@@ -149,6 +232,9 @@ export class VaultWatcher {
       if (isPdf) {
         // v3.7.16 P1-5 — extract text and re-index PDF pages. Lazy
         // import to keep markdown-only deployments zero-cost.
+        // v3.8.0-rc.2 R-7 — PDF embedding sync deferred to rc.3+: needs
+        // chunking + embedder loop similar to syncPdfEmbedDb, plus the
+        // OCR fallback path. Markdown is the higher-value first cut.
         const buf = await this.vault.readBinaryFile(absPath);
         const { extractPdfText } = await import("./pdf.js");
         const result = await extractPdfText(buf);
@@ -162,8 +248,38 @@ export class VaultWatcher {
       const note = await this.vault.readNote(absPath, stat.mtimeMs);
       const wikilinkTargets = note.parsed.wikilinks.map((w) => w.target).filter((t) => t.length > 0);
       this.ftsIndex.reindexFile(relPath, stat.mtimeMs, note.content, wikilinkTargets, note.parsed.tags);
+      // v3.8.0-rc.2 R-7 — re-embed + upsert if embed-db is wired.
+      // Failures here are logged but DON'T fail the whole watcher event
+      // (FTS5 update already succeeded; embed-db will resync on next bulk
+      // build). Same fail-soft posture as the existing FTS5 path.
+      let embedNote = "";
+      if (this.embedDb && this.embedder) {
+        try {
+          const { embedSingleNote } = await import("./server.js");
+          const result = await embedSingleNote(
+            this.vault,
+            this.embedder,
+            { relPath, absPath, mtimeMs: stat.mtimeMs },
+            { lateChunkContext: this.lateChunkContext }
+          );
+          if (result === null) {
+            this.embedDb.deleteNote(relPath);
+            embedNote = " + embed-db cleared (empty note)";
+          } else {
+            this.embedDb.upsertNote(relPath, stat.mtimeMs, result.rows);
+            embedNote = ` + embed-db upserted (${result.chunks} chunks)`;
+          }
+        } catch (err) {
+          if (!this.silent) {
+            process.stderr.write(
+              `enquire: watcher embed-db sync failed for ${relPath} — ${err instanceof Error ? err.message : String(err)}\n`
+            );
+          }
+          embedNote = " + embed-db FAILED (see above)";
+        }
+      }
       if (!this.silent) {
-        process.stderr.write(`enquire: watcher ${kind} ${relPath} (fts5 reindexed)\n`);
+        process.stderr.write(`enquire: watcher ${kind} ${relPath} (fts5 reindexed${embedNote})\n`);
       }
     } catch (err) {
       // File may have been deleted between event and our stat — drop it.

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -310,6 +310,117 @@ describe("VaultWatcher with FTS5 index (v3.6 — reindex branches)", () => {
     }
   });
 
+  // v3.8.0-rc.2 R-7 — watcher → embed-db sync. Closes the "edit-then-rebuild"
+  // loop for users on --use-hnsw or persistent embedding search. Uses a
+  // MOCK embedder (no 120MB HuggingFace model download) — testing the
+  // wiring, not the model. The real-model smoke test stays opt-in via
+  // ENQUIRE_LOAD_RERANKER_SMOKE pattern.
+  it("attachEmbed: .md change re-embeds + upserts to embed-db (R-7)", async () => {
+    const { EmbedDb } = await import("../src/embed-db.js");
+    const v = new Vault(root);
+    await v.ensureExists();
+    const fts = new FtsIndex({ file: defaultIndexFile(root), vaultRoot: root });
+    await fts.open();
+
+    // Mock embedder — returns Float32Array of fixed dim per chunk. Deterministic
+    // so we can assert the upsert went through.
+    const mockDim = 4;
+    const mockEmbedder = {
+      model: { alias: "test-mock", hfId: "mock", dim: mockDim, multilingual: false, maxTokens: 128 },
+      async embed(texts: readonly string[]): Promise<Float32Array[]> {
+        return texts.map((_, i) => {
+          const vec = new Float32Array(mockDim);
+          for (let j = 0; j < mockDim; j++) vec[j] = (i + 1) / (j + 1);
+          return vec;
+        });
+      }
+    };
+
+    const embedDbFile = path.join(root, ".cache", "test.embed.db");
+    await fs.mkdir(path.dirname(embedDbFile), { recursive: true });
+    const embedDb = new EmbedDb({
+      file: embedDbFile,
+      vaultRoot: root,
+      modelAlias: "test-mock",
+      dim: mockDim,
+      quantization: "f32"
+    });
+    await embedDb.open();
+
+    try {
+      const w = new VaultWatcher({ vault: v, ftsIndex: fts, silent: true });
+      w.attachEmbed(embedDb, mockEmbedder, 0);
+      await w.start();
+      try {
+        const filePath = path.join(root, "note-embed.md");
+        await fs.writeFile(filePath, "# Heading\n\nFirst paragraph body.\n\nSecond paragraph here.\n");
+        // Wait for watcher to process — embed-sync should fire AFTER fts5 reindex.
+        const synced = await waitFor(() => embedDb.totalChunks() > 0);
+        expect(synced).toBe(true);
+        const chunks = embedDb.totalChunks();
+        expect(chunks).toBeGreaterThanOrEqual(1);
+
+        // Unlink should drop both fts5 chunks AND embed-db rows.
+        await fs.unlink(filePath);
+        const dropped = await waitFor(() => embedDb.totalChunks() === 0);
+        expect(dropped).toBe(true);
+      } finally {
+        await w.close();
+      }
+    } finally {
+      embedDb.close();
+      fts.close();
+    }
+  });
+
+  it("attachEmbed: PDF events DON'T touch embed-db (md-only for rc.2)", async () => {
+    const { EmbedDb } = await import("../src/embed-db.js");
+    const v = new Vault(root);
+    await v.ensureExists();
+    const fts = new FtsIndex({ file: defaultIndexFile(root), vaultRoot: root });
+    await fts.open();
+
+    const mockEmbedder = {
+      model: { alias: "test-mock", hfId: "mock", dim: 4, multilingual: false, maxTokens: 128 },
+      async embed(texts: readonly string[]): Promise<Float32Array[]> {
+        return texts.map(() => new Float32Array(4));
+      }
+    };
+
+    const embedDbFile = path.join(root, ".cache", "test-pdf.embed.db");
+    await fs.mkdir(path.dirname(embedDbFile), { recursive: true });
+    const embedDb = new EmbedDb({
+      file: embedDbFile,
+      vaultRoot: root,
+      modelAlias: "test-mock",
+      dim: 4,
+      quantization: "f32"
+    });
+    await embedDb.open();
+
+    try {
+      const w = new VaultWatcher({ vault: v, ftsIndex: fts, includePdfs: true, silent: true });
+      w.attachEmbed(embedDb, mockEmbedder, 0);
+      await w.start();
+      try {
+        const pdfPath = path.join(root, "doc.pdf");
+        const pdfBuf = makePdf({ pages: ["PDF body for test"] });
+        await fs.writeFile(pdfPath, pdfBuf);
+        // FTS5 should index the PDF chunks, but embed-db should NOT receive them
+        // (PDF embed-sync via watcher deferred to rc.3+).
+        const ftsIndexed = await waitFor(() => fts.totalFiles() >= 1);
+        expect(ftsIndexed).toBe(true);
+        // Embed-db should remain empty (no .md path was indexed).
+        expect(embedDb.totalChunks()).toBe(0);
+      } finally {
+        await w.close();
+      }
+    } finally {
+      embedDb.close();
+      fts.close();
+    }
+  });
+
   it("includePdfs=false: PDF events are silently ignored (P1-5 default safety)", async () => {
     const v = new Vault(root);
     await v.ensureExists();


### PR DESCRIPTION
## Summary

Second v3.8.0 release candidate. Closes **R-7 watcher → embed-db sync** — the largest open architectural backlog item from rounds 14-22.

### Pre-3.8.0 problem
`--watch` only synced FTS5. embed-db drifted silently until manual `enquire-mcp build-embeddings` rebuild — semantic search slowly degraded across a session.

### Fix
Real-time embed-db updates on `.md` add/change/unlink events.

- Extracted `embedSingleNote()` helper in server.ts
- Added `VaultWatcher.attachEmbed()` method for post-construction wiring
- `prepareServerDeps` opens watcher-owned embed-db handle (SQLite WAL-safe alongside HNSW init)
- Peek-before-open pattern (CRIT-1 v3.6.1) honored — no DROP TABLE on schema mismatch
- Fail-soft posture — embed-db errors don't fail watcher

### Tests
+2 R-7 tests with MOCK embedder (no 120MB HuggingFace model in CI):
- Positive: `.md` change → embed-db upserts; unlink → drops
- Negative-control: PDF events do NOT touch embed-db (markdown-only for rc.2)

### Deferred to rc.3
- PDF embed-sync via watcher
- HNSW signature live-update (still triggers rebuild on next start)
- K-3 readOnlyHint invariant
- R-10 HNSW under-return
- T-1..T-5 test gaps
- 4/5 reranker E2E in CI

## Test plan

- [ ] 8 required CI gates green
- [ ] CLI parity test (rc.1) still green
- [ ] R-7 watcher embed tests pass
- [ ] F5 publishes under @rc dist-tag (v3.7.20 stays @latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)