### PR TITLE
v3.10.0-rc.3: gate-gap closure (smoke-from-manifest + enforcement-guard taxonomy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1056+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1059+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.3] — 2026-06-02
+
+> **TL;DR:** **Gate-gap closure — two structural defenses, zero `src/` runtime change.** A post-rc.2 self-audit caught two places where the apparatus was weaker than CLAUDE.md implies. **(1) smoke-from-manifest:** `scripts/smoke.mjs` hardcoded the expected read-tool set + count, so every new tool (rc.2's `obsidian_stale_notes` among them) silently broke smoke until hand-patched — a hidden coupling the `smoke` CI gate masked as a real failure. It now **derives the expected set from `TOOL_MANIFEST`** (single source of truth), so adding a tool never requires editing smoke again. **(2) enforcement-guard taxonomy:** the META-audit's #3 uncovered behavioral dimension (the **#15/#16 "claimed-guarantee vs code-guard" overclaim class**) had only two surface-specific verifiers (OIA 4d for SLSA, 4e for OCR-offline). New `tests/enforcement-guard-invariant.test.ts` is the **generalized** defense: a curated 10-entry inventory mapping each `SECURITY.md` enforcement claim → the exact code-guard symbol that backs it, failing CI if either the marker or the guard goes missing. **1056 → 1059 tests.**
+
+**Minor (pre-release) — v3.10 line; gate-gap / structural-defense increment.**
+
+### Added
+
+- **`tests/enforcement-guard-invariant.test.ts`** (+3 source `it()`) — the generalized enforcement-verb→code-guard taxonomy (closes the last open Tier-0 item: "a GENERALIZED enforcement-verb grep beyond the SLSA/OCR specifics"). A curated `GUARANTEES` manifest pins 10 `SECURITY.md` claims to their backing symbols (`resolveSafePath`, `assertOcrLangsInstalled`, `cacheMethod`, `MAX_OCR_CANVAS_DIM`, `DEFAULT_OCR_MAX_PAGES`, `0o600`, `0o700`, `SAFE_SCHEMA`, `sweepIdle`, `Allow-Credentials`); `checkGuarantee()` fails if the claim's marker is absent from SECURITY.md **or** the guard symbol is absent from `src/`. 1 positive + 2 NEGATIVE controls (missing guard symbol; missing SECURITY.md marker). This is the inventory-based form of the #15/#16 class — the META-audit's prescription: convert "did we remember to back claim X with a guard?" into a self-checking gate.
+
+### Changed
+
+- **`scripts/smoke.mjs`** — the expected read-tool set + count are now **derived from `TOOL_MANIFEST`** (`gating === "always" || "--diagnostic-search-tools" || (withFts && includes("--persistent-index"))`) instead of a hardcoded `baseTools` array + `expectedCount`. Closes the rc.2 gate-gap where a new tool broke `smoke` until the spec was hand-edited; the smoke gate now self-updates with the manifest. Two checks: derived-count match + exact name-set match (`JSON.stringify` equality against the sorted derived set).
+
+### Method note
+
+Both fixes are the same shape as the rc.36 meta-audit conclusion — **the apparatus is drift/claim-driven and was blind to two structural gaps**: (1) a test-fixture that duplicated a single source of truth (smoke's tool list vs `TOOL_MANIFEST`) and silently required manual sync, and (2) a claim-class (#15/#16 enforced-guarantee) that had only point defenses, not an inventory invariant. Per the rule "when an external lens finds a behavioral bug, internalize THAT LENS as an inventory invariant," the enforcement-guard test generalizes the two surface-specific OIA checks into one extensible manifest. **Zero `src/` runtime change** — scripts + tests only. **Deferred to rc.4:** plumb `age_days`/`stale` into the hybrid `SearchHybridHit` (the primary search surface — needs a path→mtime map across the multi-stage RRF fusion incl. `path#chunk-N` rows).
+
+### Tests (1059)
+
+`tests/enforcement-guard-invariant.test.ts` +3 source `it()`. 1056 → 1059; claims synced (README ×4 incl. tests badge, package.json, llms.txt, AGENTS, COMPARISON, ROADMAP). `scripts/smoke.mjs` is a script (no `it()`), so the smoke refactor does not change the count.
+
+### Files changed
+
+- `scripts/smoke.mjs` (derive from `TOOL_MANIFEST`), `tests/enforcement-guard-invariant.test.ts` (new), test-count claims → 1059.
+- version bump 3.10.0-rc.2 → 3.10.0-rc.3.
+
+---
+
 ## [3.10.0-rc.2] — 2026-06-01
 
 > **TL;DR:** **v3.10 staleness increment 2 — the `obsidian_stale_notes` tool (the flagship forgetting-aware capability).** A new always-on read tool (the **45th** tool): "what's gone stale in my vault?" — lists notes not edited in N days (default 365), oldest first, so an agent can proactively flag or refresh aged facts instead of recalling them as if current (the Memora frontier). Cheap **mtime-only** scan (`vault.listMarkdown()` + rc.1's `computeStaleness` — NO `readNote`, so it's not a whole-vault content scan and isn't a resource-bound scanner). Self-contained — zero change to the critical search path. The tool-count cascade (44 → 45, always-on read 33 → 34) is fully gate-verified by `docs-consistency` against `TOOL_MANIFEST`. **1050 → 1056 tests.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1056%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1059%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -46,7 +46,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 2. **Best-in-class retrieval.** Hybrid BM25 + multilingual embeddings + BGE cross-encoder reranker fused via RRF, scaled with HNSW + int8 quantization. The same IR stack a search startup would build — open-sourced, in one binary.
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 
-**45 tools · 19 MCP prompts · 1056 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1059 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -184,7 +184,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1056 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1059 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -294,7 +294,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1056 tests, ~12s)
+npm test       # full suite (1059 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ Already shipped and differentiating:
 - **GraphRAG-light** — Louvain community detection over the wikilink graph.
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
-- **Process maturity** — 1056 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1059 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -43,7 +43,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Read open editor state, active note, etc.     | **No**              | **Yes**          | Limited          | No               | No               |
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
-| Test count (public)                           | **1056**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1059**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1056 unit tests passing on every PR
+- 1059 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.2",
+  "version": "3.10.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.2",
+      "version": "3.10.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.2",
+  "version": "3.10.0-rc.3",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1056 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1059 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { TOOL_MANIFEST } from "../dist/tool-manifest.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
@@ -98,62 +99,30 @@ try {
 
   const list = await rpc("tools/list", {});
   const names = (list.result?.tools ?? []).map((t) => t.name).sort();
-  // v3.10.0: 37 tools (with --diagnostic-search-tools): 34 always-on read +
-  // 3 single-ranker diagnostic tools. With --persistent-index: + 1
-  // (obsidian_full_text_search) = 38.
-  // v3.1.0 added obsidian_hyde_search (HyDE retrieval) to always-on.
-  // v3.2.0 added 3 .base file tools: list_bases / read_base / query_base.
-  // v3.4.0 added obsidian_get_communities (GraphRAG-light).
-  // v3.10.0-rc.2 added obsidian_stale_notes (forgetting-aware staleness).
-  // NOTE: this spec is hardcoded — keep it in sync with TOOL_MANIFEST on any
-  // tool add (docs-consistency gates the doc counts; this smoke gates serve).
-  const expectedCount = withFts ? 38 : 37;
+  // v3.10.0-rc.3: the expected read-tool set is DERIVED from TOOL_MANIFEST, not
+  // hardcoded — so adding a tool can no longer silently break smoke (the rc.2
+  // gate-gap). smoke launches serve with `--diagnostic-search-tools` (+
+  // `--persistent-index` when `--with-fts`) and NOT `--enable-write`, so the
+  // registered surface is exactly: gating "always" + "--diagnostic-search-tools"
+  // (+ the single fts tool when withFts). This mirrors the registry's gating.
+  const expected = TOOL_MANIFEST.filter(
+    (t) =>
+      t.gating === "always" ||
+      t.gating === "--diagnostic-search-tools" ||
+      (withFts && t.gating.includes("--persistent-index"))
+  )
+    .map((t) => t.name)
+    .sort();
   check(
-    `tools/list returns ${expectedCount} read tools`,
-    names.length === expectedCount,
-    `got ${JSON.stringify(names)}`
+    `tools/list returns ${expected.length} read tools (derived from TOOL_MANIFEST)`,
+    names.length === expected.length,
+    `expected ${expected.length}, got ${names.length}: ${JSON.stringify(names)}`
   );
-  const baseTools = [
-    "obsidian_chat_thread_read",
-    "obsidian_context_pack",
-    "obsidian_dataview_query",
-    "obsidian_embeddings_search",
-    "obsidian_find_path",
-    "obsidian_find_similar",
-    "obsidian_frontmatter_get",
-    "obsidian_frontmatter_search",
-    "obsidian_get_backlinks",
-    "obsidian_get_communities",
-    "obsidian_get_note_neighbors",
-    "obsidian_get_outbound_links",
-    "obsidian_get_recent_edits",
-    "obsidian_get_unresolved_wikilinks",
-    "obsidian_hyde_search",
-    "obsidian_lint_wiki",
-    "obsidian_list_bases",
-    "obsidian_list_canvases",
-    "obsidian_list_notes",
-    "obsidian_list_pdfs",
-    "obsidian_list_tags",
-    "obsidian_ocr_pdf",
-    "obsidian_open_in_ui",
-    "obsidian_open_questions",
-    "obsidian_paper_audit",
-    "obsidian_query_base",
-    "obsidian_read_base",
-    "obsidian_read_canvas",
-    "obsidian_read_note",
-    "obsidian_read_pdf",
-    "obsidian_resolve_wikilink",
-    "obsidian_search",
-    "obsidian_search_text",
-    "obsidian_semantic_search",
-    "obsidian_stale_notes",
-    "obsidian_stats",
-    "obsidian_validate_note_proposal"
-  ];
-  const expected = withFts ? [...baseTools, "obsidian_full_text_search"].sort() : baseTools;
-  check("tool names match spec", JSON.stringify(names) === JSON.stringify(expected), JSON.stringify(names));
+  check(
+    "tool names match TOOL_MANIFEST-derived set",
+    JSON.stringify(names) === JSON.stringify(expected),
+    JSON.stringify(names)
+  );
   const allReadOnly = (list.result?.tools ?? []).every((t) => t.annotations?.readOnlyHint === true);
   check("read tools all have readOnlyHint=true", allReadOnly, "missing annotations");
 

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.2",
+  "version": "3.10.0-rc.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.2",
+      "version": "3.10.0-rc.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.2";
+export const VERSION = "3.10.0-rc.3";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/tests/enforcement-guard-invariant.test.ts
+++ b/tests/enforcement-guard-invariant.test.ts
@@ -1,0 +1,100 @@
+// v3.10.0-rc.3 — ENFORCEMENT-GUARANTEE → CODE-GUARD INVARIANT.
+//
+// Generalizes OIA Check 4d (SLSA-level) + 4e (OCR-offline) into a curated
+// inventory: every load-bearing SECURITY.md guarantee must (a) still be PRESENT
+// in SECURITY.md AND (b) point to a named code-guard symbol that EXISTS in src.
+// Closes the overclaim #15/#16 class — a doc that claims an ENFORCED guarantee
+// ("blocked", "rejected", "fails closed", "0600", a named cap) that no code
+// path actually backs. It's the most externally-verifiable overclaim class
+// (an auditor reads the claim → checks the code), so it gets a permanent gate.
+//
+// DELIBERATELY CURATED, not a full-prose scan of SECURITY.md. A blanket grep
+// for enforcement verbs over free prose is high-false-positive (most such
+// sentences are descriptive context, not enforced guarantees) — the exact
+// noise the rc.36 meta-audit warned against. So this pins the ~dozen
+// load-bearing guarantees to their guards; a genuinely NEW guarantee is added
+// by a human who must add a manifest entry (the same inventory discipline as
+// erasure-invariant / resource-bound-invariant). Completeness over ALL prose
+// is an accepted non-goal; the value is that the KEY guarantees can't silently
+// lose their guard (a rename/refactor that drops the guard fails CI).
+
+import { readdirSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..");
+
+/** Concatenated text of every `src/**.ts` — the guard-symbol search space. */
+function srcBlob(): string {
+  const parts: string[] = [];
+  const walk = (dir: string) => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name.endsWith(".ts")) parts.push(readFileSync(p, "utf8"));
+    }
+  };
+  walk(path.join(repoRoot, "src"));
+  return parts.join("\n");
+}
+
+// Each entry: a SECURITY.md `marker` (distinctive substring of the guarantee)
+// + a `symbol` that MUST exist in src/ as the code guard enforcing it.
+const GUARANTEES: Array<{ label: string; marker: string; symbol: string }> = [
+  { label: "path/symlink escape rejected", marker: "resolve outside are rejected", symbol: "resolveSafePath" },
+  { label: "OCR offline — CDN path blocked", marker: "blocks that path entirely", symbol: "assertOcrLangsInstalled" },
+  { label: "OCR worker read-only cache", marker: "cacheMethod", symbol: "cacheMethod" },
+  { label: "OCR canvas-dimension clamp (OOM)", marker: "MAX_OCR_CANVAS_DIM", symbol: "MAX_OCR_CANVAS_DIM" },
+  { label: "OCR per-call page cap", marker: "DEFAULT_OCR_MAX_PAGES", symbol: "DEFAULT_OCR_MAX_PAGES" },
+  { label: "restrictive file mode 0600", marker: "0600", symbol: "0o600" },
+  { label: "restrictive dir mode 0700", marker: "0700", symbol: "0o700" },
+  { label: "YAML parsed via SAFE_SCHEMA (no code-exec)", marker: "SAFE_SCHEMA", symbol: "SAFE_SCHEMA" },
+  { label: "HTTP session idle eviction (memory bound)", marker: "Idle eviction", symbol: "sweepIdle" },
+  { label: "CORS omits credentials on wildcard", marker: "Allow-Credentials", symbol: "Allow-Credentials" }
+];
+
+/** null = OK; else an explanation of the broken claim↔guard link. */
+function checkGuarantee(
+  g: { label: string; marker: string; symbol: string },
+  security: string,
+  src: string
+): string | null {
+  if (!security.includes(g.marker)) {
+    return `SECURITY.md no longer contains "${g.marker}" — the "${g.label}" guarantee was reworded/removed; update this manifest.`;
+  }
+  if (!src.includes(g.symbol)) {
+    return `code guard "${g.symbol}" for "${g.label}" is MISSING from src — SECURITY.md claims an enforcement nothing backs (overclaim #15/#16 class).`;
+  }
+  return null;
+}
+
+describe("enforcement-guarantee → code-guard invariant (rc.3, overclaim #15/#16 class)", () => {
+  it("every curated SECURITY.md guarantee still maps to a present code guard", () => {
+    const security = readFileSync(path.join(repoRoot, "SECURITY.md"), "utf8");
+    const src = srcBlob();
+    const offenders = GUARANTEES.map((g) => checkGuarantee(g, security, src)).filter(Boolean) as string[];
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  // NEGATIVE control: a guarantee whose guard symbol is absent from src MUST be
+  // flagged — otherwise the invariant is vacuous and an unenforced claim slips.
+  it("NEGATIVE control — flags a guarantee whose code guard is missing from src", () => {
+    const err = checkGuarantee(
+      { label: "fake", marker: "resolve outside are rejected", symbol: "__no_such_guard_symbol__" },
+      readFileSync(path.join(repoRoot, "SECURITY.md"), "utf8"),
+      srcBlob()
+    );
+    expect(err).toMatch(/MISSING from src/);
+  });
+
+  // NEGATIVE control: a guarantee whose SECURITY.md marker is gone MUST be
+  // flagged (so a doc rewrite that drops the claim doesn't leave a dangling guard).
+  it("NEGATIVE control — flags a guarantee whose SECURITY.md marker is gone", () => {
+    const err = checkGuarantee(
+      { label: "fake", marker: "__not in security md__", symbol: "resolveSafePath" },
+      "irrelevant security text",
+      "const resolveSafePath = 1;"
+    );
+    expect(err).toMatch(/no longer contains/);
+  });
+});


### PR DESCRIPTION
## Summary

Two structural defenses caught by a post-rc.2 self-audit. **Zero `src/` runtime change** (version-string sync only).

- **smoke-from-manifest** — `scripts/smoke.mjs` derived the expected read-tool set + count from a hardcoded `baseTools` array, so every new tool (rc.2's `obsidian_stale_notes`) silently broke `smoke` until hand-patched. It now derives the set from `TOOL_MANIFEST` (single source of truth) — `gating === "always" || "--diagnostic-search-tools" || (withFts && includes("--persistent-index"))`. Adding a tool never requires editing smoke again.
- **enforcement-guard taxonomy** — `tests/enforcement-guard-invariant.test.ts` (new, +3 `it()`) closes the last open Tier-0 item: a *generalized* enforcement-verb→code-guard defense beyond the SLSA/OCR-specific OIA 4d/4e. A curated 10-entry `GUARANTEES` inventory maps each `SECURITY.md` enforcement claim → the exact code-guard symbol that backs it (`resolveSafePath`, `assertOcrLangsInstalled`, `cacheMethod`, `MAX_OCR_CANVAS_DIM`, `DEFAULT_OCR_MAX_PAGES`, `0o600`, `0o700`, `SAFE_SCHEMA`, `sweepIdle`, `Allow-Credentials`); fails CI if either the marker or the guard goes missing. 1 positive + 2 NEGATIVE controls. This is the inventory-based form of the #15/#16 "claimed-guarantee vs code-guard" overclaim class — the META-audit's prescription.

Tests **1056 → 1059**; claims synced (README ×4 incl. badge, package.json, llms.txt, AGENTS, COMPARISON, ROADMAP).

## Test plan

- [x] `npm run lint` — biome clean (0 errors)
- [x] `npm run build` — tsc strict + noUncheckedIndexedAccess clean
- [x] `node scripts/check-version-consistency.mjs` — 7 surfaces @ 3.10.0-rc.3
- [x] `npm run test:coverage` — 1124 passed + 2 skipped; lines 89.65% / stmts 86.53% / fns 82.13% / branches 76.51% (all ≥ floors)
- [x] `node scripts/check-per-file-coverage.mjs` — 12 floors met
- [x] `node scripts/oia-walk.mjs` — no findings (12 checks)
- [x] `node scripts/scope-completeness-audit.mjs` — no gaps
- [x] `node scripts/smoke.mjs` — all checks pass (37 read tools derived from TOOL_MANIFEST) + serve-http variant
- [x] `npm run docs:api` — TypeDoc clean (treatWarningsAsErrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)