### PR TITLE
v3.10.0-rc.16: audit MED-batch 1/6 — retrieval correctness (M5 + M6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1104+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1108+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@ All notable changes to this project will be documented here. The format follows 
 - **M5 — `obsidian_open_questions` returned an arbitrary `limit`-subset, not the oldest** (`src/tools/meta.ts`). The outer loop `break`'d once `out.length >= limit` in `vault.listMarkdown` (readdir) order, then `out.sort(age desc)` ran on that already-truncated set. On a vault with more than `limit` questions, callers asking for "the most-aged open questions" got whichever notes came first in the walk. Now: cap the scan (`capScanEntries`, defense-in-depth like the graph tools), collect ALL matches, sort oldest-first, then `slice(0, limit)` — the documented contract.
 - **M6 — `HnswIndex.applyDiff` could leave a half-applied index on a dim mismatch** (`src/hnsw.ts`). The `pt.vector.length !== dim` check lived inside the addPoint loop, so a bad vector threw after the `markDelete` loop + earlier `addPoint`s had already mutated the index; the watcher's `syncHnswForFile` catch logs + continues (doesn't rebuild), leaving HNSW out of sync with the freshly-upserted embed-db until the next serve restart (ghost labels / stale `text_preview`). Now ALL dims are pre-validated before any `markDelete`/`resizeIndex`/`addPoint` → applyDiff is atomic for the only caller-data-driven throw (a native addPoint failure after the pre-grow remains the sole, rare, eventually-consistent residual, documented).
 
+### Security (dependency)
+
+- **`hono` moderate advisory (transitive, not reachable) — pinned to the patched 4.12.23 via `overrides`.** A fresh `npm audit` moderate advisory hit `hono ≤4.12.20` (GHSA-xrhx-7g5j-rcj5 IPv6-deny bypass + GHSA-3hrh-pfw6-9m5x cookie injection + GHSA-f577-qrjj-4474 JWT scheme + GHSA-2gcr-mfcq-wcc3 mount-prefix), pulled in TRANSITIVELY by `@modelcontextprotocol/sdk@1.29.0` (via `@hono/node-server`). enquire runs its OWN node-`http` transport, not hono, so none of the flagged paths are reachable — but the `audit` CI gate flags the dep tree regardless. Added `"overrides": { "hono": "^4.12.21" }` → resolves to 4.12.23 (in-range for the SDK's `^4.11.4`, non-breaking; build + SDK transport tests green). `npm audit` back to **0 vulnerabilities** (prod-moderate + all-high). Caught by CI's `audit` gate, not my local battery — lesson: run `npm audit` locally too (the battery omitted it).
+
 ### Tests (1108)
 
-`tests/redos-guard.test.ts` +3 (open-questions oldest-first: limit=1 returns the oldest not the walk-first/newest; limit=2 returns the 2 oldest; full-order regression — names+mtimes chosen so the oldest is never readdir-first, making the revert discriminating). `tests/hnsw.test.ts` +1 (applyDiff wrong-dim throws atomically — the removeLabel survives the failed diff; NEGATIVE control: a valid diff DOES remove it). 1104 → 1108.
+`tests/redos-guard.test.ts` +3 (open-questions oldest-first: limit=1 returns the oldest not the walk-first/newest; limit=2 returns the 2 oldest; full-order regression — names+mtimes chosen so the oldest is never readdir-first, making the revert discriminating). `tests/hnsw.test.ts` +1 (applyDiff wrong-dim throws atomically — the removeLabel survives the failed diff; NEGATIVE control: a valid diff DOES remove it). 1104 → 1108 (the hono override adds no tests).
 
 ### Files changed
 
 - `src/tools/meta.ts` (M5 + `capScanEntries` import), `src/hnsw.ts` (M6 dim pre-validation), `tests/redos-guard.test.ts` (+3), `tests/hnsw.test.ts` (+1), test-count claims → 1108.
+- `package.json` + `package-lock.json` (hono `overrides` → 4.12.23, security).
 - version bump 3.10.0-rc.15 → 3.10.0-rc.16.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.16] — 2026-06-05
+
+> **TL;DR:** **Audit MED-batch 1/6 — retrieval correctness.** A from-scratch 7-agent system audit (core code · transport/CLI · security/STRIDE · privacy · agent-facing surfaces · docs/process · tests), every headline adversarially re-verified against the code, returned **0 CRITICAL / 0 HIGH** for this 30+-round-audited codebase — real findings sat in the apparatus's known behavioral/docs blind spots. This RC fixes the first two verified MEDIUMs. **M5:** `obsidian_open_questions` is documented "oldest-first" but broke at `limit` in vault-WALK order and only THEN sorted — so on a vault with > `limit` questions it returned an arbitrary subset, NOT the oldest. Now collects all (scan capped via `capScanEntries`), sorts oldest-first, slices. **M6:** `HnswIndex.applyDiff` validated vector dim INSIDE the addPoint loop, so a wrong-dim vector threw AFTER some labels were `markDelete`'d and some points added → a half-applied index (silent embed-db↔HNSW divergence in the watcher, which logs + continues rather than rebuilding). Dim is now pre-validated before ANY mutation → atomic for the only caller-data-driven throw. **1104 → 1108 tests.**
+
+**Pre-release (v3.10 line) — audit fix batch 1/6.**
+
+### Fixed
+
+- **M5 — `obsidian_open_questions` returned an arbitrary `limit`-subset, not the oldest** (`src/tools/meta.ts`). The outer loop `break`'d once `out.length >= limit` in `vault.listMarkdown` (readdir) order, then `out.sort(age desc)` ran on that already-truncated set. On a vault with more than `limit` questions, callers asking for "the most-aged open questions" got whichever notes came first in the walk. Now: cap the scan (`capScanEntries`, defense-in-depth like the graph tools), collect ALL matches, sort oldest-first, then `slice(0, limit)` — the documented contract.
+- **M6 — `HnswIndex.applyDiff` could leave a half-applied index on a dim mismatch** (`src/hnsw.ts`). The `pt.vector.length !== dim` check lived inside the addPoint loop, so a bad vector threw after the `markDelete` loop + earlier `addPoint`s had already mutated the index; the watcher's `syncHnswForFile` catch logs + continues (doesn't rebuild), leaving HNSW out of sync with the freshly-upserted embed-db until the next serve restart (ghost labels / stale `text_preview`). Now ALL dims are pre-validated before any `markDelete`/`resizeIndex`/`addPoint` → applyDiff is atomic for the only caller-data-driven throw (a native addPoint failure after the pre-grow remains the sole, rare, eventually-consistent residual, documented).
+
+### Tests (1108)
+
+`tests/redos-guard.test.ts` +3 (open-questions oldest-first: limit=1 returns the oldest not the walk-first/newest; limit=2 returns the 2 oldest; full-order regression — names+mtimes chosen so the oldest is never readdir-first, making the revert discriminating). `tests/hnsw.test.ts` +1 (applyDiff wrong-dim throws atomically — the removeLabel survives the failed diff; NEGATIVE control: a valid diff DOES remove it). 1104 → 1108.
+
+### Files changed
+
+- `src/tools/meta.ts` (M5 + `capScanEntries` import), `src/hnsw.ts` (M6 dim pre-validation), `tests/redos-guard.test.ts` (+3), `tests/hnsw.test.ts` (+1), test-count claims → 1108.
+- version bump 3.10.0-rc.15 → 3.10.0-rc.16.
+
+---
+
 ## [3.10.0-rc.15] — 2026-06-03
 
 > **TL;DR:** **Watcher-test flake stabilized at the root — it was blocking RELEASES, not just PRs.** The rc.13 release run failed at `tests/watcher.test.ts:505` (chokidar FSEvents timing); a re-run published it — but a transient blip must never fail a publish (rc.20 rule). Two root races: **(1)** a brand-new file's FIRST inotify/FSEvents event can be dropped on a loaded runner even after `start()` resolves on `ready`, so a one-shot `writeFile` + `waitFor` can wait forever — the fixed-`setTimeout` warm-ups (rc.7 #36, rc.9 W-FLAKE-2) only approximated a fix; **(2)** the `:505` assertion read the embed-error stderr line IMMEDIATELY after the `fts.totalFiles()` check, but that line is logged a tick LATER in the same handler. Fixed: new `writeAndWaitFor` re-touch-on-miss helper (re-writes the file if the first event is dropped — idempotent reindex) on all 5 new-file-add sites; the lagging embed-error signal is now polled with `waitFor`; `waitFor` default 4000 → 8000 ms. **Verified green 3× back-to-back.** **1104 tests unchanged** (bodies refactored, no `it()` added). **Test-only — zero `src/`.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1104%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1108%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1104 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1108 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1104 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1108 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1104 tests, ~12s)
+npm test       # full suite (1108 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1104 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1108 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1104**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1108**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1104 unit tests passing on every PR
+- 1108 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2855,9 +2855,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.15",
+  "version": "3.10.0-rc.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.15",
+      "version": "3.10.0-rc.16",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.15",
+  "version": "3.10.0-rc.16",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1104 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1108 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -203,5 +203,8 @@
     "hnswlib-node": "^3.0.0",
     "pdfjs-dist": "^5.7.284",
     "tesseract.js": "^7.0.0"
+  },
+  "overrides": {
+    "hono": "^4.12.21"
   }
 }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.15",
+  "version": "3.10.0-rc.16",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.15",
+      "version": "3.10.0-rc.16",
       "transport": {
         "type": "stdio"
       },

--- a/src/hnsw.ts
+++ b/src/hnsw.ts
@@ -372,6 +372,21 @@ function wrapNativeIndex(ctor: HnswNativeIndex, dim: number, size: number): Hnsw
             "upgrade hnswlib-node to ≥3.0 (or rebuild from source) to use live-update; falling back to full rebuild on next serve restart"
         );
       }
+      // v3.10.0-rc.16 (audit M6) — pre-validate ALL vector dims BEFORE any
+      // mutation (markDelete / resizeIndex / addPoint). Previously the dim
+      // check lived INSIDE the addPoint loop, so a mismatched vector threw
+      // AFTER some labels were already markDelete'd and some points added —
+      // leaving a half-applied index the caller had to rebuild (silent embed-db
+      // ↔ HNSW divergence in the watcher path, which logs + continues rather
+      // than rebuilding). Hoisting the check makes applyDiff ATOMIC for the
+      // only caller-data-driven throw: if any dim is wrong, nothing mutates.
+      for (const pt of addPoints) {
+        if (pt.vector.length !== dim) {
+          throw new Error(
+            `HnswIndex.applyDiff: vector for label ${pt.label} has dim ${pt.vector.length}, expected ${dim}`
+          );
+        }
+      }
       let removed = 0;
       for (const label of removeLabels) {
         try {
@@ -396,11 +411,9 @@ function wrapNativeIndex(ctor: HnswNativeIndex, dim: number, size: number): Hnsw
         ctor.resizeIndex(Math.max(needed, Math.ceil(current * 1.5)));
       }
       for (const pt of addPoints) {
-        if (pt.vector.length !== dim) {
-          throw new Error(
-            `HnswIndex.applyDiff: vector for label ${pt.label} has dim ${pt.vector.length}, expected ${dim}`
-          );
-        }
+        // dim pre-validated above (audit M6); the only remaining throw is a
+        // genuine native/capacity error — capacity is pre-grown above, so this
+        // is rare and not caller-data-driven.
         ctor.addPoint(Array.from(pt.vector), pt.label, /* replaceDeleted */ true);
         added += 1;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.15";
+export const VERSION = "3.10.0-rc.16";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import matter from "gray-matter";
 import type { FtsIndex } from "../fts5.js";
 import type { FileEntry, Vault } from "../vault.js";
+import { capScanEntries } from "./limits.js";
 import { getBacklinks, getRecentEdits, listTags } from "./read.js";
 import { searchHybrid } from "./search.js";
 import { resolveTarget, suggestSimilar } from "./write.js";
@@ -1175,11 +1176,16 @@ export async function getOpenQuestions(
     re = new RegExp(defaultPat, "i");
   }
 
-  const entries = await vault.listMarkdown(args.folder);
+  // v3.10.0-rc.16 (audit M5) — collect ALL matches across the (capped) scan,
+  // THEN sort oldest-first + slice. The prior code broke at `limit` in vault-
+  // WALK order and only then sorted, so on a vault with > `limit` questions it
+  // returned an arbitrary limit-subset, NOT the documented oldest-first. The
+  // scan is capped (capScanEntries) so a pathological vault can't drive
+  // unbounded readNote I/O — defense-in-depth, same posture as the graph tools.
+  const entries = capScanEntries(await vault.listMarkdown(args.folder), "obsidian_open_questions");
   const out: OpenQuestion[] = [];
   const now = Date.now();
   for (const e of entries) {
-    if (out.length >= limit) break;
     const { parsed, mtimeMs } = await vault.readNote(e.absPath, e.mtimeMs);
     // Scan parsed.body so frontmatter lines (which can contain "Q:" -ish
     // tokens) don't pollute results.
@@ -1204,12 +1210,12 @@ export async function getOpenQuestions(
         age_days: Math.round((now - mtimeMs) / (24 * 3600 * 1000)),
         mtime: new Date(mtimeMs).toISOString()
       });
-      if (out.length >= limit) break;
     }
   }
-  // Sort oldest-first so things aging out surface first.
+  // Sort oldest-first so things aging out surface first, THEN return the
+  // `limit` genuinely-oldest — not an arbitrary walk-order subset (audit M5).
   out.sort((a, b) => b.age_days - a.age_days);
-  return out;
+  return out.slice(0, limit);
 }
 
 // ─── obsidian_paper_audit (v1.5 — verify #paper notes have citations) ────────

--- a/tests/hnsw.test.ts
+++ b/tests/hnsw.test.ts
@@ -383,6 +383,34 @@ describe("HNSW persistence (v2.16.0)", () => {
     expect(meta.size, "NEGATIVE control: must NOT be the stale build-time size").not.toBe(n);
   });
 
+  it("M6 (rc.16 audit) — applyDiff with a wrong-dim point throws ATOMICALLY (no markDelete before the throw)", async () => {
+    const dim = 4;
+    const norm = (a: number[]) => {
+      const s = Math.sqrt(a.reduce((t, x) => t + x * x, 0)) || 1;
+      return new Float32Array(a.map((x) => x / s));
+    };
+    const labeled = [0, 1, 2].map((i) => ({ label: i, vector: norm([i + 1, 1, 1, 1]) }));
+    const index = await buildHnsw(labeled, { dim, maxElements: 50 });
+    const q = norm([1, 1, 1, 1]); // closest to label 0
+    expect(index.searchKnn(q, 1).labels, "label 0 active pre-diff").toContain(0);
+
+    // A diff that removes label 0 AND adds a WRONG-dim point. Pre-rc.16 the dim
+    // check fired INSIDE the addPoint loop, so label 0 was already markDelete'd
+    // when the throw hit → half-applied index. Now dims are pre-validated, so a
+    // bad dim throws BEFORE any mutation.
+    expect(() => index.applyDiff([0], [{ label: 99, vector: new Float32Array([1, 1, 1]) }])).toThrow(
+      /dim 3, expected 4/
+    );
+
+    // ATOMICITY: label 0 must STILL be active — the failed diff didn't delete it.
+    expect(index.searchKnn(q, 1).labels, "label 0 must survive a failed applyDiff").toContain(0);
+
+    // NEGATIVE control: a VALID diff DOES remove label 0 — proves the search
+    // check can actually observe a removal (the atomicity assertion isn't vacuous).
+    index.applyDiff([0], [{ label: 99, vector: norm([9, 9, 9, 9]) }]);
+    expect(index.searchKnn(q, 3).labels, "valid diff removes label 0").not.toContain(0);
+  });
+
   it("returns null when signature doesn't match (stale index)", async () => {
     const persistFile = path.join(dir, "stale.hnsw");
     const v = new Float32Array(4).fill(0.5);

--- a/tests/redos-guard.test.ts
+++ b/tests/redos-guard.test.ts
@@ -246,3 +246,48 @@ describe("getOpenQuestions — pattern hardening integration", () => {
     await expect(getOpenQuestions(new Vault(root), { pattern: tooLong })).rejects.toThrow(/too long/i);
   });
 });
+
+describe("getOpenQuestions — returns the genuinely-OLDEST, not a walk-order subset (rc.16 audit M5)", () => {
+  let root: string;
+  const DAY = 24 * 3600 * 1000;
+  beforeAll(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-oq-age-"));
+    // Each note has exactly one question; mtime sets its age. Created in
+    // newest→oldest order with names that sort the OLDEST LAST, so the oldest is
+    // never readdir-first under alphabetical OR creation order — the pre-rc.16
+    // code (collect first `limit` in walk order, THEN sort) would surface the
+    // NEWEST here, the fixed code the OLDEST.
+    const notes: Array<[string, number]> = [
+      ["aaa-newest.md", 0],
+      ["mmm-mid.md", 100],
+      ["zzz-oldest.md", 200]
+    ];
+    for (const [name, ageDays] of notes) {
+      const abs = path.join(root, name);
+      await fs.writeFile(abs, `Open question: from ${name}?\n`);
+      const mtime = new Date(Date.now() - ageDays * DAY);
+      await fs.utimes(abs, mtime, mtime);
+    }
+  });
+  afterAll(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("with limit=1 returns the single OLDEST question, not the walk-first/newest", async () => {
+    const out = await getOpenQuestions(new Vault(root), { limit: 1 });
+    expect(out).toHaveLength(1);
+    // The fix: globally-oldest. The bug returned the walk-first (newest) note.
+    expect(out[0]?.source_path).toBe("zzz-oldest.md");
+    expect(out[0]?.source_path).not.toBe("aaa-newest.md");
+  });
+
+  it("with limit=2 (< total) returns the 2 OLDEST, oldest-first", async () => {
+    const out = await getOpenQuestions(new Vault(root), { limit: 2 });
+    expect(out.map((q) => q.source_path)).toEqual(["zzz-oldest.md", "mmm-mid.md"]);
+  });
+
+  it("returns ALL questions oldest-first when limit covers them (ordering regression guard)", async () => {
+    const out = await getOpenQuestions(new Vault(root), { limit: 50 });
+    expect(out.map((q) => q.source_path)).toEqual(["zzz-oldest.md", "mmm-mid.md", "aaa-newest.md"]);
+  });
+});


### PR DESCRIPTION
## Context
A from-scratch **7-agent system audit** (core code · transport/CLI · security/STRIDE · privacy · agent-facing surfaces · docs/process · tests), every headline **adversarially re-verified against the code** → **0 CRITICAL / 0 HIGH** for this 30+-round-audited codebase. Findings sat in the apparatus's known behavioral/docs blind spots. This is fix batch **1/6** (the two verified retrieval-correctness MEDIUMs).

## Fixes
- **M5 — `obsidian_open_questions` returned an arbitrary `limit`-subset, not the oldest** (`src/tools/meta.ts`). It `break`'d at `limit` in vault-walk (readdir) order, then sorted that already-truncated set — so a caller asking for "the most-aged open questions" got whichever notes came first in the walk. Now: cap the scan (`capScanEntries`, defense-in-depth), collect **all**, sort oldest-first, `slice(0, limit)`.
- **M6 — `HnswIndex.applyDiff` could leave a half-applied index on a dim mismatch** (`src/hnsw.ts`). The dim check was **inside** the addPoint loop, so a bad vector threw after `markDelete` + earlier `addPoint`s had mutated; the watcher's catch logs + continues (no rebuild) → silent embed-db↔HNSW divergence until restart. Dim is now **pre-validated before any mutation** → atomic for the only caller-data-driven throw.

## Tests (+4 → 1108)
`redos-guard.test.ts` +3 (oldest-first: limit=1 returns the oldest not the walk-first/newest; limit=2; full-order — names+mtimes chosen so the oldest is never readdir-first, making the revert discriminating). `hnsw.test.ts` +1 (wrong-dim diff throws **atomically** — the removeLabel survives; NEGATIVE control: a valid diff DOES remove it).

## Gates
All 9 green: version-consistency (7), lint, tsc, test:coverage (1173 pass + 2 skip; global + 12 per-file floors), oia (12), scope, smoke, docs:api (0 warn). No API breaks.

Next: rc.17 (M1 chunking parity), rc.18 (M3 signal-shutdown + M4 DoS caps), rc.19 (privacy/erasure), rc.20 (docs integrity), rc.21 (test/process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)