### PR TITLE
v3.10.0-rc.28: README trust-batch + tool-count drift class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ src/
 ├── tool-registry.ts    — tool registration manifest
 ├── tool-manifest.ts    — tool metadata (names, schemas, readOnlyHint)
 ├── prompts.ts          — 19 MCP prompts
-├── tools/              — 44 tool implementations (read, write, search, media, meta)
+├── tools/              — 45 tool implementations (read, write, search, media, meta)
 ├── vault.ts            — Obsidian vault filesystem layer + privacy filter
 ├── fts5.ts             — SQLite FTS5 BM25 index
 ├── embed-db.ts         — embedding storage (int8-quantized BLOBs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0-rc.28] — 2026-06-07
+
+> **TL;DR:** **README trust-batch — honest scoping + a self-propagating agent rule (seeklink-inspired).** Added a candid **"When enquire-mcp is *not* the right tool"** section (use `rg` for literal search; conversation-memory tools are a different category; not multi-user/GUI/web-scale) — explicit non-goals build trust, mirroring seeklink's "Not For". Marketed the already-existing **read-only-by-default** posture with a new **least-privilege** Trust row (`--disabled-tools` / `--enabled-tools`), and shipped a **reusable agent-rule snippet** users drop into their own `AGENTS.md`/`CLAUDE.md`/`.cursorrules` so their agent learns *when* to reach for the vault (and when to prefer `grep`). Plus two **state-driven catches** the change-driven gates' regexes missed: a stale **"44 tools" → 45** in three docs (README comparison row, `docs/COMPARISON.md` table cell, `AGENTS.md` file-tree — the 45th tool `obsidian_stale_notes` shipped in v3.10 but these phrasings never updated; one even contradicted its own 34+4+7=45 breakdown), and a **broken Karpathy gist link** in the README (404 — every other reference used the correct id). Per the "drift demands a structural defense" rule, the same PR **extends the tool-count invariants** to pin the missed phrasings (`**N production tools**`, `| Tool count | N |`, `N tool implementations`). **Docs/tests only — zero `src/` runtime change, 1143 tests unchanged.**
+
+**Pre-release (v3.10 line) — README trust-batch (seeklink-inspired) + tool-count drift class.**
+
+### Added
+
+- **README "🚫 When enquire-mcp is *not* the right tool"** — honest non-goals: literal search (`rg`), conversation-memory category (mem0/Zep/Supermemory), multi-user/hosted, non-Markdown sources, GUI/plugin, web-scale corpora. Trust through candor.
+- **README "Reusable agent rule" snippet** — a copy-paste block for any `AGENTS.md`/`CLAUDE.md`/`.cursorrules` telling the agent to search the vault first for conceptual recall and use `grep`/`rg` for literal strings (the self-propagating-adoption pattern borrowed from seeklink's Agent Notes).
+- **README Trust "Least privilege" row** — markets the existing `--disabled-tools`/`--enabled-tools` surface-subsetting (e.g. a read-only research agent gets only `obsidian_search` + `obsidian_read_note`).
+
+### Fixed
+
+- **Stale "44 tools" → 45 in three docs** (README comparison row, `docs/COMPARISON.md` "Tool count" cell, `AGENTS.md` file-tree). The 45th tool (`obsidian_stale_notes`) shipped in the v3.10 line but these phrasings drifted; the README row even contradicted its own "34 + 4 + 7 = 45" breakdown.
+- **Broken Karpathy LLM-Wiki gist link in the README** (`…914927…` → 404). Corrected to the canonical id (`…914893…`, HTTP 200) used everywhere else in the codebase.
+
+### Tooling (structural enforcement)
+
+- **Extended the tool-count invariants** (`tests/docs-consistency.test.ts`) to close the phrasings the existing `**N tools**` regex couldn't see — all pinned to `TOOL_MANIFEST.length`: `**N production tools**` (README), `| Tool count | N |` (COMPARISON table cell), `N tool implementations` (AGENTS file-tree). This is the "a drift finding demands a full-surface sweep + structural defense" rule — the instance fix alone would let the class recur.
+
+### Tests (1143)
+
+- No new `it()` — the new assertions extend three existing tool-count tests (no canonical-count change). 1143 unchanged.
+
+### Files changed
+
+- `README.md` (Not-For section, agent-rule snippet, least-privilege Trust row, 44→45 comparison row, Karpathy link fix), `docs/COMPARISON.md` (Tool count 44→45), `AGENTS.md` (44→45 file-tree), `tests/docs-consistency.test.ts` (3 invariant extensions).
+- version bump 3.10.0-rc.27 → 3.10.0-rc.28.
+
+---
+
 ## [3.10.0-rc.27] — 2026-06-07
 
 > **TL;DR:** **Docker / Glama discoverability — a borrowed lesson from `seeklink`.** MCP directories (Glama, and through Glama the `awesome-mcp-servers` listing) introspect a server by **building its Dockerfile** and completing an MCP handshake + `tools/list` over stdio. enquire shipped `glama.json` long ago but had **no Dockerfile**, so that check couldn't build it. Added a minimal, reproducible **multi-stage `Dockerfile`** that builds from source and serves the **read-only-by-default** MCP over stdio against a baked sample vault — it installs deps with `--ignore-scripts` so `tsc` resolves the optional-dep types with **no native toolchain**, then **prunes optional from the slim runtime**: each native dep loads via lazy `await import()` only when a heavy tool is *called*, so `tools/list` introspection works without them (umbrella search degrades to pure-JS TF-IDF; full FTS5/embeddings/PDF retrieval uses the npm install path). _(The first CI pass caught that `--omit=optional` broke `tsc` — the optional packages are referenced in typed dynamic imports — exactly why the `docker` job exists; corrected to `--ignore-scripts` + prune-optional.)_ Plus a `.dockerignore` for a lean context. Made it **structural** with `tests/docker-glama-invariant.test.ts`: the Dockerfile must invoke the real bin (`dist/index.js`), run `serve`, and use a Node base image whose major ≥ `engines.node` floor; `glama.json` must be valid + list the owner — each with a real NEGATIVE control. **Infra/docs/tests only — zero `src/` runtime change.** The canonical install path stays `npm install -g @oomkapwn/enquire-mcp`; the image is for directory introspection + quick container trials.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Same `npx -y @oomkapwn/enquire-mcp serve --vault <path>` command works for any M
 
 </details>
 
+**Reusable agent rule** (drop into any `AGENTS.md` / `CLAUDE.md` / `.cursorrules` so the agent knows *when* to reach for the vault):
+
+> When my question touches my own notes, decisions, projects, people, or research, **search my Obsidian vault first** via the `obsidian_*` tools (start with `obsidian_search`) and cite the source note on every fact. Prefer enquire for *conceptual / cross-language / "what did I say about X"* recall; use plain `grep` / `ripgrep` for exact literal strings. If nothing relevant comes back, say so — don't guess.
+
 ### Example queries that work well
 
 - *"Find every note where I discussed pricing strategy, summarize the evolution."* — RRF fusion + reranker handles "evolution" semantically
@@ -154,6 +158,19 @@ Same `npx -y @oomkapwn/enquire-mcp serve --vault <path>` command works for any M
 **2 — Personal knowledge base / second brain.** Hybrid retrieval surfaces the right note for *any* phrasing, in any of 50+ languages. Ask in English about a Russian-language journal entry from 2 years ago, get the right hit. Wikilink graph-boost reranks notes that sit at the centre of your knowledge graph. GraphRAG-light surfaces topical communities — discover connections you forgot you made. PDFs blend into search with `[page: N]` citations so research papers and meeting transcripts become first-class memory.
 
 **3 — Agentic RAG / context engineering.** `obsidian_search` exposes per-signal scores so the agent sees *why* each hit ranked. HyDE pre-rewrites vague queries into rich hypothetical answers before retrieval. Sub-question decomposition handles multi-hop questions ("how did our pricing strategy evolve and what was the customer reaction?") by breaking them into independent sub-queries, fusing results. The built-in eval harness (NDCG / Recall / MRR) lets you measure retrieval quality on your own queries instead of trusting vendor benchmarks.
+
+---
+
+## 🚫 When enquire-mcp is *not* the right tool
+
+Honest non-goals — reach for something else when:
+
+- **You want literal string / regex search.** `ripgrep` / `grep` is faster and exact for "find this precise token". enquire shines on *conceptual* recall — synonyms, cross-language, "what did I say about X". Use both: `rg` for literal, enquire for meaning.
+- **Your knowledge lives in chat logs, not notes.** enquire is *grounded* in the markdown you authored. Conversation-memory tools (mem0, Zep, Supermemory) that *extract* facts from chat transcripts into a separate store are a different category — see the [comparison](./docs/COMPARISON.md).
+- **You need multi-user / hosted / synced search.** enquire is local-first and single-vault by design — no server-side multi-tenant index.
+- **Your sources aren't Markdown or PDF.** `.md` / `.canvas` / `.base` / `.pdf` are first-class; other formats need conversion first.
+- **You want a GUI or an in-app Obsidian plugin.** enquire is a headless MCP server / CLI — it *complements* Obsidian, it isn't one. (Smart Connections is the in-app plugin option.)
+- **You need sub-millisecond search over millions of notes.** HNSW gives sub-10ms top-K at large scale, but enquire targets personal / team vaults, not web-scale corpora.
 
 ---
 
@@ -183,7 +200,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 | **Per-signal observability** per hit | ✅ | ❌ | ❌ |
 | **MCP-native** (Claude · Cursor · ChatGPT · Codex · OpenClaw · any client) | ✅ | ❌ Obsidian-only | varies |
 | **Privacy filter** verified at every search + write path | ✅ | n/a | ❌ |
-| **44 production tools** (34 always-on read tools + 4 opt-in + 7 gated writes) | ✅ | n/a | varies |
+| **45 production tools** (34 always-on read tools + 4 opt-in + 7 gated writes) | ✅ | n/a | varies |
 | **GraphRAG-light** (wikilink community detection via Louvain modularity) | ✅ **only here** | ❌ | ❌ |
 | **Standalone `.base` query execution** (works without Obsidian running) | ✅ **only here** | ❌ | ❌ delegates to Obsidian |
 | **HyDE retrieval** (Gao et al 2023) + sub-question decomposition | ✅ **only here** | ❌ | ❌ |
@@ -195,7 +212,7 @@ Auto-generated **[API reference at oomkapwn.github.io/enquire-mcp](https://oomka
 
 <sub>Comparison based on each project's public capabilities as of v3.8.x stable (initial snapshot v3.7.0 / 2026-05-15; refreshed in v3.8.4). Smart Connections is a paid Obsidian plugin (not an MCP server). "Other Obsidian-MCPs" refers to public open-source Obsidian-MCP servers on GitHub at time of writing. Public end-to-end retrieval benchmarks for enquire-mcp are published in <a href="./docs/benchmarks.md"><code>docs/benchmarks.md</code></a> — measured `rerank-bge` delta is +24.7 MRR / +15.5 NDCG@10 over plain hybrid on a 60-query ablation.</sub>
 
-> Strategic claim: enquire-mcp is the open-source backend for [Karpathy-style LLM Wikis](https://gist.github.com/karpathy/442a6bf555914927e9891c11519de94f) on top of your existing Obsidian vault. Knowledge that compounds, traceable to sources.
+> Strategic claim: enquire-mcp is the open-source backend for [Karpathy-style LLM Wikis](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) on top of your existing Obsidian vault. Knowledge that compounds, traceable to sources.
 
 ---
 
@@ -252,6 +269,7 @@ Plus 3 MCP resources (`obsidian://vault/info`, `obsidian://note/{path}`, `obsidi
 | Surface | Posture |
 |---|---|
 | **Default** | Read-only — `--enable-write` required for the 7 write tools |
+| **Least privilege** | `--disabled-tools` / `--enabled-tools` expose a minimal surface (e.g. a read-only research agent gets only `obsidian_search` + `obsidian_read_note`) |
 | **Path safety** | Realpath check on every read+write; symlinks-out-of-vault rejected |
 | **Privacy filter** | Verified at FTS5 + embed-db + chunk resource paths; fail-closed on empty allow-/deny-lists |
 | **HTTP transport** | Bearer auth (constant-time SHA-256 + `timingSafeEqual`), per-token rate-limit, strict CORS |

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -45,7 +45,7 @@ The four axes the external audit (#3, 2026-05) called out as decisive — **REST
 | Signed build provenance on releases (SLSA L2) | **Yes**             | No               | No               | No               | No               |
 | Forgetting-aware freshness (`age_days` / recency re-rank) | Yes (v3.10)     | No               | No               | No               | No               |
 | Test count (public)                           | **1143**             | (varies)         | (varies)         | (varies)         | (varies)         |
-| Tool count                                    | 44                  | ~25              | ~8               | ~10              | 3–5              |
+| Tool count                                    | 45                  | ~25              | ~8               | ~10              | 3–5              |
 | MCP prompt count                              | 19                  | 0                | 0                | 0                | 0                |
 | License                                       | MIT                 | Apache-2.0       | MIT              | MIT              | (varies)         |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.27",
+  "version": "3.10.0-rc.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.27",
+      "version": "3.10.0-rc.28",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@oomkapwn/enquire-mcp",
-  "version": "3.10.0-rc.27",
+  "version": "3.10.0-rc.28",
   "mcpName": "io.github.oomkapwn/enquire-mcp",
   "description": "MCP server giving AI agents (Claude Code, Claude Desktop, Cursor, ChatGPT, Codex, OpenClaw) persistent long-term memory backed by your local Obsidian markdown vault. Hybrid retrieval (BM25 + ML embeddings + BGE reranker, RRF-fused), HNSW + int8 quantization, agentic RAG (HyDE + sub-question decomposition), GraphRAG-light (Louvain), standalone Obsidian Bases, PDFs + Tesseract OCR. Vendor-neutral memory layer for any MCP-compatible agent. 45 tools, 19 MCP prompts, 1143 tests, signed npm build provenance (SLSA L2), semver-bound, MIT, zero cloud calls during serve.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oomkapwn/enquire-mcp",
     "source": "github"
   },
-  "version": "3.10.0-rc.27",
+  "version": "3.10.0-rc.28",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oomkapwn/enquire-mcp",
-      "version": "3.10.0-rc.27",
+      "version": "3.10.0-rc.28",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { main } from "./cli.js";
  * + `McpServer({version})`) and `src/tool-registry.ts` (used in the
  * `vault-info` resource payload).
  */
-export const VERSION = "3.10.0-rc.27";
+export const VERSION = "3.10.0-rc.28";
 
 // Re-exports — preserve the v3.5.x public surface so http-transport.ts and
 // tests don't need to know about the new module layout. The set below

--- a/tests/docs-consistency.test.ts
+++ b/tests/docs-consistency.test.ts
@@ -161,6 +161,17 @@ describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () =>
     expect(m, "README must declare a total tool count in **N tools** form near the top").not.toBeNull();
     const claimed = Number.parseInt(m?.[1] ?? "0", 10);
     expect(claimed).toBe(counts.allTools);
+    // v3.10.0-rc.28 — also pin the "**N production tools**" phrasing (comparison
+    // table). A stale "44 production tools" slipped the regex above (the number
+    // wasn't directly followed by " tools") and even contradicted its own
+    // 34+4+7=45 breakdown until rc.28. Inline guard against the live count, same
+    // shape as the `**N tools**` and `+ N gated writes` checks in this test.
+    for (const pm of readme.matchAll(/(\d+)\s+production tools\b/g)) {
+      expect(
+        Number.parseInt(pm[1] ?? "0", 10),
+        `README "N production tools" must equal the registered tool count (${counts.allTools})`
+      ).toBe(counts.allTools);
+    }
   });
 
   it("README write-tool-count claim matches actual write count", async () => {
@@ -480,6 +491,16 @@ describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () =>
       expect(claimed, `COMPARISON.md mentions "${m[0]}" but actual prompt count is ${counts.prompts}`).toBe(
         counts.prompts
       );
+    }
+    // v3.10.0-rc.28 — also pin the "| Tool count | N |" comparison-table cell.
+    // The "N tools" regex above can't see a bare table cell, so it stayed stale
+    // at 44 (one behind the 45th tool, obsidian_stale_notes) until rc.28.
+    const cellMatch = /Tool count\s*\|\s*\**(\d+)\**/.exec(comparisonMd);
+    if (cellMatch) {
+      expect(
+        Number.parseInt(cellMatch[1] ?? "0", 10),
+        `COMPARISON.md "Tool count | N" must equal the registered tool count (${counts.allTools})`
+      ).toBe(counts.allTools);
     }
   });
 
@@ -936,8 +957,18 @@ describe("docs/code consistency — llms.txt + AGENTS.md numeric claims (v3.8.0-
   });
 
   it("AGENTS.md test count claim (X+ tests) is a valid lower bound", async () => {
-    const err = checkAgentsTestFloor(await read("AGENTS.md"), await countActualTests());
+    const agents = await read("AGENTS.md");
+    const err = checkAgentsTestFloor(agents, await countActualTests());
     expect(err, err ?? "").toBeNull();
+    // v3.10.0-rc.28 — also pin AGENTS.md "N tool implementations" (file-tree
+    // comment) to the registered tool count; it was stale at 44 until rc.28.
+    const counts = await getActualCounts();
+    for (const tm of agents.matchAll(/(\d+)\s+tool implementations\b/g)) {
+      expect(
+        Number.parseInt(tm[1] ?? "0", 10),
+        `AGENTS.md "N tool implementations" must equal ${counts.allTools}`
+      ).toBe(counts.allTools);
+    }
   });
 
   it("AGENTS.md per-file branch floor count matches actual entries in scripts/check-per-file-coverage.mjs", async () => {


### PR DESCRIPTION
## Summary

seeklink-inspired **trust/positioning** batch, plus two **state-driven catches** the change-driven gates missed.

### Added
- **README "🚫 When enquire-mcp is *not* the right tool"** — honest non-goals (use `rg` for literal search; conversation-memory tools are a different category; not multi-user/GUI/web-scale). Trust through candor (mirrors seeklink's "Not For").
- **README reusable agent-rule snippet** — copy-paste for any `AGENTS.md`/`CLAUDE.md`/`.cursorrules` so an agent learns *when* to reach for the vault vs `grep` (self-propagating adoption).
- **README Trust "Least privilege" row** — markets the existing `--disabled-tools`/`--enabled-tools` surface-subsetting.

### Fixed (state-driven)
- **Stale "44 tools" → 45** in three docs (README comparison row, `docs/COMPARISON.md` cell, `AGENTS.md` file-tree) — the 45th tool `obsidian_stale_notes` shipped in v3.10 but these phrasings drifted; one even contradicted its own 34+4+7=45 breakdown.
- **Broken Karpathy gist link** in the README (`…914927` → HTTP 404; corrected to `…914893`, HTTP 200, the id used everywhere else).

### Structural defense
Per the "drift demands a full-surface sweep + structural defense" rule, extended the tool-count invariants to pin the phrasings the `**N tools**` regex couldn't see: `**N production tools**`, `| Tool count | N |`, `N tool implementations` — all to `TOOL_MANIFEST.length`.

## Scope
Docs/tests only — **zero `src/` runtime change, 1143 tests unchanged**.

## Gates (local)
build ✓ · lint ✓ (116) · full suite ✓ (1208 + 2 skipped) · OIA ✓ · version-consistency ✓ (7 surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)