### PR TITLE
v3.8.0-rc.10: P3-25/21/27 backlog + watcher branch floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,87 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0-rc.10] — 2026-05-22
+
+> **TL;DR:** Tenth v3.8.0 release candidate. **Backlog items P3-25, P3-21, P3-27** from the v3.8.0 pre-stable queue, plus **watcher.ts branch-floor lift** (69% → 71% target). Tilde-fence headings now correctly excluded from `extractHeadings`; `--persistent-index` help text no longer implies sole-flag sufficiency for `obsidian_full_text_search`; HNSW metadata (dim/size/rowsByLabel) validated before native constructor call. **846 tests** (+4 negative-controls). Ships under `@rc` dist-tag.
+
+**Minor — tenth v3.8.0 release candidate.**
+
+### Fix P3-25 — tilde fences (`~~~`) excluded from heading extraction
+
+**Background.** `extractHeadings` in `src/tools/read.ts` used `/^\s*```/` to detect fenced code blocks. The CommonMark spec allows fences with `~~~` (three or more tildes) as an alternative to backtick fences. A Markdown note like:
+
+```
+# Real heading
+
+~~~sh
+## fake heading inside tilde fence
+~~~
+
+## Also real
+```
+
+would previously return three headings (including the fake inside the tilde fence) — polluting the document-map projection.
+
+**Fix (`src/tools/read.ts`, `extractHeadings`):** Extended regex to `/^\s*(`{3,}|~{3,})/` — detects both backtick fences and tilde fences of length ≥ 3.
+
+**Negative-control test** (`tests/tools.test.ts`, `readNote — document-map projection` describe block): verifies `format: "map"` returns exactly `["# Real heading", "## Also real"]` for a note with a tilde-fenced block containing `## fake heading inside tilde fence`.
+
+### Fix P3-21 — `--persistent-index` help text wording drift
+
+**Background.** `PERSISTENT_INDEX_HELP` in `src/cli-help.ts` read: *"Registers obsidian_full_text_search."* This implied `--persistent-index` alone was sufficient to expose the tool. In fact, **both** `--persistent-index` AND `--diagnostic-search-tools` are required (the tool is gated on both flags independently). The old phrasing was a gating-wording drift bug introduced in v3.5.14 and never caught by the subsequent OIA walks because the string lived in a new module (`cli-help.ts`) not yet in the walk's scan path.
+
+**Fix (`src/cli-help.ts`):** Rewrote `PERSISTENT_INDEX_HELP` to: *"Maintain a SQLite FTS5 inverted index for sub-100ms BM25-ranked search. Required for obsidian_full_text_search — also pass --diagnostic-search-tools to surface it alongside the default hybrid obsidian_search."* Both flags are now explicitly called out. The `DIAGNOSTIC_SEARCH_TOOLS_HELP` string already had this correct wording.
+
+### Fix P3-27 — HNSW metadata shallow validation before native constructor
+
+**Background.** `loadHnswFromDisk` in `src/hnsw.ts` passed `meta.dim`, `meta.size`, and `meta.rowsByLabel` from a JSON-parsed `.meta` sidecar directly to the native hnswlib constructor without validating the types. A corrupted or hand-edited `.meta` file with `dim: -1` or `rowsByLabel: null` would crash the native module with an opaque C-level exception rather than triggering a clean rebuild.
+
+**Fix (`src/hnsw.ts`, `loadHnswFromDisk`):** Added three guard blocks after the existing signature check — before any native constructor call:
+- `dim` must be a positive integer (rejects ≤ 0, NaN, non-integer).
+- `size` must be a non-negative integer.
+- `rowsByLabel` must be a plain object (rejects `null`, arrays, primitives).
+
+Each guard emits a `process.stderr.write` warning and returns `null` (triggering a clean rebuild), consistent with the existing pattern for sig-mismatch.
+
+**Negative-control tests** (`tests/hnsw.test.ts`): two new `it` blocks — one with `dim: -1` (invalid int), one with `rowsByLabel: null` (non-object) — verify that `loadHnswFromDisk` returns `null` rather than throwing.
+
+### Watcher branch-floor lift (69% → 71%)
+
+Added `tests/watcher.test.ts` test: *"attachEmbed: embed-db sync failure is logged to stderr (silent=false) and FTS5 still updates — NEGATIVE control"*. Uses a throwing embedder to verify:
+1. FTS5 still updates (fail-soft path in `attachEmbed`).
+2. `embedDb.totalChunks() === 0` (embed-db write skipped).
+3. `stderr` contains `"embed-db sync failed"` plus the synthetic error message.
+
+This exercises the `try/catch` branch in `attachEmbed` that was previously uncovered, lifting `watcher.ts` from 69% to ≥71% branch coverage.
+
+### Method note
+
+Post-merge self-audit scope for rc.10 (CLAUDE.md rule since v3.7.15):
+- `src/tools/read.ts` `extractHeadings`: regex body change only. TSDoc for `extractHeadings` describes the fence behavior — updated in-line with fix. α-class clear.
+- `src/cli-help.ts` `PERSISTENT_INDEX_HELP`: string replacement. Comment header above the export already stated the intent; updated. No other caller-side TSDoc mentions this constant by value. α-class clear.
+- `src/hnsw.ts` `loadHnswFromDisk`: added early-return guards. TSDoc for `loadHnswFromDisk` says "returns null on any load error" — the new guards are consistent with that contract, no header update needed. α-class clear.
+- `tests/watcher.test.ts`: test-only addition, no production code change.
+
+Docs-consistency: test count updated 842 → 846 across README.md (badge + tagline + feature matrix + npm test line), package.json description, docs/COMPARISON.md.
+
+### Stats
+
+- **846 tests** (+4 negative-controls vs rc.9).
+- `watcher.ts` branch coverage: 69% → ≥71%.
+- `npm audit`: 0 vulnerabilities.
+- Dist-tag: `@rc` (v3.7.20 stays `@latest`).
+- All 9 required CI gates pass locally.
+
+### v3.8.0 remaining backlog
+
+- **T-2, T-3** — communities handler + hyde E2E.
+- **T-4** — optional serve-http HTTP smoke.
+- OCR'd PDF watcher embed-sync, HNSW in-memory watcher update.
+- External audit before `@latest` promotion.
+
+---
+
 ## [3.8.0-rc.9] — 2026-05-22
 
 > **TL;DR:** Ninth v3.8.0 release candidate. **Round-7 external audit response** — 3 fixes: W-FLAKE-2 (chokidar FSEvents startup warmup missing from R-7 embed tests — sibling of rc.7 #36 fix), R-10 (HNSW k multiplier 4× → 6× to reduce post-privacy-filter under-return), and N-new (qs 6.15.1 → 6.15.2, GHSA-q8mj-m7cp-5q26, DoS in `qs.stringify` with comma-format arrays). Ships under `@rc` dist-tag.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-842%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-846%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.7.x-stable-brightgreen.svg)](./STABILITY.md)
 [![SLSA-3](https://img.shields.io/badge/SLSA-3-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -36,7 +36,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 2. **Best-in-class retrieval.** Hybrid BM25 + multilingual embeddings + BGE cross-encoder reranker fused via RRF, scaled with HNSW + int8 quantization. The same IR stack a search startup would build — open-sourced, in one binary.
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 
-**44 tools · 19 MCP prompts · 842 unit tests · 50+ languages · v3.7.x stable · semver-bound · MIT · SLSA-3 signed.**
+**44 tools · 19 MCP prompts · 846 unit tests · 50+ languages · v3.7.x stable · semver-bound · MIT · SLSA-3 signed.**
 
 ---
 
@@ -112,7 +112,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **842 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **846 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **SLSA-3 build provenance** | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -222,7 +222,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable. Full changelog: 
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (842 tests, ~5s)
+npm test       # full suite (846 tests, ~5s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -43,7 +43,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Read open editor state, active note, etc.     | **No**              | **Yes**          | Limited          | No               | No               |
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | SLSA-3 build provenance on releases           | **Yes**             | No               | No               | No               | No               |
-| Test count (public)                           | **842**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **846**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.8.0-rc.9",
+  "version": "3.8.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.8.0-rc.9",
+      "version": "3.8.0-rc.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.8.0-rc.9",
-  "description": "The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client. 44 tools, 19 MCP prompts, BGE cross-encoder reranker verified end-to-end (+4 aliases in catalog, transformers.js bump pending), 842 tests, SLSA-3, semver-bound, MIT.",
+  "version": "3.8.0-rc.10",
+  "description": "The most advanced Obsidian MCP — long-term memory for AI agents. Hybrid retrieval (BM25 + TF-IDF + multilingual ML embeddings, RRF-fused) with BGE cross-encoder reranking, HNSW + int8 quantization, late-chunking, HyDE + sub-question decomposition, agentic RAG, PDFs (with OCR), standalone Bases (.base query execution — no Obsidian needed), GraphRAG-light (Louvain wikilink community detection), wikilinks, backlinks, Dataview, frontmatter, canvas. Open-source long-term memory / second brain for Claude Code, Claude Desktop, Cursor, ChatGPT custom GPT, Codex, OpenClaw, and any MCP client. 44 tools, 19 MCP prompts, BGE cross-encoder reranker verified end-to-end (+4 aliases in catalog, transformers.js bump pending), 846 tests, SLSA-3, semver-bound, MIT.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -40,8 +40,11 @@ export const DIAGNOSTIC_SEARCH_TOOLS_HELP =
   "Register the single-ranker search tools (obsidian_search_text, obsidian_semantic_search, obsidian_embeddings_search) IN ADDITION to the default obsidian_search hybrid tool — plus obsidian_full_text_search if --persistent-index is also set (it's gated on FTS5 availability separately). Off by default in v2.0+ — the umbrella obsidian_search auto-detects available signals and produces consistent recall. Enable when you need single-ranker output for diagnostics or A/B benchmarking.";
 
 /**
- * `--persistent-index` flag help. Mentions the obsidian_full_text_search
- * registration explicitly, matching the v3.5.9 D6 wording.
+ * `--persistent-index` flag help. States the FTS5 index requirement for
+ * `obsidian_full_text_search`, without implying this flag alone registers it
+ * (v3.8.0-rc.10 P3-21 — pre-rc.10 phrasing "Registers obsidian_full_text_search"
+ * was a gating wording drift: both --persistent-index AND --diagnostic-search-tools
+ * are required to expose the tool).
  */
 export const PERSISTENT_INDEX_HELP =
-  "Maintain a SQLite FTS5 inverted index for sub-100ms BM25-ranked search. Registers obsidian_full_text_search.";
+  "Maintain a SQLite FTS5 inverted index for sub-100ms BM25-ranked search. Required for obsidian_full_text_search — also pass --diagnostic-search-tools to surface it alongside the default hybrid obsidian_search.";

--- a/src/hnsw.ts
+++ b/src/hnsw.ts
@@ -367,6 +367,22 @@ export async function loadHnswFromDisk(
     );
     return null;
   }
+  // v3.8.0-rc.10 P3-27 — shallow validation of dim/size/rowsByLabel before
+  // passing them to the native hnswlib constructor. Malformed-but-valid-JSON
+  // meta files with negative/non-integer dim or missing rowsByLabel would
+  // previously produce a native crash or garbage results.
+  if (!Number.isInteger(meta.dim) || meta.dim <= 0) {
+    process.stderr.write(`enquire: HNSW meta at ${metaFile} has invalid dim=${meta.dim}; rebuilding\n`);
+    return null;
+  }
+  if (!Number.isInteger(meta.size) || meta.size < 0) {
+    process.stderr.write(`enquire: HNSW meta at ${metaFile} has invalid size=${meta.size}; rebuilding\n`);
+    return null;
+  }
+  if (typeof meta.rowsByLabel !== "object" || meta.rowsByLabel === null || Array.isArray(meta.rowsByLabel)) {
+    process.stderr.write(`enquire: HNSW meta at ${metaFile} has invalid rowsByLabel; rebuilding\n`);
+    return null;
+  }
   // Bin file present?
   try {
     await fs.access(binFile);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.8.0-rc.9";
+export const VERSION = "3.8.0-rc.10";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -216,7 +216,10 @@ function extractHeadings(body: string): Array<{ level: number; text: string; lin
   let inFence = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
-    if (/^\s*```/.test(line)) {
+    // v3.8.0-rc.10 P3-25 — detect both backtick (```) AND tilde (~~~) fences.
+    // Pre-rc.10 only backtick fences toggled `inFence`, so headings inside
+    // tilde-delimited code blocks were incorrectly extracted.
+    if (/^\s*(`{3,}|~{3,})/.test(line)) {
       inFence = !inFence;
       continue;
     }

--- a/tests/hnsw.test.ts
+++ b/tests/hnsw.test.ts
@@ -401,6 +401,41 @@ describe("HNSW persistence (v2.16.0)", () => {
     expect(loaded).toBeNull();
   });
 
+  // v3.8.0-rc.10 P3-27 — shallow validation of dim/size/rowsByLabel.
+  // Pre-rc.10 these were used without validation: a malformed-but-valid-JSON
+  // meta with dim=-1 or rowsByLabel:null would crash or produce garbage.
+  it("returns null when meta has invalid dim (P3-27 NEGATIVE control)", async () => {
+    const persistFile = path.join(dir, "bad-dim.hnsw");
+    const meta = {
+      formatVersion: 1,
+      dim: -1,
+      size: 0,
+      signature: "match",
+      rowsByLabel: {},
+      writtenAt: new Date().toISOString()
+    };
+    await fs.writeFile(`${persistFile}.bin`, "ignored");
+    await fs.writeFile(`${persistFile}.meta.json`, JSON.stringify(meta));
+    const loaded = await loadHnswFromDisk(persistFile, "match");
+    expect(loaded).toBeNull();
+  });
+
+  it("returns null when meta has invalid rowsByLabel (P3-27 NEGATIVE control)", async () => {
+    const persistFile = path.join(dir, "bad-rows.hnsw");
+    const meta = {
+      formatVersion: 1,
+      dim: 4,
+      size: 0,
+      signature: "match",
+      rowsByLabel: null,
+      writtenAt: new Date().toISOString()
+    };
+    await fs.writeFile(`${persistFile}.bin`, "ignored");
+    await fs.writeFile(`${persistFile}.meta.json`, JSON.stringify(meta));
+    const loaded = await loadHnswFromDisk(persistFile, "match");
+    expect(loaded).toBeNull();
+  });
+
   it("returns null on formatVersion mismatch (future-proof)", async () => {
     const persistFile = path.join(dir, "future.hnsw");
     const meta = {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -428,6 +428,27 @@ describe("readNote — document-map projection (v0.11)", () => {
     }
   });
 
+  // v3.8.0-rc.10 P3-25 — tilde fence (~~~) heading extraction negative-control.
+  // Pre-rc.10 extractHeadings only toggled inFence on backtick fences (`),
+  // so headings inside ~~~ blocks were incorrectly included in the map.
+  it("tilde-fence (~~~) headings are NOT extracted — NEGATIVE control (P3-25)", async () => {
+    const v = new Vault(root);
+    await fs.writeFile(
+      path.join(root, "TildeFence.md"),
+      "# Real heading\n\n~~~sh\n## fake heading inside tilde fence\n~~~\n\n## Also real\n"
+    );
+    try {
+      const result = await readNote(v, { path: "TildeFence.md", format: "map" });
+      if (!("format" in result)) throw new Error("expected map projection");
+      expect(result.headings.map((h) => `${"#".repeat(h.level)} ${h.text}`)).toEqual([
+        "# Real heading",
+        "## Also real" // ## inside ~~~ must NOT appear
+      ]);
+    } finally {
+      await fs.unlink(path.join(root, "TildeFence.md")).catch(() => {});
+    }
+  });
+
   it('`format: "full"` (default) keeps existing shape', async () => {
     const v = new Vault(root);
     const result = await readNote(v, { path: "Alpha.md" });

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -447,6 +447,72 @@ describe("VaultWatcher with FTS5 index (v3.6 — reindex branches)", () => {
     }
   });
 
+  // v3.8.0-rc.10 — watcher embed-db sync error path: silent=false branch
+  // (lines 314-319 in watcher.ts). When the embedder throws, the watcher
+  // MUST: (a) still update FTS5 (fail-soft), (b) log the error to stderr
+  // when silent=false, (c) NOT update embed-db chunks. Tests the uncovered
+  // `if (!this.silent)` branch in the embed-db sync catch block.
+  it("attachEmbed: embed-db sync failure is logged to stderr (silent=false) and FTS5 still updates — NEGATIVE control", async () => {
+    const { EmbedDb } = await import("../src/embed-db.js");
+    const v = new Vault(root);
+    await v.ensureExists();
+    const fts = new FtsIndex({ file: defaultIndexFile(root), vaultRoot: root });
+    await fts.open();
+
+    // An embedder that always throws — simulates embed pipeline failure.
+    const throwingEmbedder = {
+      model: { alias: "throwing-mock", hfId: "mock", dim: 4, multilingual: false, maxTokens: 128 },
+      async embed(_texts: readonly string[]): Promise<Float32Array[]> {
+        throw new Error("synthetic embed failure for watcher test");
+      }
+    };
+    const embedDbFile = path.join(root, ".cache", "throwing.embed.db");
+    await fs.mkdir(path.dirname(embedDbFile), { recursive: true });
+    const embedDb = new EmbedDb({
+      file: embedDbFile,
+      vaultRoot: root,
+      modelAlias: "throwing-mock",
+      dim: 4,
+      quantization: "f32"
+    });
+    await embedDb.open();
+
+    const captured: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    // biome-ignore lint/suspicious/noExplicitAny: stderr.write has overloads
+    process.stderr.write = ((chunk: any) => {
+      if (typeof chunk === "string") captured.push(chunk);
+      return true;
+    }) as unknown as typeof process.stderr.write;
+
+    try {
+      const w = new VaultWatcher({ vault: v, ftsIndex: fts, silent: false });
+      w.attachEmbed(embedDb, throwingEmbedder, 0);
+      await w.start();
+      try {
+        await new Promise((r) => setTimeout(r, 50)); // chokidar FSEvents warmup
+        const filePath = path.join(root, "embed-error.md");
+        await fs.writeFile(filePath, "# Heading\n\nBody for embed error test.\n");
+        // FTS5 must still be updated (fail-soft) even though embed-db throws.
+        const ftsOk = await waitFor(() => fts.totalFiles() >= 1, 6000);
+        expect(ftsOk).toBe(true);
+        // Embed-db must NOT have been updated (the sync failed).
+        expect(embedDb.totalChunks()).toBe(0);
+        // Stderr must contain the embed-db sync failed message.
+        const hasEmbedError = captured.some(
+          (s) => s.includes("embed-db sync failed") && s.includes("synthetic embed failure")
+        );
+        expect(hasEmbedError).toBe(true);
+      } finally {
+        await w.close();
+      }
+    } finally {
+      process.stderr.write = origWrite;
+      embedDb.close();
+      fts.close();
+    }
+  });
+
   it("includePdfs=false: PDF events are silently ignored (P1-5 default safety)", async () => {
     const v = new Vault(root);
     await v.ensureExists();


### PR DESCRIPTION
## Summary

- **P3-25** — `extractHeadings` tilde-fence fix: regex `/^\s*```/` → `/^\s*(`{3,}|~{3,})/` (CommonMark allows `~~~` fences; fake headings inside tilde blocks were leaking into document-map projections)
- **P3-21** — `PERSISTENT_INDEX_HELP` wording: old text implied `--persistent-index` alone exposes `obsidian_full_text_search`; fixed to clarify both `--persistent-index` AND `--diagnostic-search-tools` are required
- **P3-27** — `loadHnswFromDisk` shallow validation: `dim`/`size`/`rowsByLabel` now validated before native hnswlib constructor call; invalid meta triggers clean rebuild + stderr warning instead of C-level crash
- **Watcher floor** — `attachEmbed` try/catch NEGATIVE control test: exercises embed-db sync failure path, lifting `watcher.ts` branch coverage 69% → ≥71%

## Test plan

- [ ] `npm test` → 846 tests pass (845 passed + 1 skipped reranker smoke)
- [ ] `npm run lint` → exit 0 (1 info: biome.json schema version — pre-existing)
- [ ] `npm run build` → tsc clean
- [ ] `npm run check:oia` → no findings
- [ ] All 9 required CI gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)