### PR TITLE
v3.10.0-rc.9: positioning — verified head-to-head vs basic-memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.9] — 2026-06-02
+
+> **TL;DR:** **Positioning — a verified, fair head-to-head vs `basic-memory`** (the closest local-markdown-MCP rival), added to the COMPARISON "when to pick something other than enquire-mcp" section. Grounded in a fresh web-research pass (Track B of the promotion plan): `basic-memory` solves the **inverse** problem — it *writes* a knowledge-base **from your AI conversations** (readable markdown, viewable in Obsidian as a GUI), whereas enquire-mcp *recalls the notes you authored*. The entry is intentionally fair-not-sales (calls out exactly when basic-memory is the better pick, and that the two **compose**) and makes the "grounded, not extracted" line concrete with a real, citable example. Docs-only; no overclaim about the competitor (every claim verified against its public repo). **1076 tests unchanged.**
+
+**Minor (pre-release) — v3.10 line; promotion/positioning increment (no code change).**
+
+### Changed
+
+- **`docs/COMPARISON.md`** — "when to pick something other than enquire-mcp" expanded from four cases to **five**: added **`basic-memory` (basicmachines-co)**. It's the closest project in spirit (local-first, markdown, MCP-native, semantic search over a wikilinked knowledge graph, Obsidian as a GUI) but solves the inverse problem — write-memory-from-chat vs recall-what-you-authored — which makes the choice clean and sharpens enquire's "grounded, not extracted" differentiator with a concrete example. Notes that the two compose (basic-memory writes conversation-derived notes; enquire retrieves across the whole authored vault). Kept OUT of the Obsidian-MCP feature matrix (different category) to avoid a misleading row.
+
+### Method note
+
+This is the first increment of the **promotion track**. It's grounded in a Firecrawl research pass (PROMO-1), not authored from memory, specifically to avoid competitor-claim overclaim: every `basic-memory` capability stated here was verified against its public GitHub/docs (knowledge-graph, semantic search, wikilinks, MCP-native, Obsidian GUI, conversation-capture). The research also surfaced **discoverability gaps that are maintainer-gated** (not shippable as repo docs) — handed off separately: enquire is absent from the high-intent "best Obsidian MCP server" results (needs stars + listicle presence), the brand search surfaces a stale OpenClaw-directory listing rather than the canonical repo, and the highest-leverage lever remains the published LongMemEval/retrieval score (reference hardware). Glama listing confirmed live (auto-synced from the MCP registry); the "claim" is OAuth-gated. **Deliberately did NOT** churn the README use-cases for marginal on-page SEO — the real high-intent-query gap is off-page (stars/listicles), and quality > keyword-stuffing.
+
+### Tests (1076)
+
+No `it()` change (docs-only). 1076 unchanged.
+
+### Files changed
+
+- `docs/COMPARISON.md` (basic-memory "when to pick else" entry; four→five), version bump 3.10.0-rc.8 → 3.10.0-rc.9.
+
+---
+
 ## [3.10.0-rc.8] — 2026-06-02
 
 > **TL;DR:** **Post-rc.7 audit response — fusion-stage privacy parity (defense-in-depth) + a self-caught vacuous-test correction.** A state-driven audit of the rc.3→rc.7 line (behavioral/threat lens, per the rc.36 meta-audit) found that the two fusion-stage consumers of the RRF `fused` list — pre-existing **graph-boost** (calls `vault.readNote` to parse a candidate's wikilinks → reads its **content**) and the rc.5 **recency re-rank** (stats a candidate's **mtime**) — both run BEFORE the rc.18 L-HYB-1 response-build `isExcluded` guard and don't replicate it. Not exploitable today (every ranker arm already drops excluded paths before `fused`, and the response-build guard drops them from output), so this is a **third, defense-in-depth layer** for a hypothetical future ranker-arm regression — exactly the "RRF fusion trusts ranker inputs; don't" rationale L-HYB-1 was shipped on. Fixed by pruning excluded paths from `fused` once at the source via a new pure `pruneExcludedHits`. **The audit also caught itself overclaiming:** the first test written for this was an *integration* test that **passed with the fix disabled** (vacuous — the per-arm filters prevent an excluded path from ever reaching `fused` through the public API). The revert-verify exposed it; it was replaced with a **pure-helper unit test** that actually fails when the guard is removed. **1072 → 1076 tests.** `src/` change is one fusion-stage filter line + the extracted helper.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -67,7 +67,7 @@ Notes on the matrix:
 
 ## When to pick something other than enquire-mcp
 
-This is the most important section. enquire-mcp is not the right server for every Obsidian + MCP workflow. Four cases where one of the alternatives is the better fit:
+This is the most important section. enquire-mcp is not the right server for every Obsidian + MCP workflow. Five cases where one of the alternatives is the better fit:
 
 ### Pick `cyanheads/obsidian-mcp-server` if…
 
@@ -136,6 +136,20 @@ Specific scenarios:
 - **You're stitching together your own retrieval pipeline** in the agent layer (LangChain / LlamaIndex / a custom orchestrator), and Obsidian is just the document store. Don't fight the layer above — let the agent do retrieval and let the MCP server be a dumb pipe.
 
 Concrete example: "I already have a pgvector-backed RAG index over my whole digital footprint, and the Obsidian vault is one input. I just need the model to fetch a note by path when it's relevant." mcpvault-class server, not enquire-mcp.
+
+### Pick `basic-memory` (basicmachines-co) if…
+
+**Headline:** you want the AI to *write* a memory knowledge-base **from your conversations** — not recall the notes you already authored.
+
+`basic-memory` is the closest project in spirit (local-first, markdown, MCP-native, viewable in Obsidian as a GUI, semantic search over a wikilinked knowledge graph), but it solves the **inverse** problem, which makes the choice clean:
+
+- **Your "memory" IS the AI dialogue.** basic-memory captures observations from chat sessions into linked markdown so you can "continue the conversation later with full context." If write-from-chat is the primary loop, that's its sweet spot. enquire-mcp is read-first: it indexes the markdown **you wrote**, so it shines when you already have a vault to recall from — not when memory should be generated from chat. (This is the "grounded, not extracted" line made concrete: basic-memory's notes are readable, but they're *extracted from conversations*; enquire recalls the notes you authored.)
+
+- **You want bi-directional human↔LLM capture as the core workflow.** That's basic-memory's first-class path; enquire-mcp's writes are an opt-in `--enable-write` minority surface behind a deliberately read-first design.
+
+- **You don't need the heavy retrieval stack.** A conversation-derived store rarely needs RRF-fused BM25 + multilingual embeddings + a cross-encoder reranker + HNSW; enquire-mcp is more retrieval machinery than that workflow calls for.
+
+Concrete example: "After every Claude session, distill what we decided into linked notes I can browse in Obsidian" is basic-memory's grain; "search the three years of research notes I've already written and cite the relevant ones" is enquire-mcp's. **They compose** — let basic-memory *write* conversation-derived notes and let enquire-mcp *retrieve* across your whole authored vault.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.8",
+  "version": "3.10.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.8",
+      "version": "3.10.0-rc.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.8",
+  "version": "3.10.0-rc.9",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
   "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1076 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.8",
+  "version": "3.10.0-rc.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.8",
+      "version": "3.10.0-rc.9",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.8";
+export const VERSION = "3.10.0-rc.9";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below


### PR DESCRIPTION
## Summary

First increment of the **promotion track**. A fresh Firecrawl research pass (PROMO-1) grounded a fair, verified competitive addition.

- **`docs/COMPARISON.md`** — "when to pick something other than enquire-mcp" expanded four → five: added **`basic-memory`** (the closest local-markdown-MCP rival). It solves the **inverse** problem — *writes* a knowledge-base **from your AI conversations** vs enquire *recalling the notes you authored* — which makes the choice clean and makes "grounded, not extracted" concrete. Fair-not-sales (states when basic-memory wins + that the two **compose**). Kept out of the Obsidian-MCP feature matrix (different category).

Every competitor claim verified against basic-memory's public repo/docs (knowledge graph, semantic search, wikilinks, MCP-native, Obsidian GUI, conversation-capture). **Docs-only; 1076 tests unchanged.**

## Test plan
- [x] lint · tsc · version-consistency(7) · docs-consistency(45) · oia(12) · scope-completeness · smoke · docs:api(0 warnings)

## Research surfaced (maintainer-gated, handed off separately — not repo docs)
- Absent from high-intent "best Obsidian MCP server" results → needs stars + listicle presence
- Brand search surfaces a stale OpenClaw-directory listing ("1.0 stable"), not the canonical repo
- Glama listing confirmed live (auto-synced); "claim" is OAuth-gated
- Highest-leverage lever unchanged: published LongMemEval/retrieval score (reference hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)