### PR TITLE
v3.10.0-rc.19: audit MED-batch 4 — M3 signal-shutdown orchestrator (http + stdio)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1113+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1119+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.19] — 2026-06-06
+
+> **TL;DR:** **Audit MED-batch 4 — M3 signal-shutdown race (both transports).** On `SIGINT`/`SIGTERM`, `serve-http` registered **four separate** listeners on the same signal — a cache-`flush` handler, `closeWatcher`, `closeFts`, and `shutdownHttpServer` — and the flush handler called `process.exit(0)` the **moment its fast cache flush resolved**, racing ahead of `shutdownHttpServer`'s up-to-5s in-flight-session drain and **cutting off in-flight requests**. The other three were pure duplication: `shutdownHttpServer` already flushes the cache and closes fts/watcher/embed-db. Fix: ONE `makeHttpShutdownHandler` orchestrator that **awaits** the full graceful teardown, then exits (re-entrancy-guarded). The stdio path (`startServer`) had the same shape (three handlers, the flush one calling `process.exit(0)` on its own — racing the async `watcher.close()`); consolidated into one `shutdownStdioDeps(deps)` that awaits watcher → embed-db → cache → fts before exit. `shutdownStdioDeps` was extracted to `src/shutdown.ts` so it's unit-testable (server.ts is in `no-internal-imports`' RESTRICTED_MODULES — same reason embed-pipeline.ts was split in rc.4). **1113 → 1119 tests.** M7 (privacy/erasure) → rc.20.
+
+**Pre-release (v3.10 line) — audit fix batch 4 (M3).**
+
+### Fixed
+
+- **M3 (HTTP) — the cache-flush SIGINT/SIGTERM handler raced the session drain.** `startHttpServer` registered FOUR listeners on each of `SIGINT`/`SIGTERM`: a persistent-cache `flush` (calling `process.exit(0)` in its `.finally`), `closeWatcher`, `closeFts`, and `shutdown` (= `shutdownHttpServer`). Because the flush's `saveDiskCache` is fast and the registry drain (`closeAll`, up to 5s) is slow, `process.exit(0)` fired **before** in-flight stateful requests finished — exactly the leak `shutdownHttpServer` (v3.8.7 P2-11) was built to prevent. New `makeHttpShutdownHandler(server, exit?)` returns a single, re-entrancy-guarded handler that `await`s `shutdownHttpServer` (drain → close TCP listener → flush cache → close fts/watcher/embed-db) and only THEN exits. The three redundant handlers are removed (their work is wholly subsumed by `shutdownHttpServer`); `beforeExit` keeps a guarded best-effort teardown for the natural-drain path.
+- **M3 (stdio) — same shape.** `startServer` had three separate signal handlers and the cache-flush one called `process.exit(0)` on its own completion, racing the (async) `watcher.close()`. Consolidated into one orchestrator awaiting `shutdownStdioDeps(deps)` — which closes watcher + embed-db, flushes the persistent cache, then closes fts5, **awaiting each async step** (best-effort: a throw in one step never blocks the rest). The ordering is now deterministic and nothing exits mid-teardown.
+
+### Refactor
+
+- **`shutdownStdioDeps` extracted to `src/shutdown.ts`.** `src/server.ts` is in the `no-internal-imports` RESTRICTED_MODULES list ("registration boilerplate"), so a helper there can't be imported by a test — the SAME constraint that drove the rc.4 embed-pipeline extraction. The new module declares a minimal structural `StdioShutdownDeps` interface locally (no import of `ServerDeps`) so there's zero import cycle with the server module; `ServerDeps` structurally satisfies it, so `startServer` passes `deps` directly.
+
+### Tests (1119)
+
+`tests/http-transport.test.ts` +2: `makeHttpShutdownHandler` awaits full teardown before exit (asserts exit is NOT synchronous, the TCP listener is closed BEFORE exit fires, and a second signal is a re-entrancy no-op) + NEGATIVE control (a handler that skips the await "exits" while the listener is still up — proving the positive assertion depends on the await). `tests/shutdown.test.ts` (new) +4: ordering watcher→embed-db→cache→fts with awaited async steps; cache flush skipped when persistent cache disabled; best-effort (a throwing step doesn't block the rest); NEGATIVE control (a non-awaiting teardown records the sync "exit" step before the async one finishes). 1113 → 1119.
+
+### Files changed
+
+- `src/http-transport.ts` (new `makeHttpShutdownHandler`; four signal handlers → one orchestrator + guarded `beforeExit`), `src/server.ts` (import `shutdownStdioDeps`; three handlers → one orchestrator; drop now-unused `vault`/`ftsIndex`/`watcher` destructuring), `src/shutdown.ts` (new — `StdioShutdownDeps` + `shutdownStdioDeps`), `tests/http-transport.test.ts` (+2), `tests/shutdown.test.ts` (new, +4), test-count claims → 1119.
+- version bump 3.10.0-rc.18 → 3.10.0-rc.19.
+
+---
+
 ## [3.10.0-rc.18] — 2026-06-06
 
 > **TL;DR:** **Audit MED-batch 3 — M4 DoS-cap completeness (`obsidian_dataview_query` + invariant scope).** The audit flagged `obsidian_dataview_query` (`runDql`) as an uncapped whole-vault `readNote`+parse scan reachable over bearer `serve-http`. Root cause: the rc.36 `resource-bound-invariant`'s `SCANNER_SOURCES` covered `read.ts`/`search.ts`/`meta.ts` but NOT `dql.ts`, so `runDql` was never required to be CAP-or-EXEMPT (scope-too-narrow — the recurring class). Fix: cap `runDql` with `capScanEntries` (defense-in-depth — DQL is a *linear* query so a > MAX_SCAN_NOTES vault yields a partial, logged result, never a hang) + add `src/dql.ts` to `SCANNER_SOURCES` so the invariant patrols it. Also fixed a manifest drift my OWN rc.16 introduced: `getOpenQuestions` began calling `capScanEntries` in rc.16 but the manifest still listed it EXEMPT — reclassified CAPPED. **1113 tests unchanged.** M3 (signal-shutdown) → rc.19.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1113%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1119%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1113 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1119 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1113 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1119 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1113 tests, ~12s)
+npm test       # full suite (1119 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1113 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1119 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1113**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1119**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1113 unit tests passing on every PR
+- 1119 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.18",
+  "version": "3.10.0-rc.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.18",
+      "version": "3.10.0-rc.19",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.18",
+  "version": "3.10.0-rc.19",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1113 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1119 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.18",
+  "version": "3.10.0-rc.19",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.18",
+      "version": "3.10.0-rc.19",
       "transport": {
         "type": "stdio"
       },

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -927,6 +927,43 @@ export async function shutdownHttpServer(server: HttpServer): Promise<void> {
 }
 
 /**
+ * v3.10.0-rc.19 (audit M3) — single SIGINT/SIGTERM orchestrator for the HTTP
+ * transport. Returns a handler that awaits the FULL graceful teardown
+ * ({@link shutdownHttpServer}: drain in-flight stateful sessions up to
+ * `closeAll`'s bound → close the TCP listener → flush the persistent cache →
+ * close fts/watcher/embed-db) and only THEN calls `exit`.
+ *
+ * Before rc.19, SIGINT/SIGTERM had FOUR separate listeners registered on the
+ * same signal: a cache-`flush` handler, a `closeWatcher` handler, a `closeFts`
+ * handler, AND the `shutdownHttpServer` handler. The flush handler called
+ * `process.exit(0)` the moment its (fast) `saveDiskCache` resolved — racing
+ * ahead of `shutdownHttpServer`'s up-to-5s session drain and cutting off
+ * in-flight requests. The other three handlers were also pure redundancy:
+ * `shutdownHttpServer` already flushes the cache and closes fts/watcher/embed-db
+ * itself. Consolidating to ONE handler that awaits the whole chain removes the
+ * race and the duplication.
+ *
+ * `exit` is injectable for tests (default `process.exit`). The returned handler
+ * guards re-entry so a SIGINT-then-SIGTERM (or a double signal) can't kick off
+ * two concurrent teardowns or two `exit` calls.
+ */
+export function makeHttpShutdownHandler(
+  server: HttpServer,
+  exit: (code: number) => void = (code) => process.exit(code)
+): () => void {
+  let running = false;
+  return () => {
+    if (running) return;
+    running = true;
+    void shutdownHttpServer(server)
+      .catch(() => {
+        /* best-effort — never block exit on a teardown error */
+      })
+      .finally(() => exit(0));
+  };
+}
+
+/**
  * Bind and start the HTTP transport. Returns the underlying http.Server
  * so callers (tests + CLI) can listen for `listening` / close it.
  */
@@ -947,65 +984,30 @@ export async function startHttpServer(opts: HttpServeOptions): Promise<HttpServe
   });
   httpServerExtras.set(httpServer, { registry: handlerOut.registry, deps });
 
-  // Persistent-cache flush + watcher cleanup on signal. Same hooks as
-  // stdio mode — the deps own the lifecycle. Skipped under
-  // installSignalHandlers=false so tests can spawn many servers in one
-  // process without accumulating SIGINT/SIGTERM listeners.
+  // v3.10.0-rc.19 (audit M3) — ONE graceful-shutdown orchestrator on signal.
+  // `shutdownHttpServer` already drains in-flight stateful sessions, closes the
+  // TCP listener, flushes the persistent cache, and closes fts/watcher/embed-db,
+  // so a single handler that AWAITS it (then exits) replaces the four separate
+  // pre-rc.19 listeners (flush / closeWatcher / closeFts / shutdown). The old
+  // flush listener called `process.exit(0)` the moment its fast cache flush
+  // resolved — racing ahead of the up-to-5s session drain and cutting off
+  // in-flight requests; the other three were pure duplication of work
+  // shutdownHttpServer already does. Skipped under installSignalHandlers=false
+  // so tests can spawn many servers in one process without accumulating
+  // SIGINT/SIGTERM listeners.
   if (opts.installSignalHandlers !== false) {
-    if (deps.vault.persistentCacheEnabled) {
-      let saving = false;
-      let saved = false;
-      const flush = async () => {
-        if (saving || saved) return;
-        saving = true;
-        try {
-          await deps.vault.saveDiskCache();
-          saved = true;
-        } catch (err) {
-          process.stderr.write(`enquire: cache flush failed — ${err instanceof Error ? err.message : String(err)}\n`);
-        } finally {
-          saving = false;
-        }
-      };
-      process.once("SIGINT", () => {
-        flush().finally(() => process.exit(0));
-      });
-      process.once("SIGTERM", () => {
-        flush().finally(() => process.exit(0));
-      });
-      process.on("beforeExit", () => {
-        if (!saved && !saving) void flush();
-      });
-    }
-    if (deps.watcher) {
-      const closeWatcher = () => {
-        void deps.watcher?.close();
-        // v3.8.0-rc.2 R-7 — close watcher-owned embed-db handle (HTTP path).
-        deps.watcherEmbedDb?.close();
-      };
-      process.once("SIGINT", closeWatcher);
-      process.once("SIGTERM", closeWatcher);
-      process.on("beforeExit", closeWatcher);
-    }
-    if (deps.ftsIndex) {
-      const closeFts = () => deps.ftsIndex?.close();
-      process.once("SIGINT", closeFts);
-      process.once("SIGTERM", closeFts);
-      process.on("beforeExit", closeFts);
-    }
-    // Graceful HTTP-server shutdown on signal.
-    // v3.8.7 P2-11 — drain registered stateful sessions BEFORE closing
-    // the TCP listener so in-flight requests get a chance to finish and
-    // we don't leak per-session McpServer + transport pairs. The
-    // pre-existing flush/watcher/fts handlers above still fire (they're
-    // registered separately on the same signal) — `shutdownHttpServer`
-    // calls them again as a defense-in-depth no-op (idempotent thanks
-    // to the WeakMap-delete-on-shutdown pattern).
-    const shutdown = () => {
+    const onSignal = makeHttpShutdownHandler(httpServer);
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+    // beforeExit (natural drain, no signal): best-effort teardown, never exit.
+    // Idempotent via shutdownHttpServer's WeakMap-delete; guarded so the async
+    // teardown it schedules can't make beforeExit re-fire in a loop.
+    let beforeExitRan = false;
+    process.on("beforeExit", () => {
+      if (beforeExitRan) return;
+      beforeExitRan = true;
       void shutdownHttpServer(httpServer).catch(() => {});
-    };
-    process.once("SIGINT", shutdown);
-    process.once("SIGTERM", shutdown);
+    });
   }
 
   await new Promise<void>((resolve, reject) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.18";
+export const VERSION = "3.10.0-rc.19";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { type loadEmbedder, resolveModel } from "./embeddings.js";
 import { defaultIndexFile, FtsIndex, peekFtsMetaSafe } from "./fts5.js";
 import { VERSION } from "./index.js";
 import { registerPrompts } from "./prompts.js";
+import { shutdownStdioDeps } from "./shutdown.js";
 import { DEFAULT_STALE_DAYS } from "./staleness.js";
 import {
   embedDbPath,
@@ -694,60 +695,36 @@ export function buildMcpServer(deps: ServerDeps, opts: ServeOptions): McpServer 
 
 export async function startServer(opts: ServeOptions): Promise<void> {
   const deps = await prepareServerDeps(opts);
-  const { vault, ftsIndex, watcher } = deps;
   const server = buildMcpServer(deps, opts);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  if (vault.persistentCacheEnabled) {
-    let saving = false;
-    let saved = false;
-    const flush = async () => {
-      if (saving || saved) return;
-      saving = true;
-      try {
-        await vault.saveDiskCache();
-        saved = true;
-      } catch (err) {
-        process.stderr.write(`enquire: cache flush failed — ${err instanceof Error ? err.message : String(err)}\n`);
-      } finally {
-        saving = false;
-      }
-    };
-    const onSignal = () => {
-      flush().finally(() => process.exit(0));
-    };
-    process.once("SIGINT", onSignal);
-    process.once("SIGTERM", onSignal);
-    // beforeExit fires when the loop empties; we schedule one async flush.
-    // The `saved` guard prevents recursion when flush completes and beforeExit fires again.
-    process.on("beforeExit", () => {
-      if (!saved && !saving) void flush();
-    });
-  }
-
-  if (watcher) {
-    const closeWatcher = () => {
-      void watcher?.close();
-      // v3.8.0-rc.2 R-7 — close the watcher-owned embed-db handle too.
-      // Safe to call multiple times (idempotent close); WAL checkpoint
-      // happens at close time so no data loss on graceful shutdown.
-      deps.watcherEmbedDb?.close();
-    };
-    process.once("SIGINT", closeWatcher);
-    process.once("SIGTERM", closeWatcher);
-    process.on("beforeExit", closeWatcher);
-  }
-
   process.stderr.write(`${formatReadyBanner(deps)} (transport=stdio)\n`);
 
-  if (ftsIndex) {
-    const closeFts = () => ftsIndex?.close();
-    process.once("SIGINT", closeFts);
-    process.once("SIGTERM", closeFts);
-    process.on("beforeExit", closeFts);
-  }
+  // v3.10.0-rc.19 (audit M3) — ONE graceful-shutdown orchestrator on signal,
+  // mirroring the HTTP path. `shutdownStdioDeps` closes watcher + embed-db,
+  // flushes the persistent cache, then closes the fts5 index, AWAITING each
+  // async step before `process.exit(0)`. Pre-rc.19 these were three separate
+  // SIGINT/SIGTERM handlers and the cache-flush handler called `process.exit(0)`
+  // the moment its flush resolved — racing the (async) `watcher.close()`. stdio
+  // has no installSignalHandlers escape hatch (it always owns its process).
+  let shuttingDown = false;
+  const onSignal = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    void shutdownStdioDeps(deps).finally(() => process.exit(0));
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  // beforeExit (natural loop drain, no signal): best-effort teardown, never
+  // exit. Guarded so the async work it schedules can't re-trigger beforeExit.
+  let beforeExitRan = false;
+  process.on("beforeExit", () => {
+    if (beforeExitRan || shuttingDown) return;
+    beforeExitRan = true;
+    void shutdownStdioDeps(deps);
+  });
 }
 
 /**

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,0 +1,70 @@
+// v3.10.0-rc.19 (audit M3) — graceful-shutdown teardown helper for the stdio
+// transport, extracted so it is unit-testable.
+//
+// src/server.ts is in the no-internal-imports RESTRICTED_MODULES list (the
+// "registration boilerplate" rule in tests/no-internal-imports.test.ts), so a
+// helper living there can't be imported by a test — the SAME reason
+// embed-pipeline.ts was split out of server.ts in v3.8.0-rc.4. The stdio
+// signal-teardown ORDERING is the audit-M3 fix (one orchestrator that awaits
+// every async close before exit, instead of three separate SIGINT/SIGTERM
+// handlers where the cache-flush one called process.exit(0) on its own and raced
+// the others). Hosting it here lets tests/shutdown.test.ts exercise the ordering
+// + best-effort semantics directly, with no import cycle: the deps are described
+// by a minimal structural interface declared here, NOT imported from server.ts.
+
+/**
+ * Minimal structural view of the {@link import("./server.js").ServerDeps}
+ * handles that {@link shutdownStdioDeps} touches. Declared locally (rather than
+ * importing `ServerDeps`) so this module stays dependency-free and free of any
+ * import cycle with the restricted server-registration module. `ServerDeps`
+ * structurally satisfies this shape, so `startServer` passes its `deps` directly.
+ */
+export interface StdioShutdownDeps {
+  vault: { persistentCacheEnabled: boolean; saveDiskCache(): Promise<void> };
+  ftsIndex?: { close(): void } | null;
+  watcher?: { close(): Promise<void> } | null;
+  watcherEmbedDb?: { close(): void } | null;
+}
+
+/**
+ * v3.10.0-rc.19 (audit M3) — single graceful-shutdown teardown for the stdio
+ * transport, mirroring {@link import("./http-transport.js").shutdownHttpServer}'s
+ * ordering. Closes the watcher (async chokidar) + its embed-db handle, flushes
+ * the persistent disk cache, then closes the fts5 index — **awaiting each async
+ * step** so a fast cache flush can't race ahead and let `process.exit` kill the
+ * others mid-flight.
+ *
+ * Pre-rc.19, stdio mode registered three separate SIGINT/SIGTERM handlers
+ * (flush / watcher / fts) and the flush handler called `process.exit(0)` the
+ * moment its `saveDiskCache` resolved — racing the (async) `watcher.close()`.
+ *
+ * Best-effort: a throw/rejection in any one step is swallowed so the remaining
+ * steps still run (a watcher that fails to close must not block the cache flush
+ * or the fts checkpoint). Cache-flush failures are surfaced on stderr because
+ * losing the persistent cache silently would degrade the next cold start.
+ */
+export async function shutdownStdioDeps(deps: StdioShutdownDeps): Promise<void> {
+  try {
+    await deps.watcher?.close();
+  } catch {
+    /* best-effort */
+  }
+  try {
+    // v3.8.0-rc.2 R-7 — WAL checkpoint happens at close, so no data loss.
+    deps.watcherEmbedDb?.close();
+  } catch {
+    /* best-effort */
+  }
+  if (deps.vault.persistentCacheEnabled) {
+    try {
+      await deps.vault.saveDiskCache();
+    } catch (err) {
+      process.stderr.write(`enquire: cache flush failed — ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+  try {
+    deps.ftsIndex?.close();
+  } catch {
+    /* best-effort */
+  }
+}

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -16,13 +16,14 @@ import { promises as fs } from "node:fs";
 import type { AddressInfo } from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSessionRegistry,
   deriveHttpBodyCap,
   generateBearerToken,
   type HttpServeOptions,
   isInitializeRequest,
+  makeHttpShutdownHandler,
   parseMaxFileBytes,
   RateLimiter,
   readJsonBody,
@@ -1145,6 +1146,60 @@ describe("startHttpServer stateful sessions (v2.14.0)", () => {
     await shutdownHttpServer(httpServer);
     // Second call should not throw.
     await expect(shutdownHttpServer(httpServer)).resolves.toBeUndefined();
+  });
+
+  // v3.10.0-rc.19 (audit M3) — the SIGINT/SIGTERM orchestrator must AWAIT the
+  // full graceful teardown (shutdownHttpServer: drain → close TCP listener →
+  // flush cache → close fts/watcher/embed-db) and only THEN exit. Pre-rc.19 a
+  // SEPARATE cache-flush handler called process.exit(0) the moment its fast
+  // flush resolved — racing ahead of the session drain.
+  it("makeHttpShutdownHandler awaits full teardown before exit (rc.19 M3)", async () => {
+    const httpServer = await startHttpServer({
+      vault: root,
+      port: 0,
+      host: "127.0.0.1",
+      bearerToken: TOKEN,
+      mcpPath: "/mcp",
+      stateful: true,
+      installSignalHandlers: false
+    });
+    expect((httpServer.address() as AddressInfo).port).toBeGreaterThan(0);
+    let exitCode: number | undefined;
+    const handler = makeHttpShutdownHandler(httpServer, (c) => {
+      exitCode = c;
+    });
+    handler();
+    // The await sits in front of exit → it must NOT have fired synchronously.
+    expect(exitCode).toBeUndefined();
+    // Re-entrancy guard: a second signal must not schedule a second teardown/exit.
+    handler();
+    // Teardown settles → exit(0), and the TCP listener was closed BEFORE exit.
+    await vi.waitFor(() => expect(exitCode).toBe(0));
+    expect(httpServer.address()).toBeNull();
+  });
+
+  // NEGATIVE control — a handler that does NOT await shutdownHttpServer (the
+  // pre-rc.19 flush-then-exit shape) "exits" while the TCP listener is still up.
+  // This proves the positive test's "address()===null at exit" genuinely depends
+  // on the await, not on teardown happening to be instant.
+  it("NEGATIVE control — skipping the await exits while the TCP listener is still up (rc.19 M3)", async () => {
+    const httpServer = await startHttpServer({
+      vault: root,
+      port: 0,
+      host: "127.0.0.1",
+      bearerToken: TOKEN,
+      mcpPath: "/mcp",
+      stateful: true,
+      installSignalHandlers: false
+    });
+    expect(httpServer.address()).not.toBeNull();
+    // Mirror the bug: kick off teardown but read state ("exit") immediately,
+    // without awaiting it.
+    void shutdownHttpServer(httpServer);
+    const addrAtExit = httpServer.address();
+    expect(addrAtExit).not.toBeNull(); // ← listener STILL up: the race rc.19 removes
+    // Let the real teardown finish so the test leaves nothing bound.
+    await vi.waitFor(() => expect(httpServer.address()).toBeNull());
   });
 
   // v3.8.7 P2-10 — fire many concurrent initialize POSTs at a low-cap

--- a/tests/shutdown.test.ts
+++ b/tests/shutdown.test.ts
@@ -1,0 +1,103 @@
+// v3.10.0-rc.19 (audit M3) — stdio graceful-shutdown orchestration tests.
+//
+// The fix consolidates three separate SIGINT/SIGTERM handlers (flush / watcher /
+// fts) — where the cache-flush handler called process.exit(0) the moment its
+// fast flush resolved, racing the async watcher close — into ONE orchestrator
+// (shutdownStdioDeps) that AWAITS every async close before the caller exits.
+// shutdownStdioDeps was extracted to src/shutdown.ts precisely so it's
+// importable here (src/server.ts is in no-internal-imports' RESTRICTED_MODULES).
+
+import { describe, expect, it } from "vitest";
+import { shutdownStdioDeps } from "../src/shutdown.js";
+
+/** Force a macrotask boundary so a fire-and-forget (non-awaited) async step
+ *  visibly completes AFTER any synchronous follow-on work. */
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe("shutdownStdioDeps (rc.19 M3)", () => {
+  it("awaits every async close, in order: watcher → embed-db → cache → fts", async () => {
+    const order: string[] = [];
+    await shutdownStdioDeps({
+      // Both async steps yield a macrotask before recording — so if the
+      // orchestrator did NOT await them, the later SYNC steps (embeddb, fts)
+      // would record first and the order assertion would fail.
+      watcher: {
+        close: async () => {
+          await tick();
+          order.push("watcher");
+        }
+      },
+      watcherEmbedDb: { close: () => order.push("embeddb") },
+      vault: {
+        persistentCacheEnabled: true,
+        saveDiskCache: async () => {
+          await tick();
+          order.push("savecache");
+        }
+      },
+      ftsIndex: { close: () => order.push("fts") }
+    });
+    expect(order).toEqual(["watcher", "embeddb", "savecache", "fts"]);
+  });
+
+  it("skips the cache flush when the persistent cache is disabled", async () => {
+    let flushed = false;
+    await shutdownStdioDeps({
+      vault: {
+        persistentCacheEnabled: false,
+        saveDiskCache: async () => {
+          flushed = true;
+        }
+      }
+    });
+    expect(flushed).toBe(false);
+  });
+
+  it("is best-effort — a throwing step never blocks the remaining steps", async () => {
+    const order: string[] = [];
+    await expect(
+      shutdownStdioDeps({
+        watcher: {
+          close: async () => {
+            throw new Error("watcher boom");
+          }
+        },
+        watcherEmbedDb: {
+          close: () => {
+            throw new Error("embed-db boom");
+          }
+        },
+        vault: {
+          persistentCacheEnabled: true,
+          saveDiskCache: async () => {
+            order.push("savecache");
+          }
+        },
+        ftsIndex: { close: () => order.push("fts") }
+      })
+    ).resolves.toBeUndefined();
+    // The cache flush + fts close STILL ran despite the two earlier throws.
+    expect(order).toEqual(["savecache", "fts"]);
+  });
+
+  // NEGATIVE control — proves the ordering assertion in the first test genuinely
+  // depends on AWAITING the async steps. A non-awaiting teardown (the pre-rc.19
+  // shape) lets a synchronous "exit"/follow-on step run BEFORE the async close
+  // finishes, producing the racy order the rc.19 await prevents.
+  it("NEGATIVE control — a non-awaiting teardown records sync steps before async ones finish", async () => {
+    const order: string[] = [];
+    const watcherClose = async () => {
+      await tick();
+      order.push("watcher");
+    };
+    // Buggy/pre-rc.19 shape: fire-and-forget the async close, then "exit".
+    void watcherClose();
+    order.push("exit");
+    // At "exit" time the async watcher close has NOT completed yet.
+    expect(order).toEqual(["exit"]);
+    // It only lands on a later macrotask — exactly the race shutdownStdioDeps removes.
+    await tick();
+    await tick();
+    expect(order).toEqual(["exit", "watcher"]);
+  });
+});


### PR DESCRIPTION
## Summary

Audit MEDIUM-batch 4 (M3 signal-shutdown race). On `SIGINT`/`SIGTERM`, both transports raced their own teardown.

- **M3 (HTTP)** — `startHttpServer` registered **four** listeners per signal: a cache-`flush` (calling `process.exit(0)` in its `.finally`), `closeWatcher`, `closeFts`, and `shutdown` (= `shutdownHttpServer`). Since the flush's `saveDiskCache` is fast and the registry drain (`closeAll`, up to 5s) is slow, `process.exit(0)` fired **before in-flight stateful requests finished** — the exact leak `shutdownHttpServer` (v3.8.7 P2-11) prevents. The other three handlers duplicated work `shutdownHttpServer` already does. Fix: one re-entrancy-guarded `makeHttpShutdownHandler` that **awaits** the full teardown (drain → close listener → flush cache → close fts/watcher/embed-db) then exits.
- **M3 (stdio)** — same shape (three handlers; flush calling `process.exit(0)` on its own, racing the async `watcher.close()`). Consolidated into one orchestrator awaiting `shutdownStdioDeps(deps)`: watcher → embed-db → cache → fts, **awaiting each step** (best-effort).

## Refactor

`shutdownStdioDeps` extracted to **`src/shutdown.ts`** so it's unit-testable — `src/server.ts` is in `no-internal-imports`' RESTRICTED_MODULES (the same constraint that drove the rc.4 embed-pipeline split). The module declares a minimal structural `StdioShutdownDeps` locally (no `ServerDeps` import) → zero import cycle; `ServerDeps` structurally satisfies it.

## Test plan

- **1113 → 1119** source `it()`.
  - `tests/http-transport.test.ts` +2: awaits-full-teardown-before-exit (exit not synchronous; listener closed before exit; second signal is a re-entrancy no-op) + NEGATIVE control (skip-the-await "exits" while listener still up).
  - `tests/shutdown.test.ts` (new) +4: ordering watcher→embed-db→cache→fts (awaited); skip cache flush when disabled; best-effort (throwing step doesn't block the rest); NEGATIVE control (non-awaiting teardown records the sync step before the async one finishes).
- All 9 required gates green locally: lint, version-consistency (7, rc.19), docs:api, **test:coverage** (1184 pass / 0 fail; Lines 90.21%, Branches 77%), per-file (12 floors), oia, **smoke** (both variants on the CI synthetic vault), changelog-coverage, **npm audit** (0 vulns).

M7 (privacy/erasure) → rc.20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)