### PR TITLE
v3.10.0-rc.11: hermetic test cache (stop polluting the real user cache)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1085+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1088+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.11] — 2026-06-03
+
+> **TL;DR:** **Hermetic test cache — found by live-testing the installed server on a real machine.** Driving the installed `enquire-mcp@3.9.1` over JSON-RPC against a real 237-note vault confirmed it works end-to-end (boot, 33 tools, `obsidian_stats`, semantic `obsidian_search` with a built embed-db, path-escape guard) — but also surfaced **~27,000 orphaned files / ~699 MB** sitting in the real user cache (`~/Library/Caches/enquire/`). Root cause: `defaultIndexFile()` (and the embed-db / HNSW sidecars) resolve their dir from `XDG_CACHE_HOME`, and any test that spawns `serve`/`setup`/`build-embeddings`/`index` **without** an explicit `--index-file` fell back to that REAL cache and never cleaned up — weeks of `npm test` accumulated there (mtimes May 8 → Jun 3). Fixed at the root: `tests/setup.ts` now redirects `XDG_CACHE_HOME` to a throwaway temp dir before any test (and every inheriting child spawn) touches the cache. **Verified: real-cache file delta from the suite is now 0.** Structural guard added so it can't regress. **1085 → 1088 tests.**
+
+**Minor (pre-release) — v3.10 line; test-hygiene fix from live-testing (no `src/` runtime change).**
+
+### Fixed
+
+- **Test suite no longer pollutes the real user cache.** `tests/setup.ts` sets `process.env.XDG_CACHE_HOME = mkdtempSync(tmpdir()/enquire-test-cache-…)` (guarded by `if (!XDG_CACHE_HOME)` so CI/devs can override). Because `defaultIndexFile()` keys on `XDG_CACHE_HOME` on every platform and every test child-spawn inherits `process.env` (verified: no test overrides `env` without spreading `process.env`), this redirects ALL fts5 / embed-db / HNSW cache writes — in-process and spawned — to a throwaway dir the OS reclaims. Previously these landed in `~/Library/Caches/enquire/` (macOS) / `~/.cache/enquire/` (Linux) and were never cleaned, so a dev machine that ran the suite over weeks accumulated tens of thousands of orphaned index files. **Verified end-to-end:** real-cache file count is unchanged (Δ0) after a full `npm test`; the only real-cache writes observed during testing came from a separate *real* `serve` run on the actual vault (correct behavior), confirmed by matching the file hash to `sha1("/…/Obsidian Vault")`.
+
+### Added
+
+- **`tests/cache-isolation-invariant.test.ts`** (+3): asserts `XDG_CACHE_HOME` is a temp dir during tests and that `defaultIndexFile()` resolves UNDER it, NOT under the real `~/Library/Caches/enquire` (or `~/.cache/enquire`) — so removing the `setup.ts` redirect fails CI. Includes a NEGATIVE control proving the real-cache classifier discriminates (a constant `() => false` would make it vacuous). Meta-invariant-enrolled.
+
+### Method note
+
+This is the textbook value of **testing on a real machine** (the project's home-grown gates are drift/claim-driven and structurally blind to filesystem-side-effects like this): the unit suite *caused* the accumulation but never *observed* it, because no gate inspects the real cache dir. The fix is the project's standard transform — root-cause + a permanent inventory/structural invariant (`cache-isolation-invariant`) so the class can't silently return. Severity is **dev-hygiene** (not a product/CI/end-user correctness bug — a real user with one vault gets one index file; CI runners are ephemeral), but it's a real papercut (699 MB on the maintainer's machine) with a clean, verified fix. **The pre-existing local cruft is maintainer-gated to clear** (deleting files is out of scope for the agent) — see the session hand-off for the exact one-liner that keeps the live vault's index and removes the orphans.
+
+### Tests (1088)
+
+`tests/cache-isolation-invariant.test.ts` +3 source `it()`. 1085 → 1088; claims synced (README ×4, package.json, llms.txt, AGENTS, COMPARISON, ROADMAP).
+
+### Files changed
+
+- `tests/setup.ts` (XDG_CACHE_HOME redirect), `tests/cache-isolation-invariant.test.ts` (new), test-count claims → 1088.
+- version bump 3.10.0-rc.10 → 3.10.0-rc.11.
+
+---
+
 ## [3.10.0-rc.10] — 2026-06-02
 
 > **TL;DR:** **New capability — frontmatter-aware retrieval.** `obsidian_search` gains an optional `filter_frontmatter` map so an agent can scope hybrid search by YAML frontmatter: `{ status: "active", type: ["meeting","decision"] }` → only notes whose frontmatter matches **every** key (strings case-insensitive; an array frontmatter value matches by membership; an array filter value is OR). It's the first genuinely-new *feature* (not polish) since the v3.10 staleness line — Obsidian users live in frontmatter (`status`/`type`/`project`), and **no other Obsidian-MCP can scope semantic search by it**. Opt-in + additive: **absent ⇒ byte-identical** to before (same safe pattern as recency re-ranking). Matching is filter-on-the-fused-candidate-pool, which is already excluded-pruned (rc.8), so no excluded note's frontmatter is read; PDFs (no frontmatter) are excluded without a binary read. **1076 → 1085 tests.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1085%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1088%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1085 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1088 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1085 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1088 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1085 tests, ~12s)
+npm test       # full suite (1088 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1085 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1088 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1085**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1088**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1085 unit tests passing on every PR
+- 1088 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.10",
+  "version": "3.10.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.10",
+      "version": "3.10.0-rc.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.10",
+  "version": "3.10.0-rc.11",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1085 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1088 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.10",
+  "version": "3.10.0-rc.11",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.10",
+      "version": "3.10.0-rc.11",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.10";
+export const VERSION = "3.10.0-rc.11";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/tests/cache-isolation-invariant.test.ts
+++ b/tests/cache-isolation-invariant.test.ts
@@ -1,0 +1,46 @@
+// v3.10.0-rc.11 — structural guard for the hermetic-cache fix (tests/setup.ts).
+//
+// Found by live-testing the install on a real machine: tests that spawn
+// serve/setup/build-embeddings/index WITHOUT an explicit --index-file fell back
+// to defaultIndexFile() → the REAL ~/Library/Caches/enquire, never cleaned up
+// (~27k orphaned files / ~699 MB accumulated over weeks of `npm test`).
+// tests/setup.ts now redirects XDG_CACHE_HOME to a throwaway temp dir. This
+// invariant fails if that redirect is ever removed/broken — so the suite can
+// never silently start polluting a real user cache again.
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { defaultIndexFile } from "../src/fts5.js";
+
+describe("cache-isolation invariant (v3.10 rc.11 — tests never write the real cache)", () => {
+  const realCacheRoots = [
+    path.join(os.homedir(), "Library", "Caches", "enquire"), // macOS default
+    path.join(os.homedir(), ".cache", "enquire") // Linux default
+  ];
+  const underRealUserCache = (p: string): boolean => realCacheRoots.some((r) => p.startsWith(r));
+
+  it("setup.ts redirected XDG_CACHE_HOME to a throwaway temp dir", () => {
+    const xdg = process.env.XDG_CACHE_HOME;
+    expect(xdg, "tests/setup.ts must set XDG_CACHE_HOME (hermetic cache)").toBeTruthy();
+    expect(
+      (xdg as string).startsWith(os.tmpdir()) || (xdg as string).includes("enquire-test-cache-"),
+      `XDG_CACHE_HOME should be a temp dir, got: ${xdg}`
+    ).toBe(true);
+  });
+
+  it("defaultIndexFile() resolves UNDER the temp cache, NOT the real user cache", () => {
+    const f = defaultIndexFile("/Users/example/Documents/Obsidian Vault");
+    expect(underRealUserCache(f), `index file leaked to the real user cache: ${f}`).toBe(false);
+    expect(f.startsWith(process.env.XDG_CACHE_HOME as string)).toBe(true);
+  });
+
+  // NEGATIVE control: the underRealUserCache() classifier must DISCRIMINATE —
+  // it flags a real-cache path true and the (temp-redirected) resolved file
+  // false. A constant `() => false` classifier would make the test above
+  // vacuous; this fails it.
+  it("NEGATIVE control — classifier flags the real cache, clears the redirected one", () => {
+    expect(underRealUserCache(path.join(os.homedir(), "Library", "Caches", "enquire", "abc.fts5.db"))).toBe(true);
+    expect(underRealUserCache(path.join(os.homedir(), ".cache", "enquire", "abc.embed.db"))).toBe(true);
+    expect(underRealUserCache(defaultIndexFile("/Users/example/Documents/Obsidian Vault"))).toBe(false);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,23 @@
+// v3.10.0-rc.11 — HERMETIC CACHE (found by live-testing the install on a real
+// machine): `defaultIndexFile()` + the embed-db / HNSW sidecars resolve their
+// cache dir from `XDG_CACHE_HOME` (all platforms; macOS default
+// `~/Library/Caches/enquire`). Any test that spawns `serve`/`setup`/
+// `build-embeddings`/`index` WITHOUT an explicit `--index-file`/`--embed-file`
+// fell back to that REAL user cache and never cleaned up — weeks of repeated
+// `npm test` had left ~27,000 orphaned files / ~699 MB in a real user's cache.
+// Fix at the root: redirect XDG_CACHE_HOME to a throwaway temp dir BEFORE any
+// test (and any inheriting child spawn — every spawn in this suite inherits
+// process.env, verified) touches the cache. The OS reclaims it; the real cache
+// is never written. Guarded by `if (!XDG_CACHE_HOME)` so CI/devs can override.
+// Enforced by tests/cache-isolation-invariant.test.ts.
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (!process.env.XDG_CACHE_HOME) {
+  process.env.XDG_CACHE_HOME = mkdtempSync(join(tmpdir(), "enquire-test-cache-"));
+}
+
 // v3.5.6 — Vitest setup file. Warms the native / heavy optional deps
 // ONCE before any test runs, so individual tests never pay the cold-
 // import cost.


### PR DESCRIPTION
## TL;DR
Live-testing the installed `enquire-mcp@3.9.1` against a real 237-note vault (works end-to-end: boot, 33 tools, `obsidian_stats`, semantic search, path-escape guard) surfaced **~27,000 orphaned files / ~699 MB** sitting in `~/Library/Caches/enquire/`. Root cause: the **test suite** itself was writing to the **real** user cache.

## Root cause
`defaultIndexFile()` + the embed-db / HNSW sidecars resolve their cache directory from `XDG_CACHE_HOME` (all platforms; macOS default `~/Library/Caches/enquire`). Any test that spawns `serve` / `setup` / `build-embeddings` / `index` **without** an explicit `--index-file` fell back to that **real** cache and never cleaned up. Weeks of `npm test` (mtimes May 8 → Jun 3) accreted ~27k `.fts5.db` / `.embed.db` files.

## Fix (root, not instance)
`tests/setup.ts` redirects `XDG_CACHE_HOME` to a throwaway temp dir **before any test (or inheriting child spawn — every spawn in this suite inherits `process.env`, verified) touches the cache**. The OS reclaims the temp dir; the real cache is never written. Guarded by `if (!XDG_CACHE_HOME)` so CI/devs can still override.

**Verified:** real-cache file delta after a full `npm test` is now **0** (the only real-cache writes observed during testing came from a *separate, deliberate* `serve` run against the actual vault — hash matched `sha1(vaultRoot)`).

## Regression proofing
`tests/cache-isolation-invariant.test.ts` (+3, meta-invariant-enrolled with a real NEGATIVE control) asserts `XDG_CACHE_HOME` is a temp dir and `defaultIndexFile()` resolves **under** it and **not** under the real user cache; the NEGATIVE control proves the `underRealUserCache()` classifier actually discriminates.

## Scope
- Tests 1085 → 1088. **No `src/` runtime change.**
- All 9 gates green: lint, tsc(strict), version-consistency (7 surfaces), test:coverage (1153 pass + 2 skip), per-file (12 floors), oia (12 checks), scope-completeness, smoke (CI-way synthetic vault — scan + `--with-fts`), docs:api (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)