### PR TITLE
v3.10.0-rc.8: post-rc.7 audit — fusion-stage isExcluded parity + vacuous-test correction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1072+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1076+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.8] — 2026-06-02
+
+> **TL;DR:** **Post-rc.7 audit response — fusion-stage privacy parity (defense-in-depth) + a self-caught vacuous-test correction.** A state-driven audit of the rc.3→rc.7 line (behavioral/threat lens, per the rc.36 meta-audit) found that the two fusion-stage consumers of the RRF `fused` list — pre-existing **graph-boost** (calls `vault.readNote` to parse a candidate's wikilinks → reads its **content**) and the rc.5 **recency re-rank** (stats a candidate's **mtime**) — both run BEFORE the rc.18 L-HYB-1 response-build `isExcluded` guard and don't replicate it. Not exploitable today (every ranker arm already drops excluded paths before `fused`, and the response-build guard drops them from output), so this is a **third, defense-in-depth layer** for a hypothetical future ranker-arm regression — exactly the "RRF fusion trusts ranker inputs; don't" rationale L-HYB-1 was shipped on. Fixed by pruning excluded paths from `fused` once at the source via a new pure `pruneExcludedHits`. **The audit also caught itself overclaiming:** the first test written for this was an *integration* test that **passed with the fix disabled** (vacuous — the per-arm filters prevent an excluded path from ever reaching `fused` through the public API). The revert-verify exposed it; it was replaced with a **pure-helper unit test** that actually fails when the guard is removed. **1072 → 1076 tests.** `src/` change is one fusion-stage filter line + the extracted helper.
+
+**Minor (pre-release) — v3.10 line; post-sprint audit hardening.**
+
+### Added
+
+- **`pruneExcludedHits(hits, isExcluded, granularity)`** in `src/tools/search.ts` — pure, granularity-aware (`block` ids strip the `#chunk` suffix before the membership test, matching the response-build guard's `lastIndexOf("#")` logic exactly). `searchHybrid` now calls it on `fused` immediately after RRF, so graph-boost + recency + matches-build are all excluded-free by construction.
+- **`tests/search-hybrid.test.ts`** (+4): `pruneExcludedHits` note-granularity removal + order preservation, `#chunk`-suffix stripping (block), the `C# Notes.md` literal-`#` case (regression guard for the v3.7.16 P2-16 class), and a **NEGATIVE control** (predicate-driven, not unconditional — a `return hits` no-op fails it).
+
+### Method note
+
+This is the project's signature **incomplete-class-sweep** closure: rc.18 L-HYB-1 added the *response-build* `isExcluded` guard but left graph-boost's fusion-stage content-read unguarded; rc.5 then added a second unguarded fusion-stage consumer (recency mtime-stat). The class fix prunes at the source so any future consumer of `fused` inherits the guard. **Honest self-correction (worth recording):** the integration test first written to "prove" the fix was **vacuous** — it asserted graph-boost never read an excluded note, but the per-arm ranker filters (BM25 `~line 1373`, embeddings `~1100`, TF-IDF via `listMarkdown`) already prevent an excluded path from reaching `fused` through the public `searchHybrid` API, so the assertion held with OR without the prune. The mandated **revert-verify** (disable the fix, confirm the test fails) caught it red-handed. Lesson: a guard that sits *behind* an existing filter can't be exercised through the front door — test it as a pure unit with the dependency injected, or the "test" is theater. Severity of the underlying finding is **LOW** (triple-guarded; no live leak), but the defense-in-depth + the class closure + the testing lesson justify the patch. **No new behavior on any real vault** — `fused` is already excluded-free in every current code path (the prune is a no-op until a ranker arm regresses).
+
+### Tests (1076)
+
+`tests/search-hybrid.test.ts` +4 source `it()` (the vacuous integration test added during the audit was removed before ship — net 0 in `security.test.ts`). 1072 → 1076; claims synced (README ×4, package.json, llms.txt, AGENTS, COMPARISON, ROADMAP).
+
+### Files changed
+
+- `src/tools/search.ts` (`pruneExcludedHits` helper + the `fused = pruneExcludedHits(...)` call), `tests/search-hybrid.test.ts` (+4), test-count claims → 1076.
+- version bump 3.10.0-rc.7 → 3.10.0-rc.8.
+
+---
+
 ## [3.10.0-rc.7] — 2026-06-02
 
 > **TL;DR:** **v3.10 increment 6 — TDQS (tool-description quality): make the freshness signal discoverable to agents.** rc.4/rc.5 added `age_days` + `stale` to `obsidian_search` / `obsidian_find_similar` / `obsidian_semantic_search` results, but the **tool descriptions an agent actually reads** never mentioned them — so an agent had no way to know the freshness signal exists, let alone reason over it. This RC adds a concise freshness note to all three descriptions (what the fields are + that `--recency-weight` can blend fresher notes upward) — closing the "shipped-but-undiscoverable" gap. **The benchmark-methodology half of the original rc.7 plan needs no work** — `docs/benchmarks.md` already carries the full methodology (dataset, ground-truth, metric definitions, ablations, reproducibility) AND the precise "what we measure and what we don't" framing (retrieval quality, NOT end-to-end QA accuracy — "a QA-accuracy number for a retriever would be an overclaim"), shipped across the v3.7.x cascade + rc.19. **Src/description-only — zero behavior change, 1072 tests unchanged.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1072%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1076%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1072 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1076 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1072 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1076 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1072 tests, ~12s)
+npm test       # full suite (1076 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1072 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1076 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1072**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1076**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1072 unit tests passing on every PR
+- 1076 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.7",
+  "version": "3.10.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.7",
+      "version": "3.10.0-rc.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
-        "better-sqlite3": "12.10.0",
         "chokidar": "^5.0.0",
         "commander": "^14.0.3",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.7",
+  "version": "3.10.0-rc.8",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1072 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1076 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.7",
+  "version": "3.10.0-rc.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.7",
+      "version": "3.10.0-rc.8",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.7";
+export const VERSION = "3.10.0-rc.8";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1274,6 +1274,39 @@ export interface SearchHybridResponse {
  * console.log("Rankers fired:", result.signals_used);
  * ```
  */
+/**
+ * v3.10.0-rc.8 — prune excluded paths from a fused ranking list, at the
+ * fusion-stage source. Defense-in-depth parity with the rc.18 L-HYB-1
+ * response-build guard: the fusion-stage consumers of the fused list
+ * (graph-boost reads candidate CONTENT via `readNote`; recency stats candidate
+ * mtime) run before that terminal guard, and this keeps them excluded-free even
+ * if a future ranker arm forgets its own per-arm filter.
+ *
+ * Pure (the `isExcluded` predicate is injected) and granularity-aware: for
+ * `"block"` ids of the form `path#chunk`, the chunk suffix is stripped before
+ * the membership test — matching the response-build guard's `lastIndexOf("#")`
+ * logic exactly so the two layers never disagree.
+ *
+ * @param hits - fused ranking entries (each carries an `id` = path or `path#chunk`).
+ * @param isExcluded - returns true if a vault-relative path is excluded (`vault.isExcluded`).
+ * @param granularity - `"note"` (id IS the path) or `"block"` (id is `path#chunk`).
+ * @returns a new array with excluded-path entries removed (order preserved).
+ */
+export function pruneExcludedHits<T extends { id: string }>(
+  hits: T[],
+  isExcluded: (relPath: string) => boolean,
+  granularity: "note" | "block"
+): T[] {
+  return hits.filter((h) => {
+    let p = h.id;
+    if (granularity === "block") {
+      const hashIdx = h.id.lastIndexOf("#");
+      if (hashIdx > 0) p = h.id.slice(0, hashIdx);
+    }
+    return !isExcluded(p);
+  });
+}
+
 export async function searchHybrid(
   vault: Vault,
   args: {
@@ -1551,7 +1584,7 @@ export async function searchHybrid(
   }
 
   // ─── RRF fusion ─────────────────────────────────────────────────────────
-  const fused = reciprocalRankFusion(
+  let fused = reciprocalRankFusion(
     {
       bm25: bm25Ranked.map((h) => ({ id: h.id, rank: h.rank, score: h.score })),
       tfidf: tfidfRanked.map((h) => ({ id: h.id, rank: h.rank, score: h.score })),
@@ -1559,6 +1592,22 @@ export async function searchHybrid(
     },
     { topK: Math.max(limit * 4, 30) } // overshoot — graph boost may rerank
   );
+
+  // v3.10.0-rc.8 (post-rc.7 audit) — privacy guard at the SOURCE, for parity
+  // with the rc.18 L-HYB-1 response-build guard. The fusion-stage consumers of
+  // `fused` run BEFORE that terminal guard: graph-boost (below) calls
+  // `vault.readNote` to parse a candidate's wikilinks — reading its CONTENT —
+  // and the rc.5 recency re-rank stats a candidate's mtime. Each ranker arm
+  // ALREADY drops excluded paths (BM25 + embeddings post-filter, TF-IDF via
+  // listMarkdown) AND the response-build guard (~line 1790) drops them from
+  // output — so this is a THIRD, defense-in-depth layer that still holds if a
+  // future ranker arm forgets its per-arm filter (L-HYB-1's rationale: "RRF
+  // fusion trusts ranker inputs; don't"). Pruning here makes every downstream
+  // fusion stage excluded-free by construction. Extracted to the pure
+  // {@link pruneExcludedHits} and unit-tested directly: the public searchHybrid
+  // path can't inject an excluded id into `fused` (the per-arm filters already
+  // prevent it), so an integration test of this layer would be vacuous.
+  fused = pruneExcludedHits(fused, (p) => vault.isExcluded(p), granularity);
 
   // ─── v2.3.0: Wikilink graph-boost ───────────────────────────────────────
   // Re-rank top-K by counting how many *other* top-K hits link to each one.

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -10,6 +10,7 @@ import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { defaultIndexFile, FtsIndex } from "../src/fts5.js";
 import { searchHybrid } from "../src/tools/index.js";
+import { pruneExcludedHits } from "../src/tools/search.js";
 import { Vault } from "../src/vault.js";
 
 let root: string;
@@ -509,5 +510,46 @@ describe("searchHybrid — opt-in recency re-ranking (v3.10 rc.5)", () => {
       { ftsIndex: null, embedFile: embedFile(), recency: { weight: 0.9, staleDays: 30 } }
     );
     expect(result.matches[0]?.path).toBe("beta.md");
+  });
+});
+
+// v3.10.0-rc.8 (post-rc.7 audit) — the fusion-stage privacy prune. This guards
+// the fusion-stage consumers of `fused` (graph-boost reads candidate CONTENT;
+// recency stats candidate mtime) which run BEFORE the response-build
+// isExcluded guard. Tested as a PURE unit (predicate injected) because the
+// public searchHybrid path can't inject an excluded id into `fused` — the
+// per-arm ranker filters already drop them — so an integration test would be
+// vacuous (verified: it passed with the prune disabled).
+describe("pruneExcludedHits (v3.10 rc.8 — fusion-stage isExcluded parity)", () => {
+  const hits = [{ id: "Public/a.md" }, { id: "Personal/diary.md" }, { id: "Public/b.md" }];
+  const isExcludedPersonal = (p: string) => p.startsWith("Personal/");
+
+  it("removes excluded note-granularity ids, preserves order of the rest", () => {
+    const out = pruneExcludedHits(hits, isExcludedPersonal, "note");
+    expect(out.map((h) => h.id)).toEqual(["Public/a.md", "Public/b.md"]);
+  });
+
+  it("strips the #chunk suffix before the membership test (block granularity)", () => {
+    const blockHits = [{ id: "Public/a.md#0" }, { id: "Personal/diary.md#3" }, { id: "Public/b.md#1" }];
+    const out = pruneExcludedHits(blockHits, isExcludedPersonal, "block");
+    expect(out.map((h) => h.id)).toEqual(["Public/a.md#0", "Public/b.md#1"]);
+  });
+
+  it("does NOT strip a literal '#' in a note-granularity filename (C# Notes.md)", () => {
+    // In "note" granularity the id IS the path — a `#` in the name is part of it.
+    const csharp = [{ id: "C# Notes.md" }];
+    expect(pruneExcludedHits(csharp, () => false, "note").map((h) => h.id)).toEqual(["C# Notes.md"]);
+    // And it's correctly excluded when the predicate matches the full name.
+    expect(pruneExcludedHits(csharp, (p) => p === "C# Notes.md", "note")).toEqual([]);
+  });
+
+  // NEGATIVE control: the prune MUST be driven by the predicate. A predicate
+  // that excludes nothing leaves the list intact; one that matches an entry
+  // removes exactly it. A no-op impl (`return hits`) FAILS the second assertion
+  // — this is what made the integration test vacuous and this one real.
+  it("NEGATIVE control — driven by the predicate, not unconditional", () => {
+    expect(pruneExcludedHits(hits, () => false, "note")).toHaveLength(3); // excludes nothing
+    expect(pruneExcludedHits(hits, () => true, "note")).toHaveLength(0); // excludes everything
+    expect(pruneExcludedHits(hits, isExcludedPersonal, "note")).toHaveLength(2); // exactly the 1 excluded removed
   });
 });


### PR DESCRIPTION
## Summary

A state-driven audit of the rc.3→rc.7 line (behavioral/threat lens, per the rc.36 meta-audit) found a **defense-in-depth gap** in the search fusion stage.

**Finding (LOW — defense-in-depth, not a live leak):** the two fusion-stage consumers of the RRF `fused` list run **before** the rc.18 L-HYB-1 response-build `isExcluded` guard and don't replicate it:
- **graph-boost** (pre-existing): `vault.readNote()` on candidates → reads their **content** to parse wikilinks
- **rc.5 recency re-rank**: stats candidate **mtime**

Not exploitable today — every ranker arm (BM25 `~1373`, embeddings `~1100`, TF-IDF via `listMarkdown`) already drops excluded paths before `fused`, and the response-build guard drops them from output. So this is a **third, defense-in-depth layer** for a hypothetical future ranker-arm regression — exactly L-HYB-1's "RRF fusion trusts ranker inputs; don't" rationale. It's the project's **incomplete-class-sweep** pattern (L-HYB-1 guarded response-build but not the fusion-stage consumers).

**Fix:** prune excluded paths from `fused` once at the source, via a new pure `pruneExcludedHits(hits, isExcluded, granularity)` (block ids strip `#chunk` to match the response-build guard's `lastIndexOf("#")` exactly).

**Self-caught overclaim (worth highlighting):** the first test written was an *integration* test that **passed with the prune disabled** — vacuous, because the per-arm filters prevent an excluded path from reaching `fused` through the public API. The mandated **revert-verify** exposed it; replaced with a **pure-helper unit test** that genuinely fails when the guard is removed.

Tests **1072 → 1076**. `src/` = one filter line + the extracted helper; **no behavior change on any real vault**.

## Test plan

- [x] `tests/search-hybrid.test.ts` +4 — note-granularity removal + order, `#chunk` strip (block), `C# Notes.md` literal-`#` regression, NEGATIVE control (predicate-driven, not unconditional)
- [x] revert-verify: disabling the prune makes the NEGATIVE control fail (confirmed the test is non-vacuous)
- [x] lint · tsc · version-consistency(7) · test:coverage (1141+2skip; search.ts branches 67.79% > floor 66%) · per-file(12) · oia(12) · scope-completeness · smoke · docs:api(0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)