### PR TITLE
fix: skip mismatched wikilink evidence instead of aborting the vault walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Wikilink evidence mismatch does not abort the vault walk
+
+> **TL;DR:** **`obsidian_get_backlinks` and `obsidian_get_unresolved_wikilinks` no longer fail the whole vault because one note's snippet offsets disagree with the original file.** `93e03f28` added `admittedLinkEvidence`, which requires `content.slice(sourceStart, sourceEnd) === "[["+raw+"]]"` after `parseNote` has masked inline code in place. A wikilink whose alias contains matched backticks then throws `"Parsed wikilink evidence no longer matches its source generation"` from the vault walk, with no catcher. The link was already counted (or already known unresolved); only the snippet is unprovable. Those two walkers now skip that snippet/row and continue.
+>
+> **Bounded claim.** This does **not** change `parseNote` / offset preservation, does **not** make `getOutboundLinks` admit snippets (it never called this helper), and does **not** stop a true parse/read failure from failing the tool. `admittedLinkEvidence` still throws for unexpected callers. Other `93e03f28` throw-then-disable sites (`hnswPersistUnsafe`, startup `semanticRouteHealth`, brute-force `captureHnswReceiptSnapshot`) are not this slice.
+>
+> **Method note:** BACKLOG §1.CC-ter **B6**, first product slice of the `93e03f28` unit (what catches this throw, and what does that catcher then disable?). Coverage is extra phases of the existing backlink and unresolved evidence tests: `Poison.md` sorts before `Source.md` and contains a backtick-in-payload wikilink, so an uncaught throw would hide `Source.md`. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Snippet admission is local.** A mismatched evidence span drops that snippet or unresolved row; the rest of the walk continues.
+- **`Poison.md` cannot hide `Source.md`.** The extra phases require the well-formed note to remain in the result after the poison note is added.
+
 ### HTTP body-bomb docs match the live ×6 cap and 413 overflow
 
 > **TL;DR:** **SECURITY.md and the HTTP transport threat model no longer advertise a body cap four times too small, or a 400 for overflow.** Live `deriveHttpBodyCap` is `max(4 MiB, vaultMaxBytes × 6 + 64 KiB)` (~30.06 MiB at the default 5 MiB file cap). Overflow is `413 Request body too large`; `400 Parse error` is only for malformed JSON. The operator docs and the `cli-flag-docs-invariant` body-cap gate still required `× 1.5` / 7.5 MB / `400`, so the gate was false-green for the live formula. This is documentation and invariant honesty. The cap, the 413/400 dispatch, and `tests/http-transport.test.ts` are unchanged.

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -470,10 +470,7 @@ function admittedLinkEvidence(content: string, candidate: LinkCandidate): { star
   return { start, length: end - start };
 }
 
-function tryAdmittedLinkEvidence(
-  content: string,
-  candidate: LinkCandidate
-): { start: number; length: number } | null {
+function tryAdmittedLinkEvidence(content: string, candidate: LinkCandidate): { start: number; length: number } | null {
   try {
     return admittedLinkEvidence(content, candidate);
   } catch (err) {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -470,6 +470,20 @@ function admittedLinkEvidence(content: string, candidate: LinkCandidate): { star
   return { start, length: end - start };
 }
 
+function tryAdmittedLinkEvidence(
+  content: string,
+  candidate: LinkCandidate
+): { start: number; length: number } | null {
+  try {
+    return admittedLinkEvidence(content, candidate);
+  } catch (err) {
+    if (err instanceof Error && err.message === "Parsed wikilink evidence no longer matches its source generation") {
+      return null;
+    }
+    throw err;
+  }
+}
+
 /**
  * Find every note that links to the target — the "who references this?"
  * query.
@@ -522,9 +536,11 @@ export async function getBacklinks(
       count += 1;
       kindFlags[kind] = true;
       if (snippets.length < 2) {
-        const evidence = admittedLinkEvidence(content, { link, kind });
-        const { snippet } = sliceSnippet(content, evidence.start, evidence.length);
-        if (snippet) snippets.push(snippet);
+        const evidence = tryAdmittedLinkEvidence(content, { link, kind });
+        if (evidence !== null) {
+          const { snippet } = sliceSnippet(content, evidence.start, evidence.length);
+          if (snippet) snippets.push(snippet);
+        }
       }
     }
     if (count === 0) continue;
@@ -643,7 +659,8 @@ export async function getUnresolvedWikilinks(
       if (!link.target) continue;
       const match = findBestMatch(all, link.target, e.relPath);
       if (match) continue;
-      const evidence = admittedLinkEvidence(content, { link, kind });
+      const evidence = tryAdmittedLinkEvidence(content, { link, kind });
+      if (evidence === null) continue;
       const { snippet, line } = sliceSnippet(content, evidence.start, evidence.length);
       out.push({
         from_path: e.relPath,

--- a/tests/link-evidence-offsets.test.ts
+++ b/tests/link-evidence-offsets.test.ts
@@ -45,6 +45,10 @@ describe("wikilink source evidence", () => {
     expect(hits[0]?.snippet).toContain("real-one");
     expect(hits[1]?.snippet).toContain("real-two");
     expect(hits.map((hit) => hit.snippet).join("\n")).not.toContain("fenced-decoy");
+
+    await fs.writeFile(path.join(root, "Poison.md"), "See [[Missing|see `x`]]\n");
+    const poisoned = await getUnresolvedWikilinks(vault, { limit: 10 });
+    expect(poisoned.some((hit) => hit.from_path === "Source.md" && hit.snippet.includes("real-one"))).toBe(true);
   });
 
   it("uses admitted offsets for backlink snippets with duplicate literals", async () => {
@@ -70,6 +74,15 @@ describe("wikilink source evidence", () => {
     expect(hits[0]?.snippets[0]).toContain("real-one");
     expect(hits[0]?.snippets[1]).toContain("real-two");
     expect(hits[0]?.snippets.join("\n")).not.toContain("fenced-decoy");
+
+    // 93e03f28 admitted snippet offsets against the original file after
+    // parseNote masked inline code in place. A wikilink whose alias
+    // contains matched backticks then throws, aborting the vault walk.
+    // Poison.md sorts before Source.md, so an uncaught throw hides Source.
+    await fs.writeFile(path.join(root, "Poison.md"), "See [[Target|see `x`]]\n");
+    const poisoned = await getBacklinks(vault, { path: "Target.md", limit: 10 });
+    expect(poisoned.some((hit) => hit.path === "Source.md")).toBe(true);
+    expect(poisoned.some((hit) => hit.path === "Poison.md")).toBe(true);
   });
 
   it("preserves interleaved embed/wikilink source order", async () => {


### PR DESCRIPTION
## Why

`93e03f28` added `admittedLinkEvidence` with no catcher in `getBacklinks` / `getUnresolvedWikilinks`. `parseNote` masks inline code in place (`preserveOffsets`), so `raw` is taken from the sanitized string while admission checks the original file. A wikilink whose alias contains matched backticks then throws `"Parsed wikilink evidence no longer matches its source generation"` and aborts the vault walk. `Poison.md` sorts before `Source.md`, so one poisoned note hides every later hit.

## What

- `admittedLinkEvidence` still throws (fail-closed helper).
- New `tryAdmittedLinkEvidence` returns `null` only for that exact Error message; anything else rethrows.
- `getBacklinks`: after the hit is counted, skip the unprovable snippet and continue.
- `getUnresolvedWikilinks`: skip that unresolved row and continue.
- Extra phases of the existing evidence tests: `Poison.md` = `[[Target|see \`x\`]]` / `[[Missing|see \`x\`]]`. No new `it()`.
- Follow-up: biome wanted the wrapper signature on one line (`20a6c05` lint red). Claim surface unchanged.

## Bound

This does not change `parseNote` / offset preservation. `getOutboundLinks` never called this helper. Other `93e03f28` throw-then-disable sites (`hnswPersistUnsafe`, startup `semanticRouteHealth`, brute-force `captureHnswReceiptSnapshot`) are not this slice.

CHANGELOG is the bound document.

## D-73

Pass 1 CONFIRMED `20a6c05` (session `01a04606-20df-7372-87df-b39958b4150b`). Format-only follow-up does not reopen the honesty round: claim surface unchanged.

## D-45 / D-72

Hosted CI is the executable proof. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
