### PR TITLE
fix(server.json): match MCP Registry v2025-12-11 schema

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent.",
+  "description": "Long-term memory for AI agents — your Obsidian vault as searchable persistent memory.",
   "repository": {
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
@@ -17,18 +17,19 @@
       },
       "runtimeArguments": [
         {
-          "description": "Subcommand (serve = stdio MCP server; serve-http = remote MCP over HTTP; setup = download model + build indexes; doctor = health check)",
+          "type": "positional",
+          "valueHint": "subcommand",
+          "value": "serve",
+          "description": "Subcommand: serve (stdio MCP), serve-http (remote MCP), setup (download model + build indexes), doctor (health check)",
           "isRequired": true,
-          "format": "string",
-          "default": "serve",
-          "type": "positional"
+          "format": "string"
         },
         {
+          "type": "named",
+          "name": "--vault",
           "description": "Path to your Obsidian vault root directory",
           "isRequired": true,
-          "format": "string",
-          "type": "named",
-          "name": "--vault"
+          "format": "string"
         }
       ]
     }


### PR DESCRIPTION
## Summary

server.json was added in rc.13 but failed MCP Registry validation. Fixed inline during the registry submission process; committing the corrected file back to main.

Fixes:
1. description length must be ≤ 100 chars (was 489) — tightened to 91
2. PositionalArgument requires \`valueHint\` + \`value\` fields
3. NamedArgument requires \`name\` + \`type:named\` in specific order

## Verification

\`mcp-publisher validate\` passes cleanly. First successful publish:
- io.github.oomkapwn/enquire-mcp v3.8.0-rc.13
- Published at 2026-05-24 09:18 UTC, status: \`active\`, isLatest: \`true\`
- Live at https://registry.modelcontextprotocol.io/v0.1/servers?search=enquire

## Test plan

- [ ] \`mcp-publisher validate\` → \`server.json is valid\`
- [ ] CI green