### PR TITLE
fix: bind timeout guards to Vitest imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Vitest timeout binding identity follow-up
+
+> **TL;DR:** **The timeout ceiling guard now proves that each protected `describe`, `it`, and `beforeAll` identifier is the direct unaliased Vitest binding, with no competing runtime binding anywhere in the source.** A local wrapper can no longer preserve the reviewed timeout literal while registering the callback with a larger timeout or suppressing the suite entirely.
+>
+> **Method note:** the mandatory post-merge sibling sweep of PR #516 reproduced the false green on exact main `20fcf3eddaff414901299b4575d7ced1b4bc4bd5`: an aliased `it` wrapper retained the visible `25_000` argument while forwarding the callback to Vitest with `86_400_000`, and an aliased no-op `describe` kept the same AST-shaped suite without registering it. The detector now performs a whole-source runtime-binding census over every guarded file. A clean direct-import fixture is the positive control; causal mutations cover aliased `it`, aliased `beforeAll`, a no-op `describe`, and a suite-local hoisted binding. Under D-45 no local install, build, lint, test, coverage, smoke, OIA, package/client runtime, benchmark, or evaluation workload ran; executable proof remains required from GitHub-hosted CI on the exact candidate and squash-main SHAs.
+
+- **Identifier spelling is no longer treated as authority.** Each guarded suite and registration callee must have exactly one direct, runtime, unaliased named import from `vitest`; default, namespace, aliased, type-only, missing, or duplicate bindings fail closed.
+- **Runtime shadows are rejected as a class.** Variable and destructuring declarations, parameters, functions, classes, enums, namespaces, and import-equals bindings are counted across the complete source, including hoisted declarations placed after the reviewed registration.
+- **Product and publication state are unchanged.** This correction changes only the repository-integrity oracle and its causal controls; it does not change runtime code, workflows, dependencies, package version, tags, GitHub Releases, npm, or MCP Registry state.
+
 ### Full-project audit closure and split publication authority
 
 > **TL;DR:** **The rc.4 candidate closes the confirmed runtime, persistence, shutdown, HNSW-generation, resource-bound, package-artifact, documentation, Docker-reproducibility, and publication-authority findings from the full-project audit.** Release verification is read-only; npm Trusted Publishing, GitHub Release writes, and stable-only MCP Registry OIDC now live in three separately protected jobs and environments. Each privileged job rejects checkout/product execution, long-lived npm credentials, unexpected handoff entries, transport-digest drift, and any reviewed executable whose immutable SHA-256 is not the one embedded in the workflow. npm publishes the exact CI-built tarball with lifecycle scripts disabled.

--- a/tests/no-internal-imports.test.ts
+++ b/tests/no-internal-imports.test.ts
@@ -684,6 +684,87 @@ function vitestCoverageProblems(source: string, configFiles: readonly string[]):
   return problems;
 }
 
+type RegistrationVitestBinding = "beforeAll" | "describe" | "it";
+
+function registrationVitestBindingProblems(
+  sourceFile: ts.SourceFile,
+  filename: string,
+  requiredBindings: readonly RegistrationVitestBinding[]
+): string[] {
+  // A matching identifier is not registration authority: an alias plus a local
+  // wrapper can keep the reviewed literal while changing or suppressing the test.
+  const directCounts = new Map<RegistrationVitestBinding, number>();
+  const otherCounts = new Map<RegistrationVitestBinding, number>();
+  for (const binding of requiredBindings) {
+    directCounts.set(binding, 0);
+    otherCounts.set(binding, 0);
+  }
+  const recordOtherBinding = (name: ts.BindingName): void => {
+    if (ts.isIdentifier(name)) {
+      const binding = requiredBindings.find((candidate) => candidate === name.text);
+      if (binding !== undefined) {
+        otherCounts.set(binding, (otherCounts.get(binding) ?? 0) + 1);
+      }
+      return;
+    }
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element)) recordOtherBinding(element.name);
+    }
+  };
+  const visitRuntimeBindings = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      const moduleName = stringLiteralValue(node.moduleSpecifier);
+      const clause = node.importClause;
+      if (clause === undefined || clause.isTypeOnly) return;
+      if (clause.name !== undefined) recordOtherBinding(clause.name);
+      const bindings = clause.namedBindings;
+      if (bindings === undefined) return;
+      if (ts.isNamespaceImport(bindings)) {
+        recordOtherBinding(bindings.name);
+        return;
+      }
+      for (const element of bindings.elements) {
+        if (element.isTypeOnly) continue;
+        const binding = requiredBindings.find((candidate) => candidate === element.name.text);
+        if (moduleName === "vitest" && element.propertyName === undefined && binding !== undefined) {
+          directCounts.set(binding, (directCounts.get(binding) ?? 0) + 1);
+        } else {
+          recordOtherBinding(element.name);
+        }
+      }
+      return;
+    }
+    if (ts.isImportEqualsDeclaration(node)) {
+      if (!node.isTypeOnly) recordOtherBinding(node.name);
+      return;
+    }
+    if (ts.isVariableDeclaration(node) || ts.isParameter(node)) {
+      recordOtherBinding(node.name);
+    } else if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node) ||
+      ts.isEnumDeclaration(node)
+    ) {
+      if (node.name !== undefined) recordOtherBinding(node.name);
+    } else if (ts.isModuleDeclaration(node) && ts.isIdentifier(node.name)) {
+      recordOtherBinding(node.name);
+    }
+    ts.forEachChild(node, visitRuntimeBindings);
+  };
+  visitRuntimeBindings(sourceFile);
+  return requiredBindings.flatMap((binding) => {
+    const direct = directCounts.get(binding) ?? 0;
+    const other = otherCounts.get(binding) ?? 0;
+    return direct === 1 && other === 0
+      ? []
+      : [
+          `${filename} must bind ${binding} through one direct unaliased vitest named import and no other runtime bindings; found direct ${direct}, other ${other}`
+        ];
+  });
+}
+
 function registrationTimeoutProblems(
   source: string,
   filename: string,
@@ -693,6 +774,7 @@ function registrationTimeoutProblems(
   expectedTimeout: string
 ): string[] {
   const sourceFile = ts.createSourceFile(filename, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const bindingProblems = registrationVitestBindingProblems(sourceFile, filename, ["describe", callee]);
   const suites = sourceFile.statements.flatMap((statement) => {
     if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) return [];
     const call = statement.expression;
@@ -715,7 +797,7 @@ function registrationTimeoutProblems(
     suiteCallback.parameters.length !== 0 ||
     !ts.isBlock(suiteCallback.body)
   ) {
-    return [`${filename} must retain one direct top-level suite ${suiteTitle}`];
+    return [...bindingProblems, `${filename} must retain one direct top-level suite ${suiteTitle}`];
   }
   const registrations = suiteCallback.body.statements.flatMap((statement, statementIndex) => {
     if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) return [];
@@ -766,9 +848,10 @@ function registrationTimeoutProblems(
     timeout !== undefined
       ? [timeout.getText(sourceFile)]
       : ["<invalid-registration>"];
-  return isDeepStrictEqual(timeouts, [expectedTimeout])
+  const timeoutProblems = isDeepStrictEqual(timeouts, [expectedTimeout])
     ? []
     : [`${filename} must retain one direct ${callee} registration with timeout ${expectedTimeout}`];
+  return [...bindingProblems, ...timeoutProblems];
 }
 
 function importClauseHasRuntimeValue(clause: ts.ImportClause | undefined): boolean {
@@ -1557,11 +1640,22 @@ describe("Class A invariant — no test imports value from registration boilerpl
       );
     const metaTimeoutDiagnostic =
       "tests/meta-invariant-coverage.test.ts must retain one direct beforeAll registration with timeout 720_000";
+    const metaBindingDiagnostic =
+      "tests/meta-invariant-coverage.test.ts must bind beforeAll through one direct unaliased vitest named import and no other runtime bindings; found direct 0, other 1";
+    const aliasedMetaCallee = replaceExactly(
+      metaSource,
+      'import { beforeAll, describe, expect, it } from "vitest";',
+      'import { beforeAll as authenticBeforeAll, describe, expect, it } from "vitest";\n' +
+        "const beforeAll = (callback: () => void, _timeout: number): void => {\n" +
+        "  authenticBeforeAll(callback, 86_400_000);\n" +
+        "};"
+    );
     const shadowedMetaRegistration =
       'describe("META-invariant: exact structural census + NEGATIVE control coverage", () => {\n' +
       "  beforeAll(() => {}, 720_000);\n" +
       "  function beforeAll(..._args: unknown[]): void {}\n" +
       "});";
+    expect(metaTimeoutProblems(aliasedMetaCallee)).toContain(metaBindingDiagnostic);
     expect(metaTimeoutProblems(syntheticRaisedMetaRegistration)).toContain(metaTimeoutDiagnostic);
     expect(metaTimeoutProblems(shadowedMetaRegistration)).toContain(metaTimeoutDiagnostic);
     expect(metaTimeoutProblems(staleMetaTimeout)).toContain(metaTimeoutDiagnostic);
@@ -1671,6 +1765,44 @@ describe("Class A invariant — no test imports value from registration boilerpl
       );
     const docsTimeoutDiagnostic =
       "tests/docs-consistency.test.ts must retain one direct it registration with timeout 25_000";
+    const docsItBindingDiagnostic =
+      "tests/docs-consistency.test.ts must bind it through one direct unaliased vitest named import and no other runtime bindings; found direct 0, other 1";
+    const docsDescribeBindingDiagnostic =
+      "tests/docs-consistency.test.ts must bind describe through one direct unaliased vitest named import and no other runtime bindings; found direct 0, other 1";
+    const exactDocsRegistration =
+      'import { describe, it } from "vitest";\n' +
+      'describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () => {\n' +
+      '  it("OIA check count is consistent across oia-walk.mjs, AGENTS.md, ROADMAP.md (rc.22)", () => {}, 25_000);\n' +
+      "});";
+    expect(docsTimeoutProblems(exactDocsRegistration)).toEqual([]);
+    const aliasedDocsCallee = replaceExactly(
+      current.docsConsistencySource,
+      'import { describe, expect, it } from "vitest";',
+      'import { describe, expect, it as authenticIt } from "vitest";\n' +
+        "const it = (name: string, callback: () => void, _timeout: number): void => {\n" +
+        "  authenticIt(name, callback, 86_400_000);\n" +
+        "};"
+    );
+    const aliasedDocsSuite = replaceExactly(
+      current.docsConsistencySource,
+      'import { describe, expect, it } from "vitest";',
+      'import { describe as authenticDescribe, expect, it } from "vitest";\n' +
+        "void authenticDescribe;\n" +
+        "const describe = (_name: string, _callback: () => void): void => undefined;"
+    );
+    const suiteLocalOptionalVarShadow =
+      'import { describe, it } from "vitest";\n' +
+      "const authenticIt = it;\n" +
+      'describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () => {\n' +
+      '  it?.("OIA check count is consistent across oia-walk.mjs, AGENTS.md, ROADMAP.md (rc.22)", () => {}, 25_000);\n' +
+      "  var it = authenticIt;\n" +
+      '  it("sibling remains registered", () => {}, 25_000);\n' +
+      "});";
+    expect(docsTimeoutProblems(aliasedDocsCallee)).toContain(docsItBindingDiagnostic);
+    expect(docsTimeoutProblems(aliasedDocsSuite)).toContain(docsDescribeBindingDiagnostic);
+    expect(docsTimeoutProblems(suiteLocalOptionalVarShadow)).toContain(
+      docsItBindingDiagnostic.replace("found direct 0, other 1", "found direct 1, other 1")
+    );
     const docsTimeoutNeedle = '  }, 25_000);\n\n  it("package.json description tool-count matches actual count"';
     const staleDocsTimeout = replaceExactly(
       current.docsConsistencySource,


### PR DESCRIPTION
## Summary

- bind each protected describe, it, and beforeAll identifier to one direct unaliased Vitest runtime import
- reject competing runtime bindings across the complete guarded source
- add clean positive and causal alias, no-op suite, and hoisted-shadow controls
- leave product runtime, workflows, dependencies, version, tags, and publication state unchanged

## Test plan

- [x] independent static and extracted-AST review on all five guarded sources
- [x] git diff --check
- [ ] all GitHub-hosted CI and CodeQL checks green on the exact PR SHA
- [ ] squash-main CI replay green before any next audit fix

Local npm, build, lint, and test workloads were intentionally not run under the repository D-45 policy; executable proof is delegated to GitHub-hosted CI.