### PR TITLE
Fix Vitest timeout prefix reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Vitest prefix-registration reachability follow-up
+
+> **TL;DR:** **The timeout guard now admits only inert direct calls to the already authenticated target registrar before the protected registration.** Unrelated registrar spellings and eager argument expressions can no longer make the target unreachable while the structural oracle reports a valid timeout.
+>
+> **Method note:** the mandatory post-merge sweep of PR #517 found a narrower structural false negative on exact green main `a4aed350d2ab48dc3dec8186813f1a321c93226f`: a local throwing `beforeEach()` call before the exact guarded `it(...)` was accepted only because its identifier appeared in a seven-name allowlist. Binding that prefix name alone was insufficient because even an authentic `it` can evaluate a throwing argument before registering the target. The corrective detector therefore permits only function declarations plus statically inert direct calls to the same binding-verified `it` or `beforeAll`: static title where applicable, zero-parameter block-arrow callback, and absent or numeric-literal timeout. A normal preceding sibling is the positive control; local-prefix and eager-IIFE mutations are causal negatives. This proves a structural-oracle false negative, not an independently demonstrated green-CI bypass. Under D-45, executable proof remains GitHub-hosted only.
+
+- **Reachability is derived from execution shape, not a registrar-name allowlist.** `afterAll`, `afterEach`, `beforeEach`, `describe`, and `test` are no longer accepted merely by spelling, while the existing real prefixes remain unchanged direct `it` registrations.
+- **Prefix arguments are inert by construction.** Computed titles, invoked callback expressions, optional calls, type arguments, and dynamic timeout expressions fail closed before the exact target timeout is accepted.
+- **Scope remains assurance-only.** Runtime code, workflows, dependencies, package version, tags, GitHub Releases, npm, and MCP Registry state are unchanged.
+
 ### Vitest timeout binding identity follow-up
 
 > **TL;DR:** **The timeout ceiling guard now proves that each protected `describe`, `it`, and `beforeAll` identifier is the direct unaliased Vitest binding, with no competing runtime binding anywhere in the source.** A local wrapper can no longer preserve the reviewed timeout literal while registering the callback with a larger timeout or suppressing the suite entirely.

--- a/tests/no-internal-imports.test.ts
+++ b/tests/no-internal-imports.test.ts
@@ -808,31 +808,43 @@ function registrationTimeoutProblems(
   });
   const registrationEntry = registrations.length === 1 ? registrations[0] : undefined;
   const registration = registrationEntry?.call;
-  const safeRegistrationCallees = new Set([
-    "afterAll",
-    "afterEach",
-    "beforeAll",
-    "beforeEach",
-    "describe",
-    "it",
-    "test"
-  ]);
-  const shadowsRegistrationCallee = suiteCallback.body.statements.some(
+  const shadowsTargetCallee = suiteCallback.body.statements.some(
     (statement) =>
       ts.isFunctionDeclaration(statement) &&
       statement.name !== undefined &&
-      safeRegistrationCallees.has(statement.name.text)
+      statement.name.text === callee
   );
+  const inertPrefixRegistration = (statement: ts.Statement): boolean => {
+    if (ts.isFunctionDeclaration(statement)) return true;
+    if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) return false;
+    const call = statement.expression;
+    if (
+      !ts.isIdentifier(call.expression) ||
+      call.expression.text !== callee ||
+      call.questionDotToken !== undefined ||
+      call.typeArguments !== undefined
+    ) {
+      return false;
+    }
+    const callbackIndex = callee === "beforeAll" ? 0 : 1;
+    const timeoutIndex = callee === "beforeAll" ? 1 : 2;
+    const callback = call.arguments[callbackIndex];
+    const timeout = call.arguments[timeoutIndex];
+    const minimumArgumentCount = callee === "beforeAll" ? 1 : 2;
+    return (
+      (call.arguments.length === minimumArgumentCount || call.arguments.length === minimumArgumentCount + 1) &&
+      (callee === "beforeAll" || stringLiteralValue(call.arguments[0]) !== undefined) &&
+      callback !== undefined &&
+      ts.isArrowFunction(callback) &&
+      callback.parameters.length === 0 &&
+      ts.isBlock(callback.body) &&
+      (timeout === undefined || ts.isNumericLiteral(timeout))
+    );
+  };
   const registrationIsReachable =
     registrationEntry !== undefined &&
-    !shadowsRegistrationCallee &&
-    suiteCallback.body.statements.slice(0, registrationEntry.statementIndex + 1).every((statement) => {
-      if (ts.isFunctionDeclaration(statement)) return true;
-      if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) return false;
-      return ts.isIdentifier(statement.expression.expression)
-        ? safeRegistrationCallees.has(statement.expression.expression.text)
-        : false;
-    });
+    !shadowsTargetCallee &&
+    suiteCallback.body.statements.slice(0, registrationEntry.statementIndex).every(inertPrefixRegistration);
   const callbackIndex = title === undefined ? 0 : 1;
   const timeoutIndex = title === undefined ? 1 : 2;
   const callback = registration?.arguments[callbackIndex];
@@ -1772,6 +1784,7 @@ describe("Class A invariant — no test imports value from registration boilerpl
     const exactDocsRegistration =
       'import { describe, it } from "vitest";\n' +
       'describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () => {\n' +
+      '  it("sibling registration remains inert", () => {});\n' +
       '  it("OIA check count is consistent across oia-walk.mjs, AGENTS.md, ROADMAP.md (rc.22)", () => {}, 25_000);\n' +
       "});";
     expect(docsTimeoutProblems(exactDocsRegistration)).toEqual([]);
@@ -1798,11 +1811,26 @@ describe("Class A invariant — no test imports value from registration boilerpl
       "  var it = authenticIt;\n" +
       '  it("sibling remains registered", () => {}, 25_000);\n' +
       "});";
+    const localPrefixRegistrar =
+      'import { describe, it } from "vitest";\n' +
+      'const beforeEach = (): void => { throw new Error("abort collection"); };\n' +
+      'describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () => {\n' +
+      "  beforeEach();\n" +
+      '  it("OIA check count is consistent across oia-walk.mjs, AGENTS.md, ROADMAP.md (rc.22)", () => {}, 25_000);\n' +
+      "});";
+    const eagerPrefixArgument =
+      'import { describe, it } from "vitest";\n' +
+      'describe("docs/code consistency — numeric claims (v3.5.1 audit-driven)", () => {\n' +
+      '  it("sibling", (() => { throw new Error("abort collection"); })());\n' +
+      '  it("OIA check count is consistent across oia-walk.mjs, AGENTS.md, ROADMAP.md (rc.22)", () => {}, 25_000);\n' +
+      "});";
     expect(docsTimeoutProblems(aliasedDocsCallee)).toContain(docsItBindingDiagnostic);
     expect(docsTimeoutProblems(aliasedDocsSuite)).toContain(docsDescribeBindingDiagnostic);
     expect(docsTimeoutProblems(suiteLocalOptionalVarShadow)).toContain(
       docsItBindingDiagnostic.replace("found direct 0, other 1", "found direct 1, other 1")
     );
+    expect(docsTimeoutProblems(localPrefixRegistrar)).toContain(docsTimeoutDiagnostic);
+    expect(docsTimeoutProblems(eagerPrefixArgument)).toContain(docsTimeoutDiagnostic);
     const docsTimeoutNeedle = '  }, 25_000);\n\n  it("package.json description tool-count matches actual count"';
     const staleDocsTimeout = replaceExactly(
       current.docsConsistencySource,

--- a/tests/no-internal-imports.test.ts
+++ b/tests/no-internal-imports.test.ts
@@ -809,10 +809,7 @@ function registrationTimeoutProblems(
   const registrationEntry = registrations.length === 1 ? registrations[0] : undefined;
   const registration = registrationEntry?.call;
   const shadowsTargetCallee = suiteCallback.body.statements.some(
-    (statement) =>
-      ts.isFunctionDeclaration(statement) &&
-      statement.name !== undefined &&
-      statement.name.text === callee
+    (statement) => ts.isFunctionDeclaration(statement) && statement.name !== undefined && statement.name.text === callee
   );
   const inertPrefixRegistration = (statement: ts.Statement): boolean => {
     if (ts.isFunctionDeclaration(statement)) return true;


### PR DESCRIPTION
## Summary

- replace the seven-registrar prefix allowlist with a fail-closed inert-shape check
- admit only function declarations and direct calls to the already binding-authenticated target registrar
- add a real sibling positive control plus local-registrar and eager-argument causal negatives
- document the post-merge finding and its assurance-only scope; no runtime, workflow, dependency, version, tag, release, npm, or registry changes

## Test plan

- [x] `git diff --check`
- [x] two independent read-only static reviews
- [ ] all GitHub-hosted candidate checks pass on exact head SHA
- [ ] verify mergeability and exact base/head before squash merge

Under repository decision D-45, no local project workloads were run; executable proof is GitHub-hosted only.