### PR TITLE
v3.10.0-rc.17: audit MED-batch 2/6 — M1 chunking parity (embeddings line citations)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1108+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1113+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.17] — 2026-06-06
+
+> **TL;DR:** **Audit MED-batch 2/6 — M1 chunking parity (embeddings line citations).** The embedding pipeline chunks the frontmatter-STRIPPED body (to keep YAML out of the vectors) while the FTS5 index chunks the FULL note content — so for any note WITH frontmatter, embeddings / `find_similar` / `semantic_search` stored `line_start`/`line_end` that were BODY-relative (too low by the frontmatter line count), pointing deep-links at the wrong line; and the code comments falsely claimed "identical chunking across BM25 and embeddings." Fix: `parseNote` now exposes `bodyStartLine`, and `embedSingleNote` shifts each chunk's line numbers to FILE-absolute (matching FTS5) — keeping the clean body-only embeddings (no quality regression). Comments corrected; the residual `block`-granularity chunk-INDEX divergence for frontmatter'd notes is documented (the default `note` granularity fuses by path, unaffected). **1108 → 1113 tests.**
+
+**Pre-release (v3.10 line) — audit fix batch 2/6.**
+
+### Fixed
+
+- **M1 — embeddings line citations were body-relative (off by the frontmatter line count) for frontmatter'd notes.** `embedSingleNote` chunks `note.parsed.body` (frontmatter stripped, so YAML never pollutes the vectors), but `chunkContent`'s `lineStart`/`lineEnd` are then relative to the body, not the file — so a hit's deep-link pointed N lines too early (N = the frontmatter line count). `parseNote` now returns `bodyStartLine` (the 1-based file line where the body begins, via `source.indexOf(body)`; 1 with no frontmatter), and `embedSingleNote` adds `(bodyStartLine − 1)` to each chunk's line numbers → FILE-absolute, matching the FTS5 index (which chunks full content). Embedding quality is unchanged (still body-only). Existing embed-dbs apply the corrected lines as notes are re-embedded (on edit, or `enquire-mcp build-embeddings`) — no forced rebuild (proportionate: a full re-embed on every serve for a line-number fix would be disruptive).
+- **M1 (claim-vs-reality) — `embed-db.ts` header claimed "Same chunking as FTS5 … so chunk identity matches across BM25 and embeddings."** False for markdown (FTS5 chunks full content; embeddings chunk body). Corrected to describe the actual design + the file-absolute line alignment + the `block`-granularity caveat. The `reindexPdfFile` "chunk IDs match" claim is accurate (PDFs have no frontmatter) and left as-is.
+
+### Docs
+
+- `searchHybrid` granularity `@param` now notes that in `block` granularity a per-note chunk INDEX may not denote the same span across BM25 (content) and embeddings (body) for frontmatter'd notes — prefer the default `note` granularity (fused by path) for frontmatter-heavy vaults.
+
+### Tests (1113)
+
+`tests/embed-pipeline.test.ts` +2 (frontmatter'd note → chunk `lineStart` lands on the file line that actually contains the chunk text, not the `---`; NEGATIVE control: no-frontmatter ⇒ offset 0, line 1). `tests/parser.test.ts` +3 (`bodyStartLine` > 1 with frontmatter; === 1 without — NEGATIVE control; points at the first body line). 1108 → 1113.
+
+### Files changed
+
+- `src/parser.ts` (`bodyStartLine` field + computation), `src/embed-pipeline.ts` (file-absolute line offset in `embedSingleNote`), `src/embed-db.ts` (header comment), `src/tools/search.ts` (granularity `@param` caveat), `tests/embed-pipeline.test.ts` (+2), `tests/parser.test.ts` (+3), test-count claims → 1113.
+- version bump 3.10.0-rc.16 → 3.10.0-rc.17.
+
+---
+
 ## [3.10.0-rc.16] — 2026-06-05
 
 > **TL;DR:** **Audit MED-batch 1/6 — retrieval correctness.** A from-scratch 7-agent system audit (core code · transport/CLI · security/STRIDE · privacy · agent-facing surfaces · docs/process · tests), every headline adversarially re-verified against the code, returned **0 CRITICAL / 0 HIGH** for this 30+-round-audited codebase — real findings sat in the apparatus's known behavioral/docs blind spots. This RC fixes the first two verified MEDIUMs. **M5:** `obsidian_open_questions` is documented "oldest-first" but broke at `limit` in vault-WALK order and only THEN sorted — so on a vault with > `limit` questions it returned an arbitrary subset, NOT the oldest. Now collects all (scan capped via `capScanEntries`), sorts oldest-first, slices. **M6:** `HnswIndex.applyDiff` validated vector dim INSIDE the addPoint loop, so a wrong-dim vector threw AFTER some labels were `markDelete`'d and some points added → a half-applied index (silent embed-db↔HNSW divergence in the watcher, which logs + continues rather than rebuilding). Dim is now pre-validated before ANY mutation → atomic for the only caller-data-driven throw. **1104 → 1108 tests.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1108%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1113%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1108 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1113 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1108 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1113 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1108 tests, ~12s)
+npm test       # full suite (1113 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1108 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1113 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1108**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1113**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1108 unit tests passing on every PR
+- 1113 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.16",
+  "version": "3.10.0-rc.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.16",
+      "version": "3.10.0-rc.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.16",
+  "version": "3.10.0-rc.17",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1108 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1113 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.16",
+  "version": "3.10.0-rc.17",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.16",
+      "version": "3.10.0-rc.17",
       "transport": {
         "type": "stdio"
       },

--- a/src/embed-db.ts
+++ b/src/embed-db.ts
@@ -1,7 +1,13 @@
 // Persistent embedding store (v2.0 alpha). SQLite-backed Float32 vectors,
-// brute-force cosine top-K retrieval. Same chunking as FTS5 (paragraph-level
-// via fts5.chunkContent) so chunk identity matches across BM25 and embeddings —
-// foundation for the v2.0 beta hybrid RRF scorer.
+// brute-force cosine top-K retrieval. Paragraph-level chunking via
+// fts5.chunkContent — but NB embeddings chunk the frontmatter-stripped BODY (to
+// keep YAML out of the vectors) while the FTS5 index chunks the FULL note
+// content. For notes WITHOUT frontmatter the two chunkings are identical; the
+// embedding pipeline shifts its chunk line numbers to FILE-absolute (v3.10.0-rc.17,
+// audit M1) so `line_start`/`line_end` match FTS5 regardless. In `block`
+// granularity the per-note chunk INDEX can still differ for frontmatter'd notes;
+// the default `note` granularity fuses by path and is unaffected. Foundation for
+// the hybrid RRF scorer.
 //
 // Architecture mirrors fts5.ts:
 //   - Lazy-loaded better-sqlite3 (optional dep)

--- a/src/embed-pipeline.ts
+++ b/src/embed-pipeline.ts
@@ -135,6 +135,12 @@ export async function embedSingleNote(
   const note = await vault.readNote(entry.absPath, entry.mtimeMs);
   const chunks = chunkContent(note.parsed.body);
   if (chunks.length === 0) return null;
+  // v3.10.0-rc.17 (audit M1) — we chunk the BODY (frontmatter stripped) to keep
+  // YAML out of the vectors, but `chunkContent` line numbers are then body-
+  // relative. Shift them to FILE-absolute (matching the FTS5 index, which chunks
+  // full content) so deep-link `line_start`/`line_end` point at the right line
+  // in notes with frontmatter. `bodyStartLine` is 1 (offset 0) without frontmatter.
+  const lineOffset = note.parsed.bodyStartLine - 1;
   const docTitle = note.parsed.frontmatter?.title || path.basename(entry.relPath, ".md");
   const embedTexts = chunks.map((_c, i) =>
     buildEmbedText(chunks, i, {
@@ -148,8 +154,8 @@ export async function embedSingleNote(
     if (!vector) throw new Error(`embedder returned no vector for chunk ${i} of ${entry.relPath}`);
     return {
       chunkIndex: i,
-      lineStart: c.lineStart,
-      lineEnd: c.lineEnd,
+      lineStart: c.lineStart + lineOffset,
+      lineEnd: c.lineEnd + lineOffset,
       textPreview: c.text.slice(0, 480),
       vector
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.16";
+export const VERSION = "3.10.0-rc.17";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,6 +41,12 @@ export interface ParsedNote {
   frontmatter: Record<string, unknown>;
   /** Post-frontmatter body — verbatim, including code fences. */
   body: string;
+  /** 1-based line number in the ORIGINAL source where `body` begins (= the count
+   *  of frontmatter + delimiter lines + 1; 1 when there's no frontmatter). Lets
+   *  consumers that chunk `body` (the embedding pipeline) report FILE-absolute
+   *  line numbers that match the FTS5 index, which chunks the full content.
+   *  v3.10.0-rc.17 (audit M1). */
+  bodyStartLine: number;
   /** All `[[wikilinks]]` found in the body (after stripping code spans). */
   wikilinks: Wikilink[];
   /** All `![[embeds]]` found in the body (after stripping code spans). */
@@ -78,9 +84,17 @@ export function parseNote(source: string): ParsedNote {
     body = source;
   }
   const sanitized = stripCodeAndInline(body);
+  // v3.10.0-rc.17 (audit M1) — the 1-based file line where `body` starts, so
+  // body-chunking consumers (the embedding pipeline) can report FILE-absolute
+  // line numbers that match the content-chunking FTS5 index. `body` is a
+  // verbatim substring of `source`, so indexOf locates it; 1 when there's no
+  // frontmatter (bodyIdx === 0) or in the defensive not-found case.
+  const bodyIdx = source.indexOf(body);
+  const bodyStartLine = bodyIdx > 0 ? source.slice(0, bodyIdx).split("\n").length : 1;
   return {
     frontmatter,
     body,
+    bodyStartLine,
     wikilinks: extractWikilinks(sanitized),
     embeds: extractEmbeds(sanitized),
     tags: collectTags(frontmatter, sanitized)

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1262,8 +1262,13 @@ export interface SearchHybridResponse {
  * @param vault - The vault to search.
  * @param args - `query` is required + non-empty. `limit` defaults to 10.
  *   `min_signals` (default 1) requires that many rankers fired for a hit.
- *   `granularity: "note"` (default) collapses to best chunk per note;
- *   `"block"` keeps each chunk distinct. `graph_boost` defaults to `true`.
+ *   `granularity: "note"` (default) collapses to best chunk per note (fused by
+ *   path — unaffected by chunking differences); `"block"` keeps each chunk
+ *   distinct (fused by `path#chunk_index`). NB for notes WITH frontmatter the
+ *   embeddings ranker chunks the body while BM25 chunks the full content, so a
+ *   `block` chunk INDEX may not denote the same span across the two rankers —
+ *   prefer the default `note` granularity for frontmatter-heavy vaults (audit M1).
+ *   `graph_boost` defaults to `true`.
  * @param ctx - Server-side context: `ftsIndex` (nullable), `embedFile`
  *   (path may not exist), optional `reranker` config, optional
  *   `rerankerOverride` (test injection point), optional `hnsw` context for

--- a/tests/embed-pipeline.test.ts
+++ b/tests/embed-pipeline.test.ts
@@ -96,6 +96,45 @@ describe("embedSingleNote", () => {
     expect(result).toBeNull();
   });
 
+  it("M1 (rc.17 audit) — chunk line numbers are FILE-absolute for a frontmatter'd note", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const filePath = path.join(root, "fm.md");
+    const content = "---\ntitle: T\ntags: [x]\n---\n\nFirst body paragraph here.\n\nSecond body paragraph here.\n";
+    await fs.writeFile(filePath, content);
+    const stat = await fs.stat(filePath);
+    const result = await embedSingleNote(v, mockEmbedder, {
+      relPath: "fm.md",
+      absPath: filePath,
+      mtimeMs: stat.mtimeMs
+    });
+    expect(result).not.toBeNull();
+    if (!result) throw new Error("unreachable");
+    const lines = content.split("\n");
+    const row0 = result.rows[0];
+    if (!row0) throw new Error("expected at least one row");
+    // The stored (now FILE-absolute) lineStart must land on the line in the file
+    // that actually contains the chunk's text. Pre-rc.17 it was body-RELATIVE
+    // (line 1 → the `---` delimiter), a wrong deep-link for frontmatter'd notes.
+    const chunkFirstLine = row0.textPreview.split("\n")[0] ?? "";
+    expect(lines[row0.lineStart - 1]).toContain(chunkFirstLine.slice(0, 15));
+    expect(row0.lineStart, "discriminating: not the body-relative 1").toBeGreaterThan(1);
+  });
+
+  it("M1 NEGATIVE control — no frontmatter ⇒ offset 0, first chunk still starts at line 1", async () => {
+    const v = new Vault(root);
+    await v.ensureExists();
+    const filePath = path.join(root, "nofm.md");
+    await fs.writeFile(filePath, "First body paragraph here.\n\nSecond body paragraph here.\n");
+    const stat = await fs.stat(filePath);
+    const result = await embedSingleNote(v, mockEmbedder, {
+      relPath: "nofm.md",
+      absPath: filePath,
+      mtimeMs: stat.mtimeMs
+    });
+    expect(result?.rows[0]?.lineStart).toBe(1);
+  });
+
   it("honors lateChunkContext opt (>0 → contextual embed text)", async () => {
     const v = new Vault(root);
     await v.ensureExists();

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -177,3 +177,26 @@ describe("parseNote", () => {
     expect(r.tags.sort()).toEqual(["already-hashed", "single"]);
   });
 });
+
+describe("bodyStartLine (rc.17 audit M1 — file-absolute line offset)", () => {
+  it("is > 1 when frontmatter precedes the body (so body-chunk lines can be file-absolute)", () => {
+    expect(parseNote("---\ntitle: T\ntags: [x]\n---\n\nBody line.\n").bodyStartLine).toBeGreaterThan(1);
+  });
+
+  it("NEGATIVE control: is exactly 1 when there's no frontmatter", () => {
+    expect(parseNote("Body only.\n\nMore body.\n").bodyStartLine).toBe(1);
+  });
+
+  it("points at (or before) the first body line in the original source", () => {
+    const src = "---\nstatus: active\n---\n\nThe real body starts here.\n";
+    const { bodyStartLine, body } = parseNote(src);
+    // The source line at bodyStartLine begins the body region: everything from
+    // there on must contain the body's first text (not the frontmatter).
+    const fromBody = src
+      .split("\n")
+      .slice(bodyStartLine - 1)
+      .join("\n");
+    expect(fromBody).toContain("The real body starts here.");
+    expect(body).toContain("The real body starts here.");
+  });
+});


### PR DESCRIPTION
## Context
Audit fix batch **2/6**. **M1:** embeddings chunk the frontmatter-stripped **body** (to keep YAML out of the vectors) while FTS5 chunks the **full content** — so for notes with frontmatter, embeddings / `find_similar` / `semantic_search` stored `line_start`/`line_end` that were **body-relative** (too low by the frontmatter line count), pointing deep-links at the wrong line; and the code comments falsely claimed "identical chunking."

## Fix (no embedding-quality regression)
- `parseNote` now exposes `bodyStartLine` (1-based file line where the body begins; 1 with no frontmatter). `embedSingleNote` shifts each chunk's line numbers by `(bodyStartLine − 1)` → **file-absolute**, matching FTS5. Embeddings stay **body-only** (no YAML dilution). Existing embed-dbs self-heal as notes re-embed (no forced rebuild — proportionate for a line-number fix).
- **Claim-vs-reality:** corrected the `embed-db.ts` "identical chunking" comment (the `reindexPdfFile` one is accurate — PDFs have no frontmatter). Documented the residual `block`-granularity chunk-index divergence in the `searchHybrid` granularity `@param` (default `note` granularity fuses by path — unaffected).

## Tests (+5 → 1113)
`embed-pipeline.test.ts` +2 (frontmatter'd note → chunk `lineStart` lands on the file line that **contains the chunk text**, not the `---`; NEGATIVE control: no-frontmatter ⇒ line 1). `parser.test.ts` +3 (`bodyStartLine` >1 with frontmatter / ===1 without [NEGATIVE] / points at the body).

## Gates
All 9 green: version-consistency (7), lint, tsc, test:coverage (1178 pass + 2 skip; global + 12 per-file floors), oia (12), scope, smoke, docs:api (0 warn), `npm audit` (0 vulns — run locally per the rc.16 lesson).

Next: rc.18 (M3 signal-shutdown + M4 DoS caps), rc.19 (privacy/erasure), rc.20 (docs integrity), rc.21 (test/process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)