### PR TITLE
fix: keep in-message headings inside chat thread read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Chat thread read keeps headings inside messages
+
+> **TL;DR:** **`obsidian_chat_thread_read` no longer treats a `#` or `##` line inside a message as the end of the thread.** The parser stopped at the first such heading, flushed the current message, set `inThread = false`, and reported `message_count` for only the truncated prefix. A later `### user|assistant|system ·` message in the same `## Chat:` block was dropped. `chatThreadAppend` writes message bodies verbatim, so a plan that contains `## Step 1` was enough. The chat region now runs until EOF or a later `## Chat:` title line.
+>
+> **Bounded claim.** This does **not** fence-scan message bodies, so a heading-shaped line inside a code fence is still a `### role` delimiter if it matches `CHAT_HEADING_RE`, and is otherwise kept as content. A `## Chat:` line still starts a new title. Trailing vault sections after the last message (`## Notes`) are absorbed into that last message rather than truncating the thread. It does **not** change `chatThreadAppend`, search, or write tools.
+>
+> **Method note:** BACKLOG §1.CC-ter **B5**, remaining MED. Coverage is an extra phase of the existing `handles multi-line message content correctly (preserves markdown)` test, so the source `it()` census does not move. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **In-message `#` / `##` stay content.** Removing the terminator lets the existing `### role · timestamp` walker continue to later messages.
+- **`message_count` matches surviving messages.** The extra phase appends a user message that contains both heading levels, then an assistant reply, and requires `message_count === 2` with both heading strings in the user body.
+
 ### One-shot query does not rewrite the shared FTS from privacy filters
 
 > **TL;DR:** **`enquire-mcp query` (and `eval --persistent-index`) no longer persist one invocation's `--exclude-glob` / `--read-paths` as FTS deletions into the shared default per-vault index.** `syncFtsIndex` diffs live admitted Markdown against stored rows and `dropFile`s the rest. Both commands construct a privacy-filtered Vault, then opened the same `defaultIndexFile` that `serve --persistent-index` uses, so a one-shot search with `--read-paths Public/**` deleted every other note from the on-disk BM25 index. Hits were already filtered at response-build (`vault.isExcluded`); the write was a silent side effect of a read/runtime path. Skip is by **resolved path identity** with `defaultIndexFile(vaultRoot)`, so `--index-file` that spells that same path also skips. A *different* `--index-file` still syncs (M-8). `index` / `setup` / `serve` / `serve-http` are unchanged writers of the Vault they were started with.

--- a/docs/api.md
+++ b/docs/api.md
@@ -611,7 +611,7 @@ Given a question, retrieves top-relevant Markdown notes (via `obsidian_search`),
 
 ## `obsidian_chat_thread_read`
 
-Parse a note's `## Chat: <title>` block into structured messages with role / timestamp / content / line-range. Non-chat content in the same note is ignored.
+Parse a note's `## Chat: <title>` block into structured messages with role / timestamp / content / line-range. `#` / `##` lines inside a message are kept.
 
 | Argument    | Type     | Notes                                                |
 |-------------|----------|------------------------------------------------------|

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1159,7 +1159,7 @@ export function registerReadTools(
     {
       title: "Read parsed chat thread from a note",
       description:
-        "Parse a note's `## Chat: <title>` block into structured messages with role/timestamp/content/line-range. Non-chat content in the same note is ignored. Read-only.",
+        "Parse a note's `## Chat: <title>` block into structured messages with role/timestamp/content/line-range. `#`/`##` lines inside a message are kept. Read-only.",
       annotations: { ...READ_ONLY, title: "Read chat thread" },
       inputSchema: z.strictObject({
         note_path: z.string().min(1).describe("Vault-relative path to the note hosting the thread")

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1054,11 +1054,12 @@ export async function chatThreadAppend(
 /**
  * Parse a note's chat thread into structured messages.
  *
- * Reads the chat block delimited by `## Chat: <title>` and parses each
+ * Reads the chat block starting at `## Chat: <title>` and parses each
  * `### <role> · <timestamp>` sub-heading into a {@link ChatThreadMessage}.
- * Non-chat content (anything outside the chat block) is ignored. Returns
- * `thread_title: null` and an empty `messages` array if the note has no
- * chat block.
+ * Content before that title is ignored. `#` / `##` lines inside a message
+ * are kept as markdown. A later `## Chat:` title starts a new title in the
+ * same parse; the walk continues to EOF. Returns `thread_title: null` and
+ * an empty `messages` array if the note has no chat block.
  *
  * @param vault - The vault.
  * @param args - `note_path` is the vault-relative path to the thread note.
@@ -1106,21 +1107,9 @@ export async function chatThreadRead(vault: Vault, args: { note_path: string }):
       continue;
     }
     if (!inThread) continue;
-    // Higher-level heading or a different `## Chat:` block ends the thread.
-    if (/^# /.test(ln) || (/^## /.test(ln) && !CHAT_THREAD_TITLE_RE.test(ln))) {
-      if (current) {
-        messages.push({
-          role: current.role,
-          timestamp: current.timestamp,
-          content: current.lines.join("\n").trim(),
-          line_start: current.line_start,
-          line_end: i
-        });
-        current = null;
-      }
-      inThread = false;
-      continue;
-    }
+    // `#` / `##` lines inside a message are markdown content, not a thread
+    // terminator. A later `## Chat:` title is handled above. The region runs
+    // to EOF or that next title — not to the first heading in a message.
     const headingMatch = CHAT_HEADING_RE.exec(ln);
     if (headingMatch?.[1] && headingMatch[2]) {
       if (current) {

--- a/tests/chat-thread.test.ts
+++ b/tests/chat-thread.test.ts
@@ -169,5 +169,20 @@ describe("chat_thread_read (v2.2.0)", () => {
     expect(result.messages[0]?.content).toContain("Line 1");
     expect(result.messages[0]?.content).toContain("Line 3 after blank");
     expect(result.messages[0]?.content).toContain("- bullet 1");
+
+    // Extra phase: a `#` / `##` line inside a message must not end the thread
+    // or drop later messages. chatThreadAppend writes those bytes verbatim.
+    await chatThreadAppend(v, {
+      note_path: "headed.md",
+      role: "user",
+      content: "Plan:\n\n## Step 1\ndo thing\n\n# Overview"
+    });
+    await chatThreadAppend(v, { note_path: "headed.md", role: "assistant", content: "ok" });
+    const headed = await chatThreadRead(v, { note_path: "headed.md" });
+    expect(headed.message_count).toBe(2);
+    expect(headed.messages[0]?.content).toContain("## Step 1");
+    expect(headed.messages[0]?.content).toContain("# Overview");
+    expect(headed.messages[1]?.role).toBe("assistant");
+    expect(headed.messages[1]?.content).toBe("ok");
   });
 });

--- a/tests/fixtures/release-mutation-transition.v3.json
+++ b/tests/fixtures/release-mutation-transition.v3.json
@@ -46,7 +46,7 @@
       "reason": "reviewed source bytes changed while catalogue identity stayed fixed",
       "witness": {
         "from": "sha256:5b0eff418ec0c12fb950512904762ca5afc9c71c8c09968325c2c08fddbf94de",
-        "to": "sha256:035892efdfc2f9776f196534512244ec31d67557ae6984c008a81406004e6657"
+        "to": "sha256:6d718f65599e4df2760b26422fb40019d78fde2d5107b2e2be65f2461573cbd3"
       }
     },
     {

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -34,7 +34,7 @@ import { releaseMutationVersionedTransitionAuditProblems } from "./release-mutat
 
 const repoRoot = path.resolve(__dirname, "..");
 const RELEASE_MUTATION_IDENTITY_FIXTURE_SHA256 = "8205d24e6d42dd4cb8986368611514131abe701434beb30150e33ea08f4b1288";
-const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "daaec3679a3f0373002315f2a91375380967b8e28b9c087488daea86310bbb9d";
+const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "e51c1757855901fd1f2187791b49c8b6ec7a2e4649bace3d410ef16ea5ea4d6d";
 const releaseMutationIdentityFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-identity.v2.json");
 const releaseMutationTransitionFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-transition.v3.json");
 const releaseIntegritySourcePath = path.join(repoRoot, "tests/release-integrity.test.ts");


### PR DESCRIPTION
## What's in this PR

**`obsidian_chat_thread_read` no longer treats a `#` or `##` line inside a message as the end of the thread.**

The parser stopped at the first such heading, flushed the current message, set `inThread = false`, and reported `message_count` for only the truncated prefix. A later `### user|assistant|system ·` message in the same `## Chat:` block was dropped. `chatThreadAppend` writes message bodies verbatim, so a plan that contains `## Step 1` was enough.

The chat region now runs until EOF or a later `## Chat:` title line. `#`/`##` inside a message stay content.

## Tests

Extra phase of the existing `handles multi-line message content correctly (preserves markdown)` test (no new `it()`): append a user message containing both heading levels, then an assistant reply, and require `message_count === 2` with both heading strings in the user body.

## Bounds

- Does **not** fence-scan message bodies.
- A `## Chat:` line still starts a new title.
- Trailing vault sections after the last message (`## Notes`) are absorbed into that last message rather than truncating the thread.
- Does **not** change `chatThreadAppend` write behavior, search, or other tools.

The MCP tool description and `docs/api.md` state that in-message `#`/`##` are kept. The full bound lives in CHANGELOG.

## Plan

BACKLOG §1.CC-ter **B5**, remaining MED (chatThreadRead). Other remaining B5 MEDs stay separate. No tag, no npm publish.

Base: exact main `1bb9245df7ef83f1244a16b71ffe02ead925a966` (PR #528).
