### PR TITLE
v3.10.0-rc.18: audit MED-batch 3 — M4 DoS-cap completeness (dataview_query + invariant scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.18] — 2026-06-06
+
+> **TL;DR:** **Audit MED-batch 3 — M4 DoS-cap completeness (`obsidian_dataview_query` + invariant scope).** The audit flagged `obsidian_dataview_query` (`runDql`) as an uncapped whole-vault `readNote`+parse scan reachable over bearer `serve-http`. Root cause: the rc.36 `resource-bound-invariant`'s `SCANNER_SOURCES` covered `read.ts`/`search.ts`/`meta.ts` but NOT `dql.ts`, so `runDql` was never required to be CAP-or-EXEMPT (scope-too-narrow — the recurring class). Fix: cap `runDql` with `capScanEntries` (defense-in-depth — DQL is a *linear* query so a > MAX_SCAN_NOTES vault yields a partial, logged result, never a hang) + add `src/dql.ts` to `SCANNER_SOURCES` so the invariant patrols it. Also fixed a manifest drift my OWN rc.16 introduced: `getOpenQuestions` began calling `capScanEntries` in rc.16 but the manifest still listed it EXEMPT — reclassified CAPPED. **1113 tests unchanged.** M3 (signal-shutdown) → rc.19.
+
+**Pre-release (v3.10 line) — audit fix batch 3 (M4).**
+
+### Fixed
+
+- **M4 — `obsidian_dataview_query` whole-vault scan was uncapped AND invisible to the resource-bound invariant.** `runDql` (`src/dql.ts`) does `vault.listMarkdown()` → per-note `readNote` + frontmatter-eval; it's always-registered + bearer-reachable, but lived OUTSIDE the invariant's `SCANNER_SOURCES`, so the rc.36 "every whole-vault scanner is CAP-or-EXEMPT" completeness check never saw it. Now: the scan is wrapped in `capScanEntries` (defense-in-depth — DQL is O(N) linear, so a > MAX_SCAN_NOTES vault yields a partial result with a logged warning, not a hang), and `src/dql.ts` is added to `SCANNER_SOURCES`. The audit's "like the uncapped graph tools" framing is imprecise (graph tools are O(N²)/graph and MUST cap; DQL is linear) — but a cap is the right defense-in-depth for a bearer-reachable whole-vault tool, and closing the invariant scope is the structural fix.
+- **rc.16 manifest drift — `getOpenQuestions` was CAPPED in code but EXEMPT in the manifest.** rc.16 (M5) added `capScanEntries` to `getOpenQuestions` but left its `resource-bound-invariant` classification EXEMPT. Reclassified CAPPED (with its `capScanEntries` token) so the manifest matches reality — a post-rc.16 recursion-sweep catch.
+
+### Tests (1113)
+
+No new `it()` — the `resource-bound-invariant` now structurally covers `runDql` (CAPPED → must reference `capScanEntries`) and the corrected `getOpenQuestions` classification; the existing `dql.test.ts` exercises the > MAX_SCAN_NOTES cap path (logs the truncation). 1113 unchanged.
+
+### Files changed
+
+- `src/dql.ts` (`capScanEntries` import + scan cap), `tests/resource-bound-invariant.test.ts` (`SCANNER_SOURCES` += `src/dql.ts`; `runDql` + `getOpenQuestions` → CAPPED; drop `getOpenQuestions` from EXEMPT).
+- version bump 3.10.0-rc.17 → 3.10.0-rc.18.
+
+---
+
 ## [3.10.0-rc.17] — 2026-06-06
 
 > **TL;DR:** **Audit MED-batch 2/6 — M1 chunking parity (embeddings line citations).** The embedding pipeline chunks the frontmatter-STRIPPED body (to keep YAML out of the vectors) while the FTS5 index chunks the FULL note content — so for any note WITH frontmatter, embeddings / `find_similar` / `semantic_search` stored `line_start`/`line_end` that were BODY-relative (too low by the frontmatter line count), pointing deep-links at the wrong line; and the code comments falsely claimed "identical chunking across BM25 and embeddings." Fix: `parseNote` now exposes `bodyStartLine`, and `embedSingleNote` shifts each chunk's line numbers to FILE-absolute (matching FTS5) — keeping the clean body-only embeddings (no quality regression). Comments corrected; the residual `block`-granularity chunk-INDEX divergence for frontmatter'd notes is documented (the default `note` granularity fuses by path, unaffected). **1108 → 1113 tests.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.17",
+  "version": "3.10.0-rc.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.17",
+      "version": "3.10.0-rc.18",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.17",
+  "version": "3.10.0-rc.18",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
   "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1113 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.17",
+  "version": "3.10.0-rc.18",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.17",
+      "version": "3.10.0-rc.18",
       "transport": {
         "type": "stdio"
       },

--- a/src/dql.ts
+++ b/src/dql.ts
@@ -1,3 +1,4 @@
+import { capScanEntries } from "./tools/limits.js";
 import type { FileEntry, Vault } from "./vault.js";
 
 /**
@@ -310,7 +311,12 @@ export async function runDql(
 ): Promise<Array<Record<string, unknown>>> {
   const defaultLimit = opts.defaultLimit ?? DEFAULT_DQL_ROW_LIMIT;
   const folder = query.source.type === "folder" ? query.source.path : undefined;
-  const entries = await vault.listMarkdown(folder);
+  // v3.10.0-rc.18 (audit M4) — bound the whole-vault readNote scan. This tool is
+  // always-registered and bearer-reachable on serve-http, so an unbounded scan is
+  // a DoS amplifier. DQL is a LINEAR query (LIMIT/SORT applied AFTER the scan), so
+  // this is a defense-in-depth cap: on a vault larger than MAX_SCAN_NOTES the
+  // result is partial (logged once), never a hang. Real vaults are far under it.
+  const entries = capScanEntries(await vault.listMarkdown(folder), "obsidian_dataview_query");
   const wantTag = query.source.type === "tag" ? query.source.tag.toLowerCase() : null;
 
   const rows: Row[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.17";
+export const VERSION = "3.10.0-rc.18";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/tests/resource-bound-invariant.test.ts
+++ b/tests/resource-bound-invariant.test.ts
@@ -32,7 +32,10 @@ import { capScanEntries, MAX_SCAN_NOTES } from "../src/tools/limits.js";
 const repoRoot = path.resolve(__dirname, "..");
 
 // The source files whose exported tool handlers can scan the whole vault.
-const SCANNER_SOURCES = ["src/tools/read.ts", "src/tools/search.ts", "src/tools/meta.ts"];
+// v3.10.0-rc.18 (audit M4) — added src/dql.ts: `runDql` (behind obsidian_dataview_query)
+// does a whole-vault readNote scan but lived OUTSIDE this list, so the completeness
+// invariant never saw it (scope-too-narrow). Closing the gap.
+const SCANNER_SOURCES = ["src/tools/read.ts", "src/tools/search.ts", "src/tools/meta.ts", "src/dql.ts"];
 
 // CAP — always-on tools that build a vault-sized graph/pairwise structure. Each
 // MUST reference its bounding constant in its own body. (communities.ts's
@@ -47,6 +50,14 @@ const CAPPED: Record<string, { capToken: string; why: string }> = {
   getNoteNeighbors: {
     capToken: "capScanEntries",
     why: "two whole-vault readNote passes building an inbound-count map; rc.36 F-5."
+  },
+  runDql: {
+    capToken: "capScanEntries",
+    why: "obsidian_dataview_query whole-vault readNote+parse scan, bearer-reachable; defense-in-depth cap (linear query, partial on >MAX_SCAN_NOTES, logged); rc.18 M4."
+  },
+  getOpenQuestions: {
+    capToken: "capScanEntries",
+    why: "exhaustive question scan; rc.16 (M5) added capScanEntries to bound the collect-all-then-sort. Was EXEMPT; reclassified CAPPED here (manifest lagged the rc.16 cap)."
   }
 };
 
@@ -64,7 +75,6 @@ const EXEMPT: Record<string, string> = {
   frontmatterSearch: "must scan all frontmatter to find matches; capping drops results.",
   getVaultStats: "whole-vault aggregation by definition; capping yields wrong stats.",
   lintWiki: "exhaustive vault lint; must visit every note (output already supports a limit param).",
-  getOpenQuestions: "exhaustive question-pattern scan; ReDoS-guarded + pattern-length-capped separately (rc.21/25).",
   paperAudit: "exhaustive audit over the whole vault.",
   buildTfidfIndex:
     "search-index infrastructure — builds the vault-wide TF-IDF index (single pass, WeakMap-cached per vault); capping would silently drop notes from search ranking. O(N) build is inherent to a correct index, like searchText."


### PR DESCRIPTION
## Summary

Audit MEDIUM-batch 3 (M4 DoS-cap completeness). Caps the last bearer-reachable whole-vault scanner that escaped the rc.36 resource-bound invariant, and closes the scope gap that let it hide.

- **M4** — `obsidian_dataview_query` (`runDql`, `src/dql.ts`) does a whole-vault `listMarkdown`→`readNote`+parse scan, is always-registered + bearer-reachable on `serve-http`, but was **uncapped** — and **invisible** to the rc.36 `resource-bound-invariant` because its `SCANNER_SOURCES` covered `read.ts`/`search.ts`/`meta.ts` but **not** `dql.ts` (the recurring scope-too-narrow class).
  - Fix: cap `runDql`'s scan with `capScanEntries` (defense-in-depth — DQL is O(N) linear, so a `>MAX_SCAN_NOTES` vault yields a **partial, LOGGED** result, never a hang) **and** add `src/dql.ts` to `SCANNER_SOURCES` so the "every whole-vault scanner is CAP-or-EXEMPT" invariant now patrols it.
- **Manifest-drift backfill (my own rc.16)** — `getOpenQuestions` started calling `capScanEntries` in rc.16 but the resource-bound manifest still listed it `EXEMPT`; reclassified `CAPPED` (post-rc.16 recursion-sweep catch).

## Why a cap (not the audit's framing)

The audit's "like the uncapped graph tools" framing is imprecise — graph tools are O(N²) and *must* cap; DQL is linear. But a cap is still the right **defense-in-depth** for an always-on, bearer-reachable, whole-vault tool. Partial+logged > unbounded.

## Test plan

- `1113` source `it()` tests unchanged (the existing `dql.test` already exercises the `>MAX_SCAN_NOTES` cap path; the structural invariant now covers `runDql` + `getOpenQuestions`).
- All 9 required gates green locally incl. `npm audit` (0 vulns), `version-consistency` (7 surfaces), `docs:api`, `scope`, `oia`, per-file (12 floors), smoke.

M3 signal-shutdown → rc.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)