### PR TITLE
fix M-1 + L-1 from post-rc.10 audit: WATCH_HELP + stale coverage comment

### DIFF
--- a/scripts/check-per-file-coverage.mjs
+++ b/scripts/check-per-file-coverage.mjs
@@ -69,17 +69,12 @@ const FLOORS = {
   "src/tools/meta.ts": { branches: 71 }, // current 73.85% (rc.8 T-1 uplift)
   "src/tools/media.ts": { branches: 65 }, // current 67.93%
   "src/bases.ts": { branches: 71 }, // current 73.17%
-  // v3.8.0-rc.3 — lowered from 71% → 69% (current ~69.23%) because
-  // rc.3 expanded watcher.ts with a PDF embed-sync block (lines 240-288)
-  // that mirrors the rc.2 md path. The happy paths are covered by the
-  // rc.2 R-7 test + rc.3 R-7 PDF test in tests/watcher.test.ts; the
-  // fail-soft error branches (embedder throws) are integration-dep
-  // heavy (chokidar timing + pdfjs binary read) so chokidar-based
-  // tests for them flake at ~25% rate locally. Re-lifted in rc.4+
-  // when we either move embed-pipeline to its own module (enabling
-  // direct unit tests without watcher overhead) OR add dependency
-  // injection to make the throw path deterministic.
-  "src/watcher.ts": { branches: 69 }, // current ~69.23% (rc.3 expanded)
+  // v3.8.0-rc.3 — lowered from 71% → 69% because rc.3 expanded watcher.ts
+  // with a PDF embed-sync block (lines 240-288); the fail-soft error branches
+  // (embedder throws) required dependency injection to test deterministically.
+  // v3.8.0-rc.10 — the attachEmbed error-path NEGATIVE control test lifted
+  // coverage from ~69.23% → 71.15%; floor stays at 69% (2pp safety margin).
+  "src/watcher.ts": { branches: 69 }, // current ~71.15% (rc.10 attachEmbed error test)
   // v3.8.0-rc.4 — embed-pipeline extracted from server.ts. INFO-2
   // (round-24 audit) noted it was missing from FLOORS; added here in
   // rc.8 at floor 84% (2pp below current 86.84%).

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -48,3 +48,12 @@ export const DIAGNOSTIC_SEARCH_TOOLS_HELP =
  */
 export const PERSISTENT_INDEX_HELP =
   "Maintain a SQLite FTS5 inverted index for sub-100ms BM25-ranked search. Required for obsidian_full_text_search — also pass --diagnostic-search-tools to surface it alongside the default hybrid obsidian_search.";
+
+/**
+ * `--watch` flag help. Shared between `serve` and `serve-http` so the text
+ * cannot drift between subcommands (v3.8.0-rc.11 M-1 — N-5 recurrence fix:
+ * rc.6 updated serve-http, rc.7 updated serve to a *longer* string, leaving
+ * them still different; lifting here makes drift structurally impossible).
+ */
+export const WATCH_HELP =
+  "Watch the vault for .md and .pdf changes; incrementally re-syncs FTS5 and embed-db (when available). Off by default. Use this for long-running servers where you keep editing in Obsidian and want search to stay fresh without restarting.";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { DIAGNOSTIC_SEARCH_TOOLS_HELP, ENABLE_WRITE_HELP, PERSISTENT_INDEX_HELP } from "./cli-help.js";
+import { DIAGNOSTIC_SEARCH_TOOLS_HELP, ENABLE_WRITE_HELP, PERSISTENT_INDEX_HELP, WATCH_HELP } from "./cli-help.js";
 import { EmbedDb, peekEmbedDbMeta } from "./embed-db.js";
 import { DEFAULT_MODEL_ALIAS, EMBEDDING_MODELS, loadEmbedder, resolveModel } from "./embeddings.js";
 import { defaultIndexFile, FtsIndex, peekFtsMetaSafe, type TokenizeMode } from "./fts5.js";
@@ -119,10 +119,7 @@ export async function main(): Promise<void> {
       "--read-paths <pattern...>",
       "Strict allowlist — when set, ONLY paths matching one of these glob patterns are visible. Complement to --exclude-glob (denylist). If both are set: a path must match an allow-glob AND not match any exclude-glob. Same glob semantics as --exclude-glob (`*`, `**`, `?`). Repeatable. Example: `--read-paths '01_Projects/**' '99_Daily/**'`."
     )
-    .option(
-      "--watch",
-      "Watch the vault for .md and .pdf changes; incrementally re-syncs FTS5 and embed-db (when available). Off by default. Use this for long-running servers where you keep editing in Obsidian and want search to stay fresh without restarting."
-    )
+    .option("--watch", WATCH_HELP)
     .option(
       "--disabled-tools <name...>",
       "Skip registration of specific tools by exact name. Useful when you want to expose a smaller surface to a particular agent (e.g. read-only research agent gets only obsidian_search_text + obsidian_read_note). Repeatable. Names are the same as in `tools/list` — `obsidian_*`. Example: `--disabled-tools obsidian_dataview_query obsidian_full_text_search`."
@@ -194,10 +191,7 @@ export async function main(): Promise<void> {
     .option("--tokenize <mode>", "FTS5 tokenize mode: 'unicode61' (default) or 'trigram'")
     .option("--exclude-glob <pattern...>", "Privacy denylist (same semantics as `serve`).")
     .option("--read-paths <pattern...>", "Privacy allowlist (same semantics as `serve`).")
-    .option(
-      "--watch",
-      "Watch the vault for .md and .pdf changes; incrementally re-syncs FTS5 and embed-db (when available)."
-    )
+    .option("--watch", WATCH_HELP)
     .option("--disabled-tools <name...>", "Skip registration of specific tools by name.")
     .option("--enabled-tools <name...>", "Strict allowlist — when set, ONLY listed tools register.")
     .option("--diagnostic-search-tools", DIAGNOSTIC_SEARCH_TOOLS_HELP);


### PR DESCRIPTION
## Summary

Two findings from the post-rc.10 state-driven audit:

**M-1 (MEDIUM) — `--watch` help text parity (N-5 recurrence)**

After rc.6 (updated serve-http) and rc.7 ("fixed" serve), the strings were still different — rc.7 chose a longer text for `serve` rather than making them identical. Root fix: add `WATCH_HELP` constant to `src/cli-help.ts` (same pattern as `ENABLE_WRITE_HELP`, `DIAGNOSTIC_SEARCH_TOOLS_HELP`, `PERSISTENT_INDEX_HELP`) and use it in both `serve` and `serve-http` `--watch` registrations in `src/cli.ts`. Drift is now structurally impossible — one source of truth.

**L-1 (LOW) — stale comment in `scripts/check-per-file-coverage.mjs`**

Line 82 said `// current ~69.23% (rc.3 expanded)` but rc.10 lifted `watcher.ts` branch coverage to 71.15%. Updated comment; floor stays at 69%.

## Test plan

- [ ] `npm run build` → tsc clean
- [ ] `npm run lint` → exit 0
- [ ] `npm test` → 846 pass (unchanged)
- [ ] `grep -c WATCH_HELP src/cli.ts` → 3 (import + 2 usages)
- [ ] All 9 required CI gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)