### PR TITLE
v3.8.0-rc.13: AI/LLM discoverability Tier B — MCP Registry + CITATION.cff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0-rc.13] — 2026-05-24
+
+> **TL;DR:** Thirteenth v3.8.0 release candidate. **AI/LLM discoverability Tier B** — adds `mcpName` field to `package.json` (`io.github.oomkapwn/enquire-mcp`) and ships `server.json` at repo root, both required by the official MCP Registry verification (registry.modelcontextprotocol.io). Adds `CITATION.cff` for academic discoverability (Google Scholar / Semantic Scholar) citing the underlying research papers (HyDE, RRF, BM25, Louvain, HNSW, BGE). After this RC ships to npm, mcp-publisher can submit to the canonical MCP Registry — which auto-propagates to glama.ai, mcp.so, smithery.ai, and other downstream registries. **No code changes; metadata + documentation only.** 848 tests unchanged. Ships under `@rc` dist-tag.
+
+**Minor — thirteenth v3.8.0 release candidate.**
+
+### Add `mcpName` to package.json + `server.json` at repo root
+
+**Background.** The official MCP Registry (registry.modelcontextprotocol.io, launched September 2025, API v0.1 frozen October 2025) is the canonical source of MCP server metadata. Maintained by Anthropic + GitHub + PulseMCP + Stacklok, it's the upstream that glama.ai, mcp.so, smithery.ai, and other downstream registries sync from. Publishing here = auto-discovery on every downstream registry.
+
+Verification requires two things on the npm package side:
+1. `mcpName` field in `package.json` set to `io.github.<github-username>/<repo-name>` for GitHub-auth submissions
+2. The npm package must be published with this field present
+
+**Fix:**
+- Added `"mcpName": "io.github.oomkapwn/enquire-mcp"` to `package.json`
+- Created `server.json` at repo root using the v2025-12-11 schema with: name, description, repository, version, npm package identifier, stdio transport, runtime arguments (`serve` subcommand + `--vault` named arg)
+
+After rc.13 publishes to npm with the new field, the `mcp-publisher` CLI can be run locally to submit `server.json` to the official MCP Registry (GitHub OAuth auth). Downstream registries (glama, mcp.so, smithery) typically sync within 24-48 hours.
+
+### Add `CITATION.cff` for academic discoverability
+
+**Background.** enquire-mcp's retrieval stack is research-heritage: HyDE (Gao et al 2023), RRF (Cormack et al 2009), BM25 (Robertson et al 1995), Louvain modularity (Blondel et al 2008), HNSW (Malkov & Yashunin 2020), BGE (Xiao et al 2023). Academic search engines (Google Scholar, Semantic Scholar, OpenAlex) parse `CITATION.cff` files at repo roots to register the project as a citable software artifact and to cross-reference it with the underlying papers.
+
+**Fix:** Created `CITATION.cff` at repo root following the Citation File Format v1.2.0. Includes: project metadata (title, abstract, repository, license, keywords) + 6 paper references for the core retrieval algorithms with authors, year, journal, DOI URL, and explanatory `notes` field linking each paper to the enquire-mcp feature that implements it.
+
+### Stats
+
+- **848 tests** (unchanged — metadata + docs only).
+- 2 new repo-root files: `server.json` (1.0 KB), `CITATION.cff` (4.5 KB).
+- `package.json`: +1 field (`mcpName`).
+- `npm audit`: 0 vulnerabilities.
+- Dist-tag: `@rc` (v3.7.20 stays `@latest`).
+- All 9 required CI gates pass locally.
+
+### v3.8.0 remaining backlog
+
+- **Tier B0** (this RC enables): run `mcp-publisher publish` locally to submit `server.json` to the official MCP Registry after rc.13 hits npm.
+- **Tier B4**: PR to punkpeye/awesome-mcp-servers — Knowledge & Memory category.
+- **Tier C**: JSON-LD `SoftwareApplication` schema on GH Pages (TypeDoc theme tweak), GitHub Sponsors funding.yml.
+- **T-2, T-3** — communities handler + hyde E2E.
+- **T-4** — optional serve-http HTTP smoke.
+- **Multi-subcommand CLI drift audit** (from rc.11 RCA).
+- OCR'd PDF watcher embed-sync, HNSW in-memory watcher update.
+- External audit before `@latest` promotion.
+
+---
+
 ## [3.8.0-rc.12] — 2026-05-24
 
 > **TL;DR:** Twelfth v3.8.0 release candidate. **AI/LLM discoverability improvements (Tier A)** — adds `llms.txt` (https://llmstxt.org/ standard for AI agent discovery), `AGENTS.md` (Cursor 2.0 / Claude Code / Codex coding-agent convention), tightens npm `description` from 756 → 506 chars (better truncation handling in npm search UI), adds "TL;DR for AI agents" callout + "Set up in your AI agent" copy-paste prompts section in README. `llms.txt` also served from GH Pages at https://oomkapwn.github.io/enquire-mcp/llms.txt so ChatGPT browsing, Perplexity, Claude.ai web fetches discover the project via the standard URL. **No code changes; documentation + metadata only.** 848 tests unchanged. Ships under `@rc` dist-tag.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,135 @@
+# Citation File Format v1.2.0 — https://citation-file-format.github.io/
+# Adopted v3.8.0-rc.12 for academic discoverability (Google Scholar,
+# Semantic Scholar, OpenAlex). The retrieval stack is research-heritage
+# (HyDE, RRF, BM25, Louvain) so registering the citation enables
+# academic cross-linking from papers that benchmark / build on it.
+cff-version: 1.2.0
+message: "If you use enquire-mcp in research, please cite it as below."
+type: software
+title: "enquire-mcp"
+abstract: >-
+  MCP server providing long-term memory for AI agents (Claude Code,
+  Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) backed by a local
+  Obsidian markdown vault. Hybrid retrieval (BM25 + TF-IDF + multilingual
+  ML embeddings, RRF-fused), BGE cross-encoder reranking, HNSW + int8
+  quantization, HyDE + sub-question decomposition for agentic RAG,
+  Louvain wikilink community detection (GraphRAG-light), standalone
+  Obsidian Bases query execution, PDFs blended into search with
+  Tesseract OCR. Vendor-neutral, open-source, MIT.
+authors:
+  - given-names: "Alex"
+    family-names: "Oomka"
+    alias: "oomkapwn"
+    orcid: ""
+repository-code: "https://github.com/oomkapwn/enquire-mcp"
+url: "https://www.npmjs.com/package/@oomkapwn/enquire-mcp"
+license: MIT
+keywords:
+  - "MCP"
+  - "Model Context Protocol"
+  - "long-term memory"
+  - "AI agents"
+  - "Obsidian"
+  - "hybrid retrieval"
+  - "BM25"
+  - "RRF"
+  - "reciprocal rank fusion"
+  - "HNSW"
+  - "agentic RAG"
+  - "HyDE"
+  - "GraphRAG"
+  - "Louvain community detection"
+  - "BGE reranker"
+  - "vector quantization"
+  - "semantic search"
+  - "retrieval-augmented generation"
+references:
+  - type: article
+    title: "Precise Zero-Shot Dense Retrieval without Relevance Labels"
+    authors:
+      - family-names: "Gao"
+        given-names: "Luyu"
+      - family-names: "Ma"
+        given-names: "Xueguang"
+      - family-names: "Lin"
+        given-names: "Jimmy"
+      - family-names: "Callan"
+        given-names: "Jamie"
+    year: 2023
+    journal: "arXiv preprint"
+    notes: "HyDE — Hypothetical Document Embeddings. enquire-mcp implements this in obsidian_hyde_search."
+    url: "https://arxiv.org/abs/2212.10496"
+  - type: article
+    title: "Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods"
+    authors:
+      - family-names: "Cormack"
+        given-names: "Gordon V."
+      - family-names: "Clarke"
+        given-names: "Charles L. A."
+      - family-names: "Buettcher"
+        given-names: "Stefan"
+    year: 2009
+    conference:
+      name: "SIGIR '09 — Proceedings of the 32nd international ACM SIGIR conference on Research and development in information retrieval"
+    notes: "RRF with k=60. enquire-mcp fuses BM25, TF-IDF, and embedding rankings via this method."
+    url: "https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf"
+  - type: article
+    title: "Okapi at TREC-3"
+    authors:
+      - family-names: "Robertson"
+        given-names: "Stephen E."
+      - family-names: "Walker"
+        given-names: "Steve"
+      - family-names: "Jones"
+        given-names: "Susan"
+      - family-names: "Hancock-Beaulieu"
+        given-names: "Micheline M."
+      - family-names: "Gatford"
+        given-names: "Mike"
+    year: 1995
+    journal: "NIST Special Publication"
+    notes: "BM25 ranking function. enquire-mcp uses SQLite FTS5's BM25 implementation."
+    url: "https://www.microsoft.com/en-us/research/publication/okapi-at-trec-3/"
+  - type: article
+    title: "Fast unfolding of communities in large networks"
+    authors:
+      - family-names: "Blondel"
+        given-names: "Vincent D."
+      - family-names: "Guillaume"
+        given-names: "Jean-Loup"
+      - family-names: "Lambiotte"
+        given-names: "Renaud"
+      - family-names: "Lefebvre"
+        given-names: "Etienne"
+    year: 2008
+    journal: "Journal of Statistical Mechanics: Theory and Experiment"
+    notes: "Louvain modularity optimization. enquire-mcp uses this for wikilink community detection (GraphRAG-light)."
+    url: "https://arxiv.org/abs/0803.0476"
+  - type: article
+    title: "Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs"
+    authors:
+      - family-names: "Malkov"
+        given-names: "Yu A."
+      - family-names: "Yashunin"
+        given-names: "D. A."
+    year: 2020
+    journal: "IEEE Transactions on Pattern Analysis and Machine Intelligence"
+    volume: "42"
+    issue: "4"
+    notes: "HNSW vector index. enquire-mcp uses hnswlib-node for sub-10ms top-K vector retrieval."
+    url: "https://arxiv.org/abs/1603.09320"
+  - type: article
+    title: "C-Pack: Packed Resources For General Chinese Embeddings"
+    authors:
+      - family-names: "Xiao"
+        given-names: "Shitao"
+      - family-names: "Liu"
+        given-names: "Zheng"
+      - family-names: "Zhang"
+        given-names: "Peitian"
+      - family-names: "Muennighoff"
+        given-names: "Niklas"
+    year: 2023
+    journal: "arXiv preprint"
+    notes: "BAAI BGE embedding + reranker models. enquire-mcp uses bge-multilingual-gemma2 and bge-reranker-base."
+    url: "https://arxiv.org/abs/2309.07597"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.8.0-rc.12",
+  "version": "3.8.0-rc.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.8.0-rc.12",
+      "version": "3.8.0-rc.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.8.0-rc.12",
+  "version": "3.8.0-rc.13",
+  "mcpName": "io.github.oomkapwn/enquire-mcp",
   "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 44 tools, 19 MCP prompts, 848 tests, SLSA-3, semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.oomkapwn/enquire-mcp",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent.",
+  "repository": {
+    "url": "https://github.com/oomkapwn/enquire-mcp",
+    "source": "github"
+  },
+  "version": "3.8.0-rc.13",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@oomkapwn/enquire-mcp",
+      "version": "3.8.0-rc.13",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "description": "Subcommand (serve = stdio MCP server; serve-http = remote MCP over HTTP; setup = download model + build indexes; doctor = health check)",
+          "isRequired": true,
+          "format": "string",
+          "default": "serve",
+          "type": "positional"
+        },
+        {
+          "description": "Path to your Obsidian vault root directory",
+          "isRequired": true,
+          "format": "string",
+          "type": "named",
+          "name": "--vault"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.8.0-rc.12";
+export const VERSION = "3.8.0-rc.13";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below


### PR DESCRIPTION
## Summary

Tier B discoverability — enables canonical MCP Registry submission + academic citation.

- **\`mcpName\`** field in \`package.json\`: \`io.github.oomkapwn/enquire-mcp\` (required for MCP Registry verification)
- **\`server.json\`** at repo root (v2025-12-11 schema)
- **\`CITATION.cff\`** at repo root with 6 paper refs (HyDE, RRF, BM25, Louvain, HNSW, BGE)

After this RC publishes to npm, \`mcp-publisher publish\` submits \`server.json\` to the canonical MCP Registry. Downstream registries (glama.ai, mcp.so, smithery.ai) auto-sync.

## Test plan

- [ ] \`npm test\` → 848 pass (unchanged)
- [ ] \`npm run lint\` → exit 0
- [ ] \`node scripts/check-version-consistency.mjs\` → 3.8.0-rc.13 across 5 surfaces
- [ ] \`node scripts/oia-walk.mjs\` → no findings
- [ ] After merge + npm publish: submit via \`mcp-publisher publish\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)