### PR TITLE
fix: classify proposal tags against the listTags ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Note-proposal tag classification uses the listTags API ceiling
+
+> **TL;DR:** **`obsidian_validate_note_proposal` no longer classifies a live vault tag as `new` just because it is not in the top 200 by count.** Tag pre-classification called `listTags(vault, {})`, which defaults to a 200-row dashboard slice. Existing tags sorted after that slice were missing from the lookup set, so a proposal that reused them got `status: "new"` and a `new-tag` warning. The call now passes `limit: 2000`, the same ceiling the `listTags` function and `obsidian_list_tags` MCP schema already enforce.
+>
+> **Bounded claim.** This does **not** raise the `listTags` presentation ceiling, does **not** scan past `MAX_TAG_DISTINCT` / incomplete inventory throws, and does **not** change `obsidian_list_tags` default 200. Vaults with more than 2000 distinct tags can still misclassify tags outside that slice. It does **not** change wikilink, YAML, or path-collision arms.
+>
+> **Method note:** BACKLOG §1.CC-ter **B5**, remaining MED. Coverage is an extra phase of the existing `flags new tags so the LLM doesn't fork a tag forest` test, so the source `it()` census does not move. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Classification uses `limit: 2000`.** That is the existing `listTags` TypeError ceiling, not a new API.
+- **A 201st-by-sort existing tag stays `existing`.** The extra phase builds an isolated vault with `planning` plus 200 `a000`–`a199` tags (equal count, earlier alphabet) and requires a proposal that reuses `planning` not to warn `new-tag`.
+
 ### Chat thread read keeps headings inside messages
 
 > **TL;DR:** **`obsidian_chat_thread_read` no longer treats a `#` or `##` line inside a message as the end of the thread.** The parser stopped at the first such heading, flushed the current message, set `inThread = false`, and reported `message_count` for only the truncated prefix. A later `### user|assistant|system ·` message in the same `## Chat:` block was dropped. `chatThreadAppend` writes message bodies verbatim, so a plan that contains `## Step 1` was enough. The chat region now runs until EOF or a later `## Chat:` title line.

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -321,7 +321,10 @@ export async function validateNoteProposal(vault: Vault, args: ValidateProposalA
   }
 
   // 4. Tag pre-classification (existing vs new).
-  const existingTags = new Set((await listTags(vault, {})).map((t) => foldTag(t.tag)));
+  // listTags defaults to a 200-row dashboard slice; classification must use the
+  // function's existing 2000 ceiling so a live tag sorted after the top 200 is
+  // not reported as new. Vaults with more than 2000 distinct tags remain bounded.
+  const existingTags = new Set((await listTags(vault, { limit: 2000 })).map((t) => foldTag(t.tag)));
   const proposedTagsRaw = new Set<string>();
   // Frontmatter tags.
   const fmData = yamlReport.parsed ? parseFrontmatter(args.content).data : {};

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -709,6 +709,27 @@ describe("validateNoteProposal — anti-slop write linter (v0.12)", () => {
     expect(newTags.map((t) => t.name)).toContain("brand-new-tag-xyzzy");
     expect(result.tags.find((t) => t.name === "planning")?.status).toBe("existing");
     expect(result.warnings.some((w) => w.kind === "new-tag" && w.message.includes("brand-new-tag-xyzzy"))).toBe(true);
+
+    // Extra phase: default listTags limit is 200 (dashboard). Classification
+    // must not treat a real vault tag as new just because 200 other tags sort
+    // ahead of it. Isolated vault so the shared fixture stays at 3 notes.
+    const crowded = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-validate-tags-"));
+    try {
+      await fs.writeFile(path.join(crowded, "planning.md"), "---\ntags: [planning]\n---\n\nbody.\n");
+      for (let i = 0; i < 200; i++) {
+        const tag = `a${String(i).padStart(3, "0")}`;
+        await fs.writeFile(path.join(crowded, `${tag}.md`), `---\ntags: [${tag}]\n---\n\nbody.\n`);
+      }
+      const crowdedVault = new Vault(crowded);
+      const crowdedResult = await validateNoteProposal(crowdedVault, {
+        path: "Inbox/reuse-planning.md",
+        content: "---\ntags: [planning]\n---\n\nbody.\n"
+      });
+      expect(crowdedResult.tags.find((t) => t.name === "planning")?.status).toBe("existing");
+      expect(crowdedResult.warnings.some((w) => w.kind === "new-tag" && w.message.includes("planning"))).toBe(false);
+    } finally {
+      await fs.rm(crowded, { recursive: true, force: true });
+    }
   });
 
   it("path collision in mode=create blocks (errors), in mode=overwrite warns instead", async () => {


### PR DESCRIPTION
## What's in this PR

**`obsidian_validate_note_proposal` no longer classifies a live vault tag as `new` just because it is not in the top 200 by count.**

Tag pre-classification called `listTags(vault, {})`, which defaults to a 200-row dashboard slice. Existing tags sorted after that slice were missing from the lookup set. The call now passes `limit: 2000`, the same ceiling `listTags` and `obsidian_list_tags` already enforce.

## Tests

Extra phase of the existing `flags new tags so the LLM doesn't fork a tag forest` test (no new `it()`): isolated vault with `planning` plus 200 `a000`–`a199` tags (equal count, earlier alphabet); a proposal that reuses `planning` must stay `existing`.

## Bounds

- Does **not** raise the `listTags` presentation ceiling or change `obsidian_list_tags` default 200.
- Vaults with more than 2000 distinct tags can still misclassify tags outside that slice.
- Does **not** change wikilink, YAML, or path-collision arms.

## Plan

BACKLOG §1.CC-ter **B5**, remaining MED (`listTags`). Other remaining B5 MEDs (`doctor READY`, body-bomb) stay separate. No tag, no npm publish.

Base: exact main `10da72a69ace3550a1c698d8e609d32faf4524e7` (PR #529).
