### PR TITLE
v3.10.0-rc.10: frontmatter-aware retrieval (opt-in filter_frontmatter)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1076+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1085+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.10] — 2026-06-02
+
+> **TL;DR:** **New capability — frontmatter-aware retrieval.** `obsidian_search` gains an optional `filter_frontmatter` map so an agent can scope hybrid search by YAML frontmatter: `{ status: "active", type: ["meeting","decision"] }` → only notes whose frontmatter matches **every** key (strings case-insensitive; an array frontmatter value matches by membership; an array filter value is OR). It's the first genuinely-new *feature* (not polish) since the v3.10 staleness line — Obsidian users live in frontmatter (`status`/`type`/`project`), and **no other Obsidian-MCP can scope semantic search by it**. Opt-in + additive: **absent ⇒ byte-identical** to before (same safe pattern as recency re-ranking). Matching is filter-on-the-fused-candidate-pool, which is already excluded-pruned (rc.8), so no excluded note's frontmatter is read; PDFs (no frontmatter) are excluded without a binary read. **1076 → 1085 tests.**
+
+**Minor (pre-release) — v3.10 line; new feature: frontmatter-aware retrieval (increment 1/N).**
+
+### Added
+
+- **`obsidian_search` `filter_frontmatter?: Record<string, scalar | scalar[]>`** — post-filters fused hits by the note's parsed YAML frontmatter. AND across keys; per key, scalar-equality (strings case-insensitive, numbers/booleans strict, no cross-type coercion) or array-membership; a filter value may be an array for OR. Notes with no frontmatter, or missing a filtered key, are excluded (a filter is a positive assertion). Runs only when the param is passed; filters the candidate pool (so a strict filter can legitimately return < `limit`). Reads candidate frontmatter via the cached `vault.readNote` (graph-boost usually warms it); fail-soft (an unreadable candidate is excluded, honoring the filter).
+- **Pure exported `frontmatterMatches(frontmatter, filter)`** (+ `FrontmatterFilterValue` / `FrontmatterFilterScalar` types) — the matching semantics, unit-testable in isolation. zod schema added to the `obsidian_search` registration (`z.record` of string→scalar|scalar[]).
+- **`tests/search-hybrid.test.ts`** (+9): 6 `frontmatterMatches` unit tests (scalar/case-insensitive, array-membership, array-OR + multi-key-AND, number/boolean strictness, missing-key/empty/absent → no match, a NEGATIVE control that discriminates) + 3 integration tests through `searchHybrid` (filter narrows to the matching note; **NEGATIVE control** — no filter returns all three, proving the filter is what narrowed it; array-value OR + multi-key AND).
+
+### Method note
+
+This is the deliberate answer to "is the project at a dead-end?" — the *refinement* track had hit diminishing returns, so the next real value is a **new capability**, not another micro-RC. Frontmatter-aware retrieval was chosen because it (1) expands what the product can *do* (not polish), (2) plays to the retrieval core — the project's strength, (3) is deeply Obsidian-native (frontmatter is a first-class Obsidian primitive) with **no competitor parity**, and (4) ships **additively/opt-in** so the critical search path is byte-identical when unused. Rejected alternatives, with reasons: conversation write-back (it's `basic-memory`'s grain and muddies the "grounded, not extracted" differentiator), multi-vault (explicit non-goal in CLAUDE.md), and answer-synthesis (we're a retriever, not a QA generator — would be the kind of overclaim `docs/benchmarks.md` explicitly avoids). The integration test is non-vacuous by construction (the NEGATIVE control returns all three notes when the filter is absent — so a no-op filter implementation fails it), unlike the rc.8 case the revert-verify caught. **Next increments:** rc.11 — `tag` filter parity (FTS has it; hybrid doesn't) + optional boost-by-frontmatter; rc.12 — positioning for the capability.
+
+### Tests (1085)
+
+`tests/search-hybrid.test.ts` +9 source `it()`. 1076 → 1085; claims synced (README ×4, package.json, llms.txt, AGENTS, COMPARISON, ROADMAP). Tool count unchanged (45 — this adds a *parameter*, not a tool).
+
+### Files changed
+
+- `src/tools/search.ts` (`filter_frontmatter` arg + `frontmatterMatches`/`frontmatterValueMatches`/`frontmatterScalarEq` helpers + matches-loop integration + `fmFilter` hoist), `src/tool-registry.ts` (zod schema), `tests/search-hybrid.test.ts` (+9), `docs/api.md` (args-table row), test-count claims → 1085.
+- version bump 3.10.0-rc.9 → 3.10.0-rc.10.
+
+---
+
 ## [3.10.0-rc.9] — 2026-06-02
 
 > **TL;DR:** **Positioning — a verified, fair head-to-head vs `basic-memory`** (the closest local-markdown-MCP rival), added to the COMPARISON "when to pick something other than enquire-mcp" section. Grounded in a fresh web-research pass (Track B of the promotion plan): `basic-memory` solves the **inverse** problem — it *writes* a knowledge-base **from your AI conversations** (readable markdown, viewable in Obsidian as a GUI), whereas enquire-mcp *recalls the notes you authored*. The entry is intentionally fair-not-sales (calls out exactly when basic-memory is the better pick, and that the two **compose**) and makes the "grounded, not extracted" line concrete with a real, citable example. Docs-only; no overclaim about the competitor (every claim verified against its public repo). **1076 tests unchanged.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1076%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1085%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1076 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1085 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1076 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1085 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1076 tests, ~12s)
+npm test       # full suite (1085 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1076 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1085 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1076**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1085**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/docs/api.md
+++ b/docs/api.md
@@ -548,6 +548,7 @@ If the index is missing, the tool returns a clean error pointing at `enquire-mcp
 | `limit`            | `number?` (≤ 100)     | Max hits. Default 10.                                                              |
 | `min_signals`      | `number?` (1–3)       | Filter: only return hits that ranked in at least N rankers. Default 1. Set 2+ for high-precision multi-ranker consensus. |
 | `embedding_model`  | `string?`             | Override the embedding model alias (default `multilingual`). Only consulted if a `.embed.db` exists. |
+| `filter_frontmatter` | `Record<string, scalar \| scalar[]>?` | v3.10 — keep only hits whose YAML frontmatter satisfies every `key: value` pair (AND across keys). Per key: strings match case-insensitively; an array frontmatter value matches by membership (`{tags: "project"}` matches `tags: [project, x]`); the filter value may be an array for OR (`{type: ["meeting","decision"]}`). Notes with no frontmatter, or missing a filtered key, are excluded. Omit for no filtering. Filters the fused candidate pool, so a strict filter may return fewer than `limit`. Example: `{ status: "active", type: ["meeting","decision"] }`. |
 
 **Returns:** `{ query, method: "rrf", k: 60, signals_used, total_candidates, matches: [{ path, title, score, snippet, chunk_index?, line_start?, line_end?, per_signal: { bm25?, tfidf?, embeddings? }, age_days?, stale? }] }`.
 

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1076 unit tests passing on every PR
+- 1085 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.9",
+  "version": "3.10.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.9",
+      "version": "3.10.0-rc.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.9",
+  "version": "3.10.0-rc.10",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1076 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1085 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/scripts/check-per-file-coverage.mjs
+++ b/scripts/check-per-file-coverage.mjs
@@ -72,7 +72,7 @@ const FLOORS = {
   "src/ocr.ts": { branches: 60, lines: 40 }, // current branches 66.66% / lines 44.44%
   "src/http-transport.ts": { branches: 65 }, // current 72.85% (v3.8.7 P2-10/P2-11 raised branch coverage with 10 new tests)
   "src/doctor.ts": { branches: 64 }, // current 68.99% (rc.16 P2-12 privacy tests lifted it +2.9pp)
-  "src/tools/search.ts": { branches: 66 }, // current 68.27%
+  "src/tools/search.ts": { branches: 66 }, // current 69.71% (rc.10 frontmatter-filter helpers + matches-loop branch lifted it)
   // v3.8.0-rc.8 — lifted from 65% → 71% after T-1 contextPack tests
   // raised per-file branches from 67.66% → 73.85%.
   "src/tools/meta.ts": { branches: 74 }, // current 78.51% (rc.25 added leadingAtomSet/branchIsNullable/bodyVariable detector branches)

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.9",
+  "version": "3.10.0-rc.10",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.9",
+      "version": "3.10.0-rc.10",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.9";
+export const VERSION = "3.10.0-rc.10";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -943,6 +943,15 @@ export function registerReadTools(
           .optional()
           .describe(
             "v2.3.0: post-RRF wikilink graph-boost — rerank top-K by counting how many OTHER top-K hits link to each one. Default ON. Set false to disable for diagnostic comparison. The 'only enquire-mcp does this' feature: generic vector stores can't do this without an Obsidian-aware layer."
+          ),
+        filter_frontmatter: z
+          .record(
+            z.string(),
+            z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number(), z.boolean()]))])
+          )
+          .optional()
+          .describe(
+            "v3.10: optional YAML-frontmatter filter — a {key: value} map. A hit is kept only if its note's frontmatter satisfies EVERY pair (AND across keys). Per key: strings match case-insensitively, an array frontmatter value matches by membership (e.g. {tags: 'project'} matches `tags: [project, x]`), and the filter value may itself be an array for OR ({type: ['meeting','decision']}). Notes with no frontmatter or missing a filtered key are excluded. Omit for no filtering (default). Filters the fused candidate pool, so a strict filter can return fewer than `limit` hits."
           )
       }
     },

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1307,6 +1307,64 @@ export function pruneExcludedHits<T extends { id: string }>(
   });
 }
 
+/** v3.10 (rc.10) — a scalar a frontmatter filter can match against. */
+export type FrontmatterFilterScalar = string | number | boolean;
+/** v3.10 (rc.10) — one filter value: a scalar, or an array of scalars (OR-semantics). */
+export type FrontmatterFilterValue = FrontmatterFilterScalar | FrontmatterFilterScalar[];
+
+/**
+ * v3.10 (rc.10) — case-insensitive-for-strings, strict-for-number/boolean scalar
+ * equality. Strings compare case- and whitespace-insensitively (frontmatter is
+ * human-authored — `Active` should match `active`); numbers/booleans compare
+ * strictly. Mixed types never match (`"1"` ≠ `1`).
+ */
+function frontmatterScalarEq(a: unknown, b: FrontmatterFilterScalar): boolean {
+  if (typeof b === "string") return typeof a === "string" && a.trim().toLowerCase() === b.trim().toLowerCase();
+  return a === b; // number / boolean — strict
+}
+
+/**
+ * v3.10 (rc.10) — does a single note frontmatter value satisfy one filter value?
+ * Handles the four shapes intuitively:
+ * - note scalar vs filter scalar → equality
+ * - note scalar vs filter array  → note ∈ filter (OR)
+ * - note array  vs filter scalar → filter ∈ note (membership, e.g. `tags`)
+ * - note array  vs filter array  → non-empty intersection (any-of)
+ */
+function frontmatterValueMatches(have: unknown, want: FrontmatterFilterValue): boolean {
+  const wants = Array.isArray(want) ? want : [want];
+  const haves = Array.isArray(have) ? have : [have];
+  return wants.some((w) => haves.some((h) => frontmatterScalarEq(h, w)));
+}
+
+/**
+ * v3.10 (rc.10) — does a note's frontmatter satisfy a frontmatter filter?
+ *
+ * AND across keys (every `key: value` pair must match); per-key matching is
+ * scalar-equality or array-membership, with OR over an array filter value
+ * (see `frontmatterValueMatches`). A note with NO frontmatter, or missing any filtered
+ * key, does NOT match (a filter is a positive assertion — absence ≠ match). Pure
+ * + injectable so it's unit-tested directly without spinning up a vault.
+ *
+ * @example
+ * ```ts
+ * frontmatterMatches({ status: "Active", tags: ["proj", "x"] }, { status: "active", tags: "proj" }); // true
+ * frontmatterMatches({ status: "done" }, { status: "active" }); // false
+ * frontmatterMatches(undefined, { status: "active" }); // false (no frontmatter)
+ * ```
+ */
+export function frontmatterMatches(
+  frontmatter: Record<string, unknown> | undefined | null,
+  filter: Record<string, FrontmatterFilterValue>
+): boolean {
+  if (!frontmatter) return false;
+  for (const [key, want] of Object.entries(filter)) {
+    if (!(key in frontmatter)) return false;
+    if (!frontmatterValueMatches(frontmatter[key], want)) return false;
+  }
+  return true;
+}
+
 export async function searchHybrid(
   vault: Vault,
   args: {
@@ -1323,6 +1381,19 @@ export async function searchHybrid(
      *  top-K hits link to each one. Default true; set false to disable for
      *  diagnostic comparison (e.g. measuring whether boost helped). */
     graph_boost?: boolean;
+    /**
+     * v3.10 (rc.10) — optional frontmatter filter. A `{ key: value }` map;
+     * a hit is kept only if its note's YAML frontmatter satisfies EVERY pair
+     * (AND across keys). Per key, the value matches by scalar-equality
+     * (strings case-insensitive) or array-membership, and a filter value may
+     * itself be an array for OR — see {@link frontmatterMatches}. A note with
+     * no frontmatter, or missing a filtered key, is excluded (a filter is a
+     * positive assertion). Absent ⇒ no filtering (byte-identical to pre-3.10).
+     * Filtering happens on the fused candidate pool (already excluded-pruned),
+     * so a strict filter may return fewer than `limit` hits — that's correct.
+     * @example `{ status: "active", type: ["meeting", "decision"] }`
+     */
+    filter_frontmatter?: Record<string, FrontmatterFilterValue>;
   },
   ctx: {
     /** FTS5 index, if `--persistent-index` is enabled at server start. */
@@ -1372,6 +1443,11 @@ export async function searchHybrid(
   const limit = args.limit ?? 10;
   const minSignals = args.min_signals ?? 1;
   const granularity = args.granularity ?? "note";
+  // v3.10 (rc.10) — opt-in frontmatter filter. Normalized to `undefined` when
+  // absent/empty so the per-candidate filter block (and its extra readNote) is
+  // skipped entirely on the default path ⇒ byte-identical to pre-3.10.
+  const fmFilter =
+    args.filter_frontmatter && Object.keys(args.filter_frontmatter).length > 0 ? args.filter_frontmatter : undefined;
   // Fan-out per-ranker top-K. Bigger than user's `limit` so RRF has room
   // to surface a doc that's mid-rank in one signal but top in another.
   const fanOutK = Math.max(50, limit * 5);
@@ -1827,6 +1903,25 @@ export async function searchHybrid(
       if (hashIdx > 0) pathForFilter = f.id.slice(0, hashIdx);
     }
     if (vault.isExcluded(pathForFilter)) continue;
+    // v3.10 (rc.10) — opt-in frontmatter filter. Runs ONLY when the caller
+    // passed `filter_frontmatter` (else skipped — byte-identical default).
+    // PDFs/canvas have no YAML frontmatter, so a frontmatter filter excludes
+    // them without a binary-decoding read. Otherwise read the note (cached;
+    // graph-boost has usually warmed it) and keep only if its frontmatter
+    // satisfies the filter. The candidate pool is already excluded-pruned
+    // (rc.8), so no excluded note's frontmatter is ever read here. Fail-soft:
+    // an unreadable candidate can't be verified → excluded (honors the filter).
+    if (fmFilter) {
+      if (!pathForFilter.toLowerCase().endsWith(".md")) continue;
+      let fm: Record<string, unknown> | undefined;
+      try {
+        const note = await vault.readNote(vault.resolveInside(pathForFilter));
+        fm = note.parsed.frontmatter;
+      } catch {
+        continue;
+      }
+      if (!frontmatterMatches(fm, fmFilter)) continue;
+    }
     // Snippet preference: BM25 > embeddings > TF-IDF (BM25 snippets bracket
     // the matched terms with «…», highest signal-to-noise).
     const bm = bm25Map.get(f.id);

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -10,7 +10,7 @@ import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { defaultIndexFile, FtsIndex } from "../src/fts5.js";
 import { searchHybrid } from "../src/tools/index.js";
-import { pruneExcludedHits } from "../src/tools/search.js";
+import { frontmatterMatches, pruneExcludedHits } from "../src/tools/search.js";
 import { Vault } from "../src/vault.js";
 
 let root: string;
@@ -551,5 +551,95 @@ describe("pruneExcludedHits (v3.10 rc.8 — fusion-stage isExcluded parity)", ()
     expect(pruneExcludedHits(hits, () => false, "note")).toHaveLength(3); // excludes nothing
     expect(pruneExcludedHits(hits, () => true, "note")).toHaveLength(0); // excludes everything
     expect(pruneExcludedHits(hits, isExcludedPersonal, "note")).toHaveLength(2); // exactly the 1 excluded removed
+  });
+});
+
+// v3.10 (rc.10) — frontmatter-aware retrieval filter. Pure matcher unit-tested
+// directly (semantics), then the opt-in filter exercised end-to-end through
+// searchHybrid with a NEGATIVE control proving it actually narrows.
+describe("frontmatterMatches (v3.10 rc.10 — filter semantics)", () => {
+  it("scalar equality, strings case-insensitive", () => {
+    expect(frontmatterMatches({ status: "Active" }, { status: "active" })).toBe(true);
+    expect(frontmatterMatches({ status: "done" }, { status: "active" })).toBe(false);
+  });
+  it("array frontmatter value matches by membership", () => {
+    expect(frontmatterMatches({ tags: ["proj", "x"] }, { tags: "proj" })).toBe(true);
+    expect(frontmatterMatches({ tags: ["a", "b"] }, { tags: "proj" })).toBe(false);
+  });
+  it("array filter value is OR; multiple keys are AND", () => {
+    expect(frontmatterMatches({ type: "meeting" }, { type: ["meeting", "decision"] })).toBe(true);
+    expect(frontmatterMatches({ status: "active", type: "meeting" }, { status: "active", type: "decision" })).toBe(
+      false
+    );
+  });
+  it("numbers/booleans are strict (no cross-type coercion)", () => {
+    expect(frontmatterMatches({ priority: 1, pinned: true }, { priority: 1, pinned: true })).toBe(true);
+    expect(frontmatterMatches({ priority: 1 }, { priority: "1" })).toBe(false); // 1 ≠ "1"
+  });
+  it("missing key, empty, or absent frontmatter never matches a filter", () => {
+    expect(frontmatterMatches({ status: "active" }, { type: "meeting" })).toBe(false); // missing key
+    expect(frontmatterMatches({}, { status: "active" })).toBe(false);
+    expect(frontmatterMatches(undefined, { status: "active" })).toBe(false);
+    expect(frontmatterMatches(null, { status: "active" })).toBe(false);
+  });
+  // NEGATIVE control: the matcher must DISCRIMINATE — a satisfiable filter
+  // returns true, an unsatisfiable one false. A constant impl fails one of these.
+  it("NEGATIVE control — discriminates (not constant)", () => {
+    const fm = { status: "active", type: "meeting" };
+    expect(frontmatterMatches(fm, { status: "active" })).toBe(true);
+    expect(frontmatterMatches(fm, { status: "archived" })).toBe(false);
+  });
+});
+
+describe("searchHybrid — opt-in frontmatter filter (v3.10 rc.10)", () => {
+  let fmRoot: string;
+  beforeAll(async () => {
+    fmRoot = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-hybrid-fm-"));
+    await fs.writeFile(
+      path.join(fmRoot, "active.md"),
+      "---\nstatus: active\ntype: project\n---\nkubernetes ingress controller routing.\n"
+    );
+    await fs.writeFile(
+      path.join(fmRoot, "done.md"),
+      "---\nstatus: done\ntype: project\n---\nkubernetes ingress controller routing.\n"
+    );
+    await fs.writeFile(path.join(fmRoot, "nofm.md"), "kubernetes ingress controller routing, no frontmatter.\n");
+  });
+  afterAll(async () => {
+    await fs.rm(fmRoot, { recursive: true, force: true });
+  });
+
+  it("filters hits to notes whose frontmatter matches (and excludes no-frontmatter / non-matching)", async () => {
+    const v = new Vault(fmRoot);
+    const result = await searchHybrid(
+      v,
+      { query: "kubernetes ingress", limit: 10, filter_frontmatter: { status: "active" } },
+      { ftsIndex: null, embedFile: path.join(fmRoot, "nonexistent.embed.db") }
+    );
+    expect(result.matches.map((m) => m.path)).toEqual(["active.md"]);
+  });
+
+  // NEGATIVE control: WITHOUT the filter, the same query returns all three —
+  // proving the filter above actually removed done.md + nofm.md (not that the
+  // query only matched one note).
+  it("NEGATIVE control — no filter returns all three (the filter is what narrowed it)", async () => {
+    const v = new Vault(fmRoot);
+    const result = await searchHybrid(
+      v,
+      { query: "kubernetes ingress", limit: 10 },
+      { ftsIndex: null, embedFile: path.join(fmRoot, "nonexistent.embed.db") }
+    );
+    const paths = result.matches.map((m) => m.path).sort();
+    expect(paths).toEqual(["active.md", "done.md", "nofm.md"]);
+  });
+
+  it("array-value frontmatter filter (OR) + AND across keys", async () => {
+    const v = new Vault(fmRoot);
+    const result = await searchHybrid(
+      v,
+      { query: "kubernetes ingress", limit: 10, filter_frontmatter: { type: "project", status: ["active", "done"] } },
+      { ftsIndex: null, embedFile: path.join(fmRoot, "nonexistent.embed.db") }
+    );
+    expect(result.matches.map((m) => m.path).sort()).toEqual(["active.md", "done.md"]); // both projects, nofm excluded
   });
 });


### PR DESCRIPTION
## Summary

**New capability** (not polish) — the deliberate answer to "is the project at a dead-end?": expand what it can *do*. `obsidian_search` gains an optional **`filter_frontmatter`** map so an agent can scope hybrid retrieval by YAML frontmatter.

- `{ status: "active", type: ["meeting","decision"] }` → keep only hits whose frontmatter satisfies **every** key (AND). Per key: strings case-insensitive, numbers/booleans strict; an **array frontmatter value** matches by membership (`{tags:"project"}` ↔ `tags: [project,x]`); an **array filter value** is OR. Notes with no frontmatter / missing a filtered key are excluded.
- **Opt-in + additive** — absent ⇒ byte-identical to before (same safe pattern as recency re-ranking).
- Filters the fused candidate pool (already excluded-pruned per rc.8 → no excluded note's frontmatter is read); PDFs excluded without a binary read; fail-soft.
- **No other Obsidian-MCP scopes semantic search by frontmatter** — Obsidian-native edge.

**1076 → 1085 tests.** Tool count unchanged (45 — this adds a *parameter*).

## Test plan
- [x] `frontmatterMatches` unit (×6): case-insensitive scalar, array-membership, array-OR + multi-key-AND, number/boolean strictness, missing/empty/absent → no match, NEGATIVE control (discriminates)
- [x] integration (×3): filter narrows to the matching note; **NEGATIVE control** — no filter returns all three (proves the filter narrowed it → non-vacuous); array-OR + AND
- [x] lint · tsc · version-consistency(7) · test:coverage (1150+2skip; `search.ts` branches **69.71%** > floor 66%, +1.4pp) · per-file(12) · oia(12) · scope · smoke · docs:api(0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)