### PR TITLE
fix: do not quarantine brute search on HNSW snapshot failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Incomplete embedding generation does not quarantine brute-force semantic search
+
+> **TL;DR:** **`obsidian_embeddings_search` (and the embeddings arm of `obsidian_search`) no longer stay down for the life of a `serve` process because HNSW snapshot admission refused one declared source.** After brute ranking stopped calling the snapshot helper, `prepareServerDeps` still ran `captureHnswReceiptSnapshot()` on the brute-only startup path and latched `semanticUsable=false` on any throw. The `--use-hnsw` catch did the same for `EmbedSnapshotIntegrityError` / `EmbedSnapshotCapacityError`. Serve-path search then threw `SEMANTIC_ROUTE_QUARANTINED` even though remaining well-formed rows were rankable. Brute-only startup no longer opens a second EmbedDb for that snapshot. HNSW integrity/capacity failures now leave the brute route up (`hnswContext` null), matching a missing/corrupt sidecar.
+>
+> **Bounded claim.** This does **not** change `captureHnswReceiptSnapshot` itself or `hnswPersistUnsafe`. Mixed-generation after awaited filesystem work is still refused by `captureGenerationIdentity`. Live pending-queue overflow may still latch `semanticUsable` (B0). Incomplete declared sources remain an HNSW-snapshot refusal, not a process-wide semantic quarantine.
+>
+> **Method note:** BACKLOG §1.CC-ter **B6**, third product slice of the `93e03f28` unit. Coverage is a retarget of the existing `it.each([false, true])` complete-admission test: an extra `Healthy.md` sibling must remain searchable after `Semantic.md`'s `n_chunks` is poked incomplete, `semanticUsable` stays true, `buildHnsw` is uncalled, and brute-only startup must not log the old quarantine line. No new `it()`. K-1 pins drop the removed integrity EmbedDb site. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Brute-only startup does not run the HNSW envelope.** `prepareServerDeps` no longer opens `integrityDb` to call `captureHnswReceiptSnapshot` when `--use-hnsw` is off.
+- **HNSW snapshot failure is an optimization miss.** Integrity/capacity errors leave `semanticUsable` true and `hnswContext` null so brute ranking can still return remaining current-source rows.
+
 ### Brute-force embedding search does not run the HNSW graph envelope
 
 > **TL;DR:** **`obsidian_embeddings_search` (and the embeddings arm of `obsidian_search`) no longer fail a whole brute-force query because HNSW snapshot admission refused the corpus.** `93e03f28` called `captureHnswReceiptSnapshot()` inside `searchReceiptRows` and discarded the return, so ranking inherited the HNSW envelope (`MAX_HNSW_SNAPSHOT_ROWS = 250_000`, 64 MiB text, complete `n_chunks`). One incomplete declared source or over-envelope corpus threw `EmbedSnapshotIntegrityError` / `EmbedSnapshotCapacityError` with no catcher, including `--use-hnsw` off. Ranking still uses one SQLite transaction; mixed-generation after awaited filesystem work is still refused by `captureGenerationIdentity`. HNSW build/load still use the snapshot helper.

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,8 +5,6 @@ import {
   assertEmbedDbRecoveryOwnership,
   discoverEmbedDbConfig,
   EmbedDb,
-  EmbedSnapshotCapacityError,
-  EmbedSnapshotIntegrityError,
   type HnswPersistenceReceipt,
   type HnswPersistenceRow,
   hnswPersistBase,
@@ -489,7 +487,6 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
   let ftsIndex: FtsIndex | null = null;
   let watcher: VaultWatcher | null = null;
   let watcherEmbedDb: EmbedDb | null = null;
-  let integrityDb: EmbedDb | null = null;
   let hnswSnapshotDb: EmbedDb | null = null;
   let hnswContext: ServerDeps["hnswContext"] = null;
   let hnswPersistenceLifetime: PersistenceFamilyLeaseHandle | null = null;
@@ -771,43 +768,6 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
     }
 
     const semanticRouteHealth = watcher?.searchHealth ?? { semanticUsable: true, hnswUsable: true };
-    // HNSW is optional, but embedding-generation integrity is not. Admit the
-    // complete durable generation once even on the brute-force route so a
-    // missing declared chunk or malformed row cannot be laundered into partial
-    // semantic results merely because --use-hnsw is off.
-    if (startupEmbedDbAvailable && !opts.useHnsw) {
-      try {
-        const discovered = await discoverEmbedDbConfig(startupEmbedFile, vault.root);
-        if (discovered.kind === "missing" || discovered.kind === "refused") {
-          throw new EmbedSnapshotIntegrityError("Embedding index configuration could not be verified");
-        }
-        const storedConfiguration =
-          discovered.kind === "owned" ? resolveStoredEmbeddingConfiguration(discovered.meta) : null;
-        const model = storedConfiguration?.model ?? resolveModel(undefined);
-        integrityDb = new EmbedDb({
-          file: startupEmbedFile,
-          vaultRoot: vault.root,
-          modelAlias: model.alias,
-          dim: model.dim,
-          quantization: storedConfiguration?.quantization ?? opts.quantizeEmbeddings ?? "f32"
-        });
-        await integrityDb.open(discovered);
-        integrityDb.captureHnswReceiptSnapshot();
-      } catch (err) {
-        semanticRouteHealth.semanticUsable = false;
-        semanticRouteHealth.hnswUsable = false;
-        process.stderr.write(
-          `enquire: embedding generation failed complete semantic admission; semantic search is quarantined — ${
-            err instanceof Error ? err.message : String(err)
-          }\n`
-        );
-      } finally {
-        if (integrityDb) {
-          await integrityDb.closeAndRelease();
-          integrityDb = null;
-        }
-      }
-    }
 
     // v2.13.0 — opt-in HNSW approximate nearest-neighbor index. Built in-memory
     // on serve start from the embed-db rows instead of the O(n) brute-force
@@ -1058,22 +1018,13 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
             "HNSW startup failed and persistence cleanup was incomplete"
           );
         }
-        if (err instanceof EmbedSnapshotIntegrityError || err instanceof EmbedSnapshotCapacityError) {
-          // A corrupt/incomplete or over-envelope durable DB is not an HNSW-only
-          // optimization failure. Quarantine the shared semantic capability so
-          // the brute path cannot return a surviving partial generation.
-          semanticRouteHealth.semanticUsable = false;
-          semanticRouteHealth.hnswUsable = false;
-          process.stderr.write(
-            `enquire: embedding generation failed complete semantic admission; semantic search is quarantined — ${err.message}\n`
-          );
-        } else {
-          // Native/sidecar-specific failures remain an optimization miss: the
-          // already-admitted EmbedDb can safely serve the brute-force route.
-          process.stderr.write(
-            `enquire: HNSW build failed; falling back to brute-force semantic search — ${err instanceof Error ? err.message : String(err)}\n`
-          );
-        }
+        // Incomplete/over-envelope snapshot admission and native/sidecar
+        // failures are both HNSW-optimization misses. Brute EmbedDb can still
+        // rank current well-formed rows; process-wide semanticUsable stays up.
+        // Live pending-queue overflow may still latch it (B0).
+        process.stderr.write(
+          `enquire: HNSW build failed; falling back to brute-force semantic search — ${err instanceof Error ? err.message : String(err)}\n`
+        );
         hnswContext = null;
       }
     }
@@ -1175,13 +1126,10 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
     };
   } catch (error) {
     const temporaryCleanupErrors: unknown[] = [];
-    for (const db of new Set(
-      [integrityDb, hnswSnapshotDb].filter((candidate): candidate is EmbedDb => candidate !== null)
-    )) {
+    if (hnswSnapshotDb) {
       try {
-        await db.closeAndRelease();
-        if (integrityDb === db) integrityDb = null;
-        if (hnswSnapshotDb === db) hnswSnapshotDb = null;
+        await hnswSnapshotDb.closeAndRelease();
+        hnswSnapshotDb = null;
       } catch (cleanupError) {
         temporaryCleanupErrors.push(cleanupError);
       }

--- a/tests/fixtures/release-mutation-transition.v3.json
+++ b/tests/fixtures/release-mutation-transition.v3.json
@@ -178,7 +178,7 @@
       "reason": "reviewed source bytes changed while catalogue identity stayed fixed",
       "witness": {
         "from": "sha256:c2a1b4125ec2836e34c38160ceff4676ea584e86acbe86edd1a0705dbb63c65e",
-        "to": "sha256:20cf4d01ec7b5b91f5efaa647dcd7d2a1802143b6edbad1805a1a24593bc2b40"
+        "to": "sha256:1782414fbd01300df476da65632a8b7b4da17d9ceb059753ac05cd19d3a3c683"
       }
     },
     {

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -108,9 +108,9 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
     sha256: "7b894cbf9487ed799e090cceea745217012fa9d3e0d6bb07b481f8d0ab4cde26"
   },
   "src/server.ts": {
-    constructors: { EmbedDb: 3, FtsIndex: 1 },
+    constructors: { EmbedDb: 2, FtsIndex: 1 },
     discoveries: {
-      discoverEmbedDbConfig: 3,
+      discoverEmbedDbConfig: 2,
       discoverEmbedDbConfigCached: 0,
       discoverFtsIndexConfig: 1
     },
@@ -123,8 +123,8 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "./fts5.js|assertTokenizeMode|assertTokenizeMode",
       "./fts5.js|discoverFtsIndexConfig|discoverFtsIndexConfig"
     ],
-    k1Opens: 4,
-    sha256: "a577f4eb5ec7a973bba9def32f43c75110ec7bec5c8ff6eed104b46697387496"
+    k1Opens: 3,
+    sha256: "064153c91b0867aae7400ddbabb6fd06f566995a667014015a8c58497ce9b1d9"
   },
   "src/tools/search.ts": {
     constructors: { EmbedDb: 1, FtsIndex: 0 },
@@ -2802,8 +2802,8 @@ async function discoverEmbedDbConfigCached(file, vaultRoot) {
     const pinnedServer = await fs.readFile(pinnedServerPath, "utf8");
     const missingServerOpen = replaceExactly(
       pinnedServer,
-      "      await integrityDb.open(discovered);",
-      "      void integrityDb;"
+      "          await watcherEmbedDb.open(discovered);",
+      "          void watcherEmbedDb;"
     );
     const serverPin = PRODUCTION_FILE_PINS["src/server.ts"];
     expect(serverPin).toBeDefined();

--- a/tests/k1-class-invariant.test.ts
+++ b/tests/k1-class-invariant.test.ts
@@ -48,7 +48,7 @@ const DISCOVERY_MARKERS = ["discoverEmbedDbConfig", "discoverEmbedDbConfigCached
 const SAFE_MARKER = "SAFE BY DESIGN";
 // Context window — must accommodate discovery, fail-closed state branching,
 // and supported-config projection before construction. The caller-pattern
-// inventory below separately proves exact def-use/order at all eleven sites.
+// inventory below separately proves exact def-use/order at all ten sites.
 const CONTEXT_LINES = 128;
 
 interface ConstructorSite {
@@ -70,7 +70,7 @@ interface ProductionConfigurationCall {
 
 const EXPECTED_PRODUCTION_DISCOVERY_CALLS: Readonly<Record<string, Readonly<Record<string, number>>>> = {
   "src/cli.ts": { discoverEmbedDbConfig: 2, discoverFtsIndexConfig: 4 },
-  "src/server.ts": { discoverEmbedDbConfig: 3, discoverFtsIndexConfig: 1 },
+  "src/server.ts": { discoverEmbedDbConfig: 2, discoverFtsIndexConfig: 1 },
   "src/tools/search.ts": { discoverEmbedDbConfigCached: 1 }
 };
 const CONFIGURATION_DEFINING_MODULES = new Set(["src/embed-db.ts", "src/fts5.ts"]);
@@ -98,7 +98,7 @@ function productionConfigurationCalls(file: string, source: string): ProductionC
   return calls;
 }
 
-/** Pin all production callers to the reviewed eleven-site fail-closed inventory. */
+/** Pin all production callers to the reviewed ten-site fail-closed inventory. */
 function productionConfigurationInventoryProblems(calls: readonly ProductionConfigurationCall[]): string[] {
   const problems: string[] = [];
   const counts = new Map<string, number>();
@@ -123,8 +123,8 @@ function productionConfigurationInventoryProblems(calls: readonly ProductionConf
       if (actual !== expected) problems.push(`${file} ${name}: expected ${expected}, found ${actual}`);
     }
   }
-  if (productionDiscoveryTotal !== 11) {
-    problems.push(`global production discovery inventory: expected 11, found ${productionDiscoveryTotal}`);
+  if (productionDiscoveryTotal !== 10) {
+    problems.push(`global production discovery inventory: expected 10, found ${productionDiscoveryTotal}`);
   }
   return problems;
 }
@@ -339,12 +339,6 @@ function configurationDiscoveryRootProblems(cliSource: string, serverSource: str
       expected: 2
     },
     {
-      label: "server non-HNSW integrity Embed canonical-root discovery",
-      source: serverSource,
-      needle: "discoverEmbedDbConfig(startupEmbedFile, vault.root)",
-      expected: 1
-    },
-    {
       label: "search cached Embed canonical-root discovery",
       source: searchSource,
       needle: "discoverEmbedDbConfigCached(embedFile, vault.root)",
@@ -360,7 +354,7 @@ function configurationDiscoveryRootProblems(cliSource: string, serverSource: str
     { label: "CLI FTS", source: cliSource, marker: "discoverFtsIndexConfig(", expected: 4 },
     { label: "CLI Embed", source: cliSource, marker: "discoverEmbedDbConfig(", expected: 2 },
     { label: "server FTS", source: serverSource, marker: "discoverFtsIndexConfig(", expected: 1 },
-    { label: "server Embed", source: serverSource, marker: "discoverEmbedDbConfig(", expected: 3 },
+    { label: "server Embed", source: serverSource, marker: "discoverEmbedDbConfig(", expected: 2 },
     { label: "search cached Embed", source: searchSource, marker: "discoverEmbedDbConfigCached(", expected: 1 },
     { label: "CLI legacy FTS peek", source: cliSource, marker: "peekFtsMetaSafe(", expected: 0 },
     { label: "CLI legacy Embed peek", source: cliSource, marker: "peekEmbedDbMeta(", expected: 0 },
@@ -377,8 +371,8 @@ function configurationDiscoveryRootProblems(cliSource: string, serverSource: str
     countLiteral(cliSource, "discoverEmbedDbConfig(") +
     countLiteral(serverSource, "discoverEmbedDbConfig(") +
     countLiteral(searchSource, "discoverEmbedDbConfig(");
-  if (uncachedEmbedDiscoveries !== 5) {
-    problems.push(`uncached Embed discovery inventory: expected 5, found ${uncachedEmbedDiscoveries}`);
+  if (uncachedEmbedDiscoveries !== 4) {
+    problems.push(`uncached Embed discovery inventory: expected 4, found ${uncachedEmbedDiscoveries}`);
   }
   return problems;
 }
@@ -406,7 +400,7 @@ interface FailClosedCallerSpec {
   openFailurePolicy?: "finally-propagate" | "rethrow" | "fail-soft-null";
 }
 
-/** Build the reviewed one-to-one fail-closed contract for all eleven production callers. */
+/** Build the reviewed one-to-one fail-closed contract for all ten production callers. */
 function failClosedCallerSpecs(cliSource: string, serverSource: string, searchSource: string): FailClosedCallerSpec[] {
   return [
     {
@@ -526,21 +520,6 @@ function failClosedCallerSpecs(cliSource: string, serverSource: string, searchSo
       className: "EmbedDb",
       discoveryBinding: "discovered",
       instanceBinding: "watcherEmbedDb"
-    },
-    {
-      label: "server non-HNSW integrity Embed",
-      source: serverSource,
-      start: "if (startupEmbedDbAvailable && !opts.useHnsw) {",
-      end: "// v2.13.0 — opt-in HNSW",
-      discovery: "discoverEmbedDbConfig(startupEmbedFile, vault.root)",
-      refusal: 'if (discovered.kind === "missing" || discovered.kind === "refused")',
-      refusalEffect: 'throw new EmbedSnapshotIntegrityError("Embedding index configuration could not be verified");',
-      reviewedTryAncestors: 1,
-      resolver: "resolveStoredEmbeddingConfiguration(discovered.meta)",
-      acquisition: "new EmbedDb({",
-      className: "EmbedDb",
-      discoveryBinding: "discovered",
-      instanceBinding: "integrityDb"
     },
     {
       label: "server HNSW Embed",
@@ -1269,7 +1248,7 @@ function hoistedInstanceCaptureInvokedBeforeOpen(
 }
 
 /**
- * Bind each of the eleven preflight reads to exactly one constructor and its
+ * Bind each of the ten preflight reads to exactly one constructor and its
  * first awaited open. Textual proximity is insufficient: the same const
  * binding must cross the discovery -> constructor -> open boundary unchanged.
  */
@@ -1433,8 +1412,8 @@ function configurationDiscoveryOpenBindingProblems(
       problems.push(`${spec.label}: constructed instance is used or reassigned before open`);
     }
   }
-  if (specs.length !== 11) {
-    problems.push(`discovery/open binding inventory: expected 11 specs, found ${specs.length}`);
+  if (specs.length !== 10) {
+    problems.push(`discovery/open binding inventory: expected 10 specs, found ${specs.length}`);
   }
   return problems;
 }
@@ -2585,7 +2564,7 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
     expect(failClosedSpecInventoryProblems(cliSource, serverSource, searchSource, configurationCalls)).toEqual([]);
     expect(storedEmbeddingConfigurationHelperProblems(embeddingsSource)).toEqual([]);
     expect(countLiteral(cliSource, "resolveStoredEmbeddingConfiguration(")).toBe(2);
-    expect(countLiteral(serverSource, "resolveStoredEmbeddingConfiguration(")).toBe(3);
+    expect(countLiteral(serverSource, "resolveStoredEmbeddingConfiguration(")).toBe(2);
     expect(countLiteral(searchSource, "resolveStoredEmbeddingConfiguration(")).toBe(1);
 
     const cliRootFiltersRemoved = replaceExactly(
@@ -2613,25 +2592,20 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
       ])
     );
 
-    const serverRootFiltersRemoved = replaceExactly(
-      replaceAllExactly(
-        replaceExactly(
-          serverSource,
-          "discoverFtsIndexConfig(indexFile, vault.root)",
-          "discoverFtsIndexConfig(indexFile)"
-        ),
-        "discoverEmbedDbConfig(embedFile, vault.root)",
-        "discoverEmbedDbConfig(embedFile)",
-        2
+    const serverRootFiltersRemoved = replaceAllExactly(
+      replaceExactly(
+        serverSource,
+        "discoverFtsIndexConfig(indexFile, vault.root)",
+        "discoverFtsIndexConfig(indexFile)"
       ),
-      "discoverEmbedDbConfig(startupEmbedFile, vault.root)",
-      "discoverEmbedDbConfig(startupEmbedFile)"
+      "discoverEmbedDbConfig(embedFile, vault.root)",
+      "discoverEmbedDbConfig(embedFile)",
+      2
     );
     expect(configurationDiscoveryRootProblems(cliSource, serverRootFiltersRemoved, searchSource)).toEqual(
       expect.arrayContaining([
         "server FTS canonical-root discovery: expected 1, found 0",
-        "server Embed canonical-root discoveries: expected 2, found 0",
-        "server non-HNSW integrity Embed canonical-root discovery: expected 1, found 0"
+        "server Embed canonical-root discoveries: expected 2, found 0"
       ])
     );
 
@@ -2652,7 +2626,7 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
     expect(configurationDiscoveryRootProblems(cliSource, serverSource, searchCacheRemoved)).toEqual(
       expect.arrayContaining([
         "search cached Embed canonical-root discovery: expected 1, found 0",
-        "uncached Embed discovery inventory: expected 5, found 6"
+        "uncached Embed discovery inventory: expected 4, found 5"
       ])
     );
 
@@ -2671,11 +2645,11 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
     expect(rawPeekProblems).toEqual(
       expect.arrayContaining([
         "src/cli.ts discoverFtsIndexConfig: expected 4, found 3",
-        "global production discovery inventory: expected 11, found 10"
+        "global production discovery inventory: expected 10, found 9"
       ])
     );
     expect(failClosedSpecInventoryProblems(rawPeekCli, serverSource, searchSource, rawPeekCalls)).toContain(
-      "fail-closed caller spec inventory: 11 specs for 10 production discoveries"
+      "fail-closed caller spec inventory: 10 specs for 9 production discoveries"
     );
 
     const uncataloguedCaller = productionConfigurationCalls(
@@ -2688,7 +2662,7 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
     expect(productionConfigurationInventoryProblems([...configurationCalls, ...uncataloguedCaller])).toEqual(
       expect.arrayContaining([
         "uncatalogued production discovery caller: src/new-index-caller.ts:2 discoverFtsIndexConfig",
-        "global production discovery inventory: expected 11, found 12"
+        "global production discovery inventory: expected 10, found 11"
       ])
     );
     expect(
@@ -2699,7 +2673,7 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
     ).toEqual(
       expect.arrayContaining([
         "src/new-index-caller.ts discoverFtsIndexConfig: expected 1 fail-closed specs, found 0",
-        "fail-closed caller spec inventory: 11 specs for 12 production discoveries"
+        "fail-closed caller spec inventory: 10 specs for 11 production discoveries"
       ])
     );
 
@@ -2728,15 +2702,6 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
     );
     expect(configurationDiscoveryOpenBindingProblems(cliSource, hnswConstructorAliasDropped, searchSource)).toContain(
       "server HNSW Embed: constructor authority is not passed through one immutable db alias"
-    );
-
-    const integrityWrongDiscovery = replaceExactly(
-      serverSource,
-      "      await integrityDb.open(discovered);",
-      "      await integrityDb.open(discoveredEmbed);"
-    );
-    expect(configurationDiscoveryOpenBindingProblems(cliSource, integrityWrongDiscovery, searchSource)).toContain(
-      "server non-HNSW integrity Embed: awaited open is not bound to the exact discovery const"
     );
 
     const searchDeadOpenDecoy = replaceExactly(
@@ -2995,12 +2960,11 @@ describe("K-1 class invariant (v3.6.3 methodological guard; recursive scan since
       serverSource,
       'if (discovered.kind === "missing" || discovered.kind === "refused")',
       "if (false)",
-      3
+      2
     );
     expect(configurationDiscoveryFailClosedProblems(cliSource, serverEmbedFallbackReenabled, searchSource)).toEqual(
       expect.arrayContaining([
         "server watcher Embed: refused discovery refusal/degrade is missing",
-        "server non-HNSW integrity Embed: refused discovery refusal/degrade is missing",
         "server HNSW Embed: refused discovery refusal/degrade is missing"
       ])
     );

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -34,7 +34,7 @@ import { releaseMutationVersionedTransitionAuditProblems } from "./release-mutat
 
 const repoRoot = path.resolve(__dirname, "..");
 const RELEASE_MUTATION_IDENTITY_FIXTURE_SHA256 = "8205d24e6d42dd4cb8986368611514131abe701434beb30150e33ea08f4b1288";
-const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "efa7ad9b91ef89ab8cad703198124ac371316e98d5b75184ccdbcc03641a16d3";
+const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "0c03846edde047fef252c607bf743e6b17d90eb874ab85d40fd7aa5fd1bb2804";
 const releaseMutationIdentityFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-identity.v2.json");
 const releaseMutationTransitionFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-transition.v3.json");
 const releaseIntegritySourcePath = path.join(repoRoot, "tests/release-integrity.test.ts");

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,11 +316,11 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "e55e091701d76495ba5c3138665e2bfd35942ec6c4013b391f3ce2c387ec7b23" }
+    { count: 4, sha256: "cd08ae1254e5615ba561a782703142699992f1d36b0cd9549598580b9eca31e1" }
   ],
   [
     "k1-class-invariant.test.ts",
-    { count: 102, sha256: "0d3ae28d0035c5baa7a319c61420f8fd28b99cbe09f71eb954684347a1923f06" }
+    { count: 100, sha256: "bba71123746679eb2da9184d7cbf73bace5fba7ce73817c4bac370d57102c9a2" }
   ],
   ["jsonld.test.ts", { count: 11, sha256: "ec02eb24004f2c975daa1b3a668451217e2884cec7cf301e33f91f8bce98d05b" }],
   [
@@ -993,11 +993,11 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["sensitive-reader growth label normalization", "57522a53037186bd73e6009e064f56527b9995826ece3c7c88fdfd2756e6fd23"],
   ["publisher kind label normalization", "dbdbeceb385475c63fdd65c52a02d69f0df72f270fc1733841d7bed3ecc02623"],
   ["hardlink route label normalization", "8869c89d87f15f690cdfbfc352a1d9006a415c200d3880a4e35ad1b3fc148988"],
-  ["K-1 statement semicolon normalization", "c2175a68d2170c6522439bf902f016362959eb2e3f310649d37f174d80cdeee1"],
-  ["K-1 block-comment stripping", "69d0a93af70fcf0a28a62d2f4b69cbcab1eeabe0eace7dfc1b18b34020d3f53c"],
-  ["K-1 line-comment stripping", "69d0a93af70fcf0a28a62d2f4b69cbcab1eeabe0eace7dfc1b18b34020d3f53c"],
-  ["K-1 module-extension normalization", "432236d6a9e45f291e32f5a5ae7a12be0e23474cb942d86b23c09a451b9a2c74"],
-  ["K-1 source-path separator normalization", "2d130e46fcde1c547faa467de907b4e2e560017a54ccf3280c3da01496d3c4cb"],
+  ["K-1 statement semicolon normalization", "16d035dcb619ed86a565e7aa31d24ffe1eaf3be6126768a6934d95ffb5075997"],
+  ["K-1 block-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
+  ["K-1 line-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
+  ["K-1 module-extension normalization", "981b6269d0ffbfc748f4f307f72b3d12866652a01eb9a7a8417de0a6cac60a5f"],
+  ["K-1 source-path separator normalization", "65ffd9d88fe7b7e007739bcce950d39c4a2c0b3c5b381b8a262db61d168400bf"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -1907,9 +1907,35 @@ describe("embeddingsSearch — HNSW database-generation authority", () => {
 
 describe("prepareServerDeps — complete semantic-generation admission", () => {
   it.each([false, true] as const)(
-    "quarantines an incomplete source generation before a semantic query (useHnsw=%s)",
+    "keeps brute-force semantic search when a declared source generation is incomplete (useHnsw=%s)",
     async (useHnsw) => {
       const fixture = await createSemanticAdmissionFixture();
+      const healthyFile = path.join(fixture.vaultRoot, "Healthy.md");
+      await fs.writeFile(healthyFile, "healthy sibling note\n");
+      const healthyStat = await fs.stat(healthyFile);
+      const writer = new EmbedDb({
+        file: fixture.embedFile,
+        vaultRoot: fixture.vaultRoot,
+        modelAlias: "multilingual",
+        dim: 384,
+        quantization: "f32"
+      });
+      await writer.open();
+      try {
+        const vector = new Float32Array(384);
+        vector[0] = 1;
+        writer.upsertNote("Healthy.md", healthyStat.mtimeMs, [
+          {
+            chunkIndex: 0,
+            lineStart: 1,
+            lineEnd: 1,
+            textPreview: "healthy sibling note",
+            vector
+          }
+        ]);
+      } finally {
+        await writer.closeAndRelease();
+      }
       const Database = (await import("better-sqlite3")).default;
       const mutate = new Database(fixture.embedFile);
       try {
@@ -1936,22 +1962,26 @@ describe("prepareServerDeps — complete semantic-generation admission", () => {
           hnswPersist: false
         });
 
-        expect(deps.watcherHealth).toMatchObject({ semanticUsable: false, hnswUsable: false });
+        expect(deps.watcherHealth).toMatchObject({ semanticUsable: true, hnswUsable: true });
         expect(deps.hnswContext).toBeNull();
         expect(buildHnsw).not.toHaveBeenCalled();
-        await expect(
-          isolatedEmbeddingsSearch(
-            deps.vault,
-            { query: "semantic admission marker", limit: 1 },
-            fixture.embedFile,
-            deps.hnswContext,
-            deps.watcherHealth
-          )
-        ).rejects.toThrow(/embedding search is quarantined/i);
+        const result = await isolatedEmbeddingsSearch(
+          deps.vault,
+          { query: "semantic admission marker", limit: 2 },
+          fixture.embedFile,
+          deps.hnswContext,
+          deps.watcherHealth
+        );
+        expect(result.method).toBe("embeddings-cosine");
+        expect(result.matches.map((match) => match.path).sort()).toEqual(["Healthy.md", "Semantic.md"]);
 
         const log = stderr.mock.calls.map(([chunk]) => String(chunk)).join("");
-        expect(log).toMatch(/failed complete semantic admission/i);
-        expect(log).not.toMatch(/falling back to brute-force semantic search/i);
+        expect(log).not.toMatch(/failed complete semantic admission/i);
+        if (useHnsw) {
+          expect(log).toMatch(/HNSW build failed; falling back to brute-force semantic search/i);
+        } else {
+          expect(log).not.toMatch(/falling back to brute-force semantic search/i);
+        }
       } finally {
         stderr.mockRestore();
         resetSemanticAdmissionRuntimeMocks();


### PR DESCRIPTION
## Why

After PR #534, brute ranking no longer calls `captureHnswReceiptSnapshot`, but `prepareServerDeps` still ran that snapshot on the brute-only startup path and latched `semanticUsable=false` on any throw. The `--use-hnsw` catch did the same for `EmbedSnapshotIntegrityError` / `EmbedSnapshotCapacityError`. Serve-path `embeddingsSearch` then threw `SEMANTIC_ROUTE_QUARANTINED` even though remaining well-formed rows were rankable.

## What

- Remove the brute-only `integrityDb` snapshot admission.
- Treat HNSW snapshot integrity/capacity like a missing/corrupt sidecar: leave `semanticUsable` true, `hnswContext` null.
- Retarget the existing `it.each([false, true])`: extra `Healthy.md` remains searchable after `Semantic.md` `n_chunks` is poked incomplete. No new `it()`.
- Refresh K-1 pins for the removed EmbedDb site.

## Bound

This does not change `captureHnswReceiptSnapshot` itself or `hnswPersistUnsafe`. Mixed-generation after awaited filesystem work is still refused by `captureGenerationIdentity`. Live pending-queue overflow may still latch `semanticUsable` (B0). Incomplete declared sources remain an HNSW-snapshot refusal.

CHANGELOG is the bound document.

## D-73

Pass 1 bound to `2ec4673`.

## D-45 / D-72

Hosted CI is the executable proof. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
