### PR TITLE
v3.10.0-rc.23: HIGH — serve-http shutdown-hang regression (rc.19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Notes for AI coding agents (Cursor, Claude Code, Codex, Aider, Devin, etc.) work
 ## TL;DR
 
 - Production code: `src/*.ts` (TypeScript strict + `noUncheckedIndexedAccess`)
-- Tests: `tests/*.test.ts` (Vitest, 1130+ tests)
+- Tests: `tests/*.test.ts` (Vitest, 1132+ tests)
 - Build: `npm run build` (tsc → `dist/`)
 - Test: `npm test` (full suite ~12s)
 - Lint: `npm run lint` (biome — must exit 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.23] — 2026-06-06
+
+> **TL;DR:** **HIGH — `serve-http` hung forever on SIGINT/SIGTERM (a regression of rc.19's own M3 fix).** A post-MED-batch re-sweep (3-agent audit on the rc.22 commit) caught it: rc.19 correctly made shutdown **await** the full teardown before `process.exit(0)` — but `shutdownHttpServer` awaits `server.close()`, and Node's `http.Server.close()` callback fires only once EVERY connection has ended and **does not terminate idle keep-alive sockets**. So any lingering connection (a reverse proxy's keep-alive, a half-open socket, an LB health probe, an SSE stream) made graceful shutdown block **indefinitely**. Pre-rc.19 this latent `close()` hang was masked because the cache-flush handler called `process.exit(0)` on its own; rc.19 removed that hatch and added no bound → "await the drain" became "await forever." **Reproduced** (lingering socket + SIGTERM → process alive >8s, would hang forever; pre-rc.19 exited in 8ms). Fix: a bounded `closeServerBounded()` — close idle keep-alives immediately, then force-close stragglers via `server.closeAllConnections()` after a 3s grace — so shutdown resolves on `close()` completion OR the grace, never never. **Verified: post-fix the same repro exits in ~3.0s, code 0.** This is the textbook recursion-pair (a fix for one shutdown bug shipping another); documented as such. **1130 → 1132 tests.**
+
+**Pre-release (v3.10 line) — post-MED-batch audit; HIGH regression fix.**
+
+### Fixed
+
+- **HIGH — `serve-http` graceful shutdown could hang forever on a lingering connection (regression introduced by rc.19).** `shutdownHttpServer` did `await new Promise(resolve => server.close(() => resolve()))`. `http.Server.close()` waits for ALL open connections to end and never force-closes idle keep-alives, so a single held-open socket blocked the await — and rc.19's `makeHttpShutdownHandler` gates `process.exit(0)` behind that await, so the process never exited. Under an orchestrator (systemd/docker) this escalates to a SIGKILL after the stop-timeout, defeating the very graceful-drain guarantee rc.19 was built to provide. New `closeServerBounded(server, graceMs = HTTP_CLOSE_GRACE_MS=3000)`: registers `server.close()`, immediately calls `server.closeIdleConnections()` (so the common no-in-flight case resolves at once), and arms an unref'd `setTimeout` that force-closes stragglers with `server.closeAllConnections()` after the grace — resolving whichever happens first. Both `shutdownHttpServer` close sites (the `!extras` fast path + the main path, after `registry.closeAll()` drains in-flight MCP requests) route through it. Reproduced + fix-verified empirically (lingering-socket SIGTERM: hang → 3.0s bounded exit).
+
+### Tests (1132)
+
+`tests/http-transport.test.ts` +2: `closeServerBounded` resolves within the grace despite a lingering keep-alive socket (the rc.19 hang — pre-fix this never returns) + CONTROL (with nothing lingering it resolves promptly, well under a large grace — proving it resolves on `close()` completion, NOT by always waiting the grace; a naive `setTimeout(resolve, grace)` impl fails this). 1130 → 1132.
+
+### Files changed
+
+- `src/http-transport.ts` (new `HTTP_CLOSE_GRACE_MS` + exported `closeServerBounded`; both `shutdownHttpServer` close sites bounded), `tests/http-transport.test.ts` (+2 + `node:http`/`node:net` imports), test-count claims → 1132.
+- version bump 3.10.0-rc.22 → 3.10.0-rc.23.
+
+### Method note
+
+The fix was found by re-running a focused audit on the just-shipped commit (the CLAUDE.md "post-merge re-sweep after a class-closing release" rule) — a 3-agent pass (adversarial diff re-review · docs/process · behavioral/STRIDE) that I commissioned after the MED batch, with the HIGH **empirically reproduced and fix-verified by me** before shipping (not taken on the agent's word). It is a clean recursion-pair instance: rc.19 fixed a shutdown race (flush `exit` beat the drain) and, in removing the `exit` hatch, exposed a latent `server.close()` hang. The remaining audit findings (1 LOW behavioral — `obsidian_query_base` uncapped scan; 2 LOW correctness — parser `indexOf`, watcher unlink-skip; 5 LOW docs currency) ship as rc.24/rc.25.
+
+---
+
 ## [3.10.0-rc.22] — 2026-06-06
 
 > **TL;DR:** **Audit MED-batch 7 (final) — M8/M9 test & process integrity.** **M8a (vacuous test):** `security.test.ts`'s "embeddingsSearch filters excluded paths" test was THEATER — it said "we can't test without a model" and **reimplemented** the privacy filter inline (`rawHits.filter(h => !vault.isExcluded(...))`), never running the real code, so `embeddingsSearch`'s two inline filter sites (search.ts ~1100/1106) were uncovered and would stay green even if the guard were deleted. Extracted the filter into a pure, exported `filterExcludedEmbedHits` (the `embeddingsSearch` sibling of rc.8's `pruneExcludedHits`), routed both sites through it, and made the test + a new unit test exercise the REAL helper. **M8b (silent-skip):** the E2E CI-GUARD only asserted `distExists()` — T-3/T-4 had **no** guard at all, and none checked that the server actually spawned, so a spawn failure in CI would silently skip whole suites (incl. T-4's 401-no-bearer auth check). Added/strengthened CI-GUARDs across T-2/T-3/T-4 to assert dist built **and** the process spawned in CI. **M9 (config drift, ι-class):** `package.json` `prepublishOnly` used a single `npm audit --audit-level=high` (all deps) while CI + release both use the stricter two-step (`--omit=dev --audit-level=moderate` then `--include=dev --audit-level=high`) — so prepublish would miss a *moderate prod* vuln CI/release catch. Aligned. **1126 → 1130 tests. This closes the comprehensive-audit MEDIUM batch (M1–M10).**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/oomkapwn/enquire-mcp/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@oomkapwn/enquire-mcp.svg?label=npm&color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
 [![downloads](https://img.shields.io/npm/dm/@oomkapwn/enquire-mcp.svg?color=cb3837)](https://www.npmjs.com/package/@oomkapwn/enquire-mcp)
-[![tests](https://img.shields.io/badge/tests-1130%20passing-brightgreen.svg)](#trust)
+[![tests](https://img.shields.io/badge/tests-1132%20passing-brightgreen.svg)](#trust)
 [![stable](https://img.shields.io/badge/v3.9.x-stable-brightgreen.svg)](./STABILITY.md)
 [![build provenance](https://img.shields.io/badge/build_provenance-SLSA_L2-blue.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![MCP](https://img.shields.io/badge/MCP-1.29-8A2BE2.svg)](https://modelcontextprotocol.io/)
@@ -49,7 +49,7 @@ Your Obsidian vault becomes **persistent, queryable long-term memory** for any M
 > 3. **Zero cloud calls during serve.** Models cached locally (one-time download from HuggingFace). Your vault content never leaves your machine. Air-gap-safe by default.
 > 4. **Freshness-aware recall.** Every hit reports how old the note is; opt-in recency re-ranking lets an agent prefer fresh knowledge and flag stale facts for re-verification — the forgetting-aware frontier, built on the `mtime` your files already have.
 
-**45 tools · 19 MCP prompts · 1130 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
+**45 tools · 19 MCP prompts · 1132 unit tests · 50+ languages · v3.9.x stable · semver-bound · MIT · npm build provenance (SLSA L2).**
 
 ---
 
@@ -187,7 +187,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
-| **1130 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
+| **1132 unit tests · 9 required + 4 advisory CI gates per PR** | ✅ | n/a | rare |
 | **Signed build provenance** (npm + Sigstore, SLSA Build L2) | ✅ | n/a | ❌ |
 | **Semver-bound public surface** ([STABILITY.md](./STABILITY.md)) | ✅ | n/a | ❌ |
 | Standalone (no Obsidian plugin needed) | ✅ | ❌ requires Obsidian | varies |
@@ -297,7 +297,7 @@ Channel: `npm install @oomkapwn/enquire-mcp` → latest stable (`@latest` = v3.9
 ```bash
 git clone https://github.com/oomkapwn/enquire-mcp.git
 cd enquire-mcp && npm install
-npm test       # full suite (1130 tests, ~12s)
+npm test       # full suite (1132 tests, ~12s)
 npm run lint   # zero warnings
 npm run build  # tsc → dist/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Already shipped and differentiating:
 - **Standalone Obsidian Bases** `.base` query execution (no Obsidian process needed).
 - **PDFs blended into search** with `[page: N]` citations + Tesseract OCR for scanned docs.
 - **Forgetting-aware freshness** (v3.10) — every search hit carries `age_days` + a `stale` flag from the note's live mtime, the `obsidian_stale_notes` tool surfaces aged notes, and opt-in recency re-ranking (`--recency-weight` / `--stale-days`, default off) lets agents prefer fresher knowledge. Directly addresses the stale-fact-reuse frontier (Memora, arXiv:2604.20006) that conversation-memory stores ignore — the only Obsidian MCP with it.
-- **Process maturity** — 1130 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
+- **Process maturity** — 1132 tests, 9 required CI gates, semver-bound public surface, signed npm build provenance (SLSA Build L2), 12 state-driven OIA drift checks, structural invariant suite.
 
 ## Competitive read (why the roadmap is shaped the way it is)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Zero outbound network calls in serve mode     | **Yes** (default)   | Local-only (REST)| Local-only (REST)| Yes              | Yes              |
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
-| Test count (public)                           | **1130**             | (varies)         | (varies)         | (varies)         | (varies)         |
+| Test count (public)                           | **1132**             | (varies)         | (varies)         | (varies)         | (varies)         |
 | Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ Auto-degrades gracefully: works with any subset of signals available. Returns `p
 
 ## Trust and stability
 
-- 1130 unit tests passing on every PR
+- 1132 unit tests passing on every PR
 - 9 required + 4 advisory CI gates per merge (lint, test ×2 [Node 22/24], smoke, audit, coverage, version-consistency, docs, oia + macOS + CodeQL + Analyze)
 - Signed build provenance on every npm release (npm + Sigstore, SLSA Build L2; isolated-builder L3 on the roadmap)
 - Semver-bound public surface — see [STABILITY.md](https://github.com/oomkapwn/enquire-mcp/blob/main/STABILITY.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.22",
+  "version": "3.10.0-rc.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.22",
+      "version": "3.10.0-rc.23",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.22",
+  "version": "3.10.0-rc.23",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
-  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1130 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
+  "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1132 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",
   "bin": {
     "enquire-mcp": "dist/index.js"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.22",
+  "version": "3.10.0-rc.23",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.22",
+      "version": "3.10.0-rc.23",
       "transport": {
         "type": "stdio"
       },

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -856,6 +856,53 @@ interface HttpServerExtras {
 const httpServerExtras = new WeakMap<HttpServer, HttpServerExtras>();
 
 /**
+ * v3.10.0-rc.23 — bounded grace for `server.close()`. Node's
+ * `http.Server.close()` callback fires only once EVERY connection has ended, and
+ * it does NOT terminate idle keep-alive sockets — so a client / reverse-proxy
+ * (or a half-open socket) holding a connection open makes `close()` hang
+ * indefinitely. We immediately close idle keep-alives, then force-close any
+ * straggler after this grace, so shutdown can never block forever.
+ *
+ * This is the bound whose absence turned rc.19's signal-handler consolidation
+ * into a hang: pre-rc.19 a cache-flush handler called `process.exit(0)` on its
+ * own (masking the latent `close()` hang); rc.19 correctly made shutdown AWAIT
+ * the full drain — but without this cap, "await the drain" became "await
+ * forever" whenever a connection lingered (reproduced: a lingering socket +
+ * SIGTERM hung `serve-http` indefinitely).
+ */
+const HTTP_CLOSE_GRACE_MS = 3000;
+
+/** Close an `http.Server` with a bounded grace (see {@link HTTP_CLOSE_GRACE_MS}).
+ *  Resolves as soon as `close()` completes, or after `graceMs` once stragglers
+ *  are force-closed — never hangs on a lingering keep-alive connection.
+ *  `graceMs` is injectable for tests; production callers use the default. */
+export function closeServerBounded(server: HttpServer, graceMs: number = HTTP_CLOSE_GRACE_MS): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const grace = setTimeout(() => {
+      // Force-close active stragglers (Node ≥18.2; engines floor is ≥22.13).
+      try {
+        server.closeAllConnections();
+      } catch {
+        /* already closed / unavailable */
+      }
+    }, graceMs);
+    if (typeof grace.unref === "function") grace.unref();
+    server.close(() => {
+      clearTimeout(grace);
+      resolve();
+    });
+    // Idle keep-alive sockets won't end on their own; close them now so the
+    // common case (no in-flight request) resolves immediately rather than
+    // waiting out the grace.
+    try {
+      server.closeIdleConnections();
+    } catch {
+      /* best-effort */
+    }
+  });
+}
+
+/**
  * v3.8.7 P2-11 — graceful shutdown helper for an `http.Server` returned
  * by {@link startHttpServer}. Drains stateful sessions (if any), closes
  * the underlying TCP listener, then closes vault/fts/watcher/embed-db
@@ -885,7 +932,7 @@ export async function shutdownHttpServer(server: HttpServer): Promise<void> {
   if (!extras) {
     // Already cleaned up (or not from startHttpServer). Still close the
     // TCP listener for safety.
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await closeServerBounded(server);
     return;
   }
   httpServerExtras.delete(server);
@@ -896,7 +943,7 @@ export async function shutdownHttpServer(server: HttpServer): Promise<void> {
   } catch {
     /* best-effort */
   }
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await closeServerBounded(server);
   // Close deps last — they own SQLite + chokidar handles that should
   // outlive in-flight requests (which we drained above). Vault doesn't
   // own a SQLite handle (no `close()` method), but it owns the

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.22";
+export const VERSION = "3.10.0-rc.23";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -13,11 +13,14 @@
 // `httpServer.close()`.
 
 import { promises as fs } from "node:fs";
+import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  closeServerBounded,
   createSessionRegistry,
   deriveHttpBodyCap,
   generateBearerToken,
@@ -1200,6 +1203,40 @@ describe("startHttpServer stateful sessions (v2.14.0)", () => {
     expect(addrAtExit).not.toBeNull(); // ← listener STILL up: the race rc.19 removes
     // Let the real teardown finish so the test leaves nothing bound.
     await vi.waitFor(() => expect(httpServer.address()).toBeNull());
+  });
+
+  // v3.10.0-rc.23 — bounded shutdown. rc.19 made shutdown AWAIT `server.close()`,
+  // but Node's `close()` never terminates idle keep-alive sockets, so a lingering
+  // connection hung `serve-http` forever on SIGINT/SIGTERM (reproduced). The fix:
+  // close idle conns immediately + force-close stragglers after a grace.
+  it("closeServerBounded resolves within the grace despite a lingering keep-alive connection (rc.23)", async () => {
+    const srv = createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((r) => srv.listen(0, "127.0.0.1", () => r()));
+    const port = (srv.address() as AddressInfo).port;
+    // Open a raw socket and hold it open — never send a complete request. This
+    // is exactly the lingering connection that makes a naive `server.close()` hang.
+    const sock = net.connect(port, "127.0.0.1");
+    sock.on("error", () => {});
+    await new Promise((r) => setTimeout(r, 50));
+    const t0 = Date.now();
+    await closeServerBounded(srv, 150); // tiny grace for the test
+    const elapsed = Date.now() - t0;
+    expect(elapsed, "must not hang on the lingering socket").toBeLessThan(2000);
+    expect(srv.listening).toBe(false);
+    sock.destroy();
+  });
+
+  // CONTROL: with NO lingering connection, it must resolve as soon as close()
+  // completes — NOT wait out the grace. A naive `setTimeout(resolve, grace)` impl
+  // would fail this (it'd always take ~the full grace).
+  it("closeServerBounded resolves promptly (well under the grace) when nothing lingers (rc.23 control)", async () => {
+    const srv = createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((r) => srv.listen(0, "127.0.0.1", () => r()));
+    const t0 = Date.now();
+    await closeServerBounded(srv, 5000); // large grace it must NOT wait out
+    const elapsed = Date.now() - t0;
+    expect(elapsed, "must resolve on close() completion, not by waiting the grace").toBeLessThan(1000);
+    expect(srv.listening).toBe(false);
   });
 
   // v3.8.7 P2-10 — fire many concurrent initialize POSTs at a low-cap


### PR DESCRIPTION
## Summary

A post-MED-batch re-sweep (3-agent audit on the rc.22 commit) caught a **HIGH regression introduced by rc.19**: `serve-http` hangs forever on SIGINT/SIGTERM when any keep-alive / half-open connection lingers.

**Mechanism:** `shutdownHttpServer` awaits `server.close()`; Node's `http.Server.close()` fires only once EVERY connection ends and never terminates idle keep-alive sockets — so a reverse-proxy keep-alive / half-open socket / LB probe / SSE stream blocks it forever. rc.19's `makeHttpShutdownHandler` gates `process.exit(0)` behind that await (the correct "await the full drain"), so the process never exits. Pre-rc.19 a cache-flush handler called `process.exit(0)` on its own, masking the latent hang; rc.19 removed that hatch and added no bound. **Textbook recursion-pair** (a fix for one shutdown bug exposed another).

**Reproduced** empirically: lingering socket + SIGTERM → alive >8s (hangs); pre-rc.19 exited in 8ms.

**Fix:** `closeServerBounded(server, graceMs=3000)` — `closeIdleConnections()` immediately + an unref'd `setTimeout` → `closeAllConnections()` after the grace; resolves on `close()` completion **or** the grace, never never. Both `shutdownHttpServer` close sites route through it. **Post-fix the same repro exits in ~3.0s, code 0.**

## Test plan

- **1130 → 1132**: `tests/http-transport.test.ts` +2 — `closeServerBounded` resolves within the grace despite a lingering keep-alive socket (the hang; pre-fix never returns) + **CONTROL** (resolves promptly when nothing lingers → proves it doesn't always wait the grace).
- All 9 gates green: lint, version (7, rc.23), docs:api, test:coverage (1197 pass / 0 fail; Lines 90.23%; count 1132), per-file (12), oia, smoke (both), changelog-coverage, npm audit two-step (0 vulns).

Found via the CLAUDE.md post-merge re-sweep rule; HIGH empirically verified before shipping. Remaining LOW findings → rc.24 (code) / rc.25 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)