### PR TITLE
fix: do not charge vault I/O as open-questions ReDoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Open-questions matching budget does not charge vault I/O as ReDoS
+
+> **TL;DR:** **`obsidian_open_questions` with a caller-supplied pattern no longer rejects a legitimate regex as catastrophic backtracking merely because uncached note reads consumed the matching wall clock.** After 93e rewrote the envelope, `matchDeadline` was `Date.now() + scanBudgetMs` before the uncached walk, and both the pre-`readNoteUncached` check and `flushCandidateBatch` remaining-time math treated vault I/O as matching. `matchingTimeout()` has no inner catcher, so one slow read returned zero questions with a ReDoS error. The budget now decrements only around `matchBatch` and is not reset per note. Incomplete listing still fails closed. The default inline matcher stays uncharged.
+>
+> **Bounded claim.** This does **not** raise `MAX_QUESTION_SCAN_MS`, weaken `isCatastrophicRegex`, or remove the worker sink-bound. A true worker overrun still rejects the pattern. It does **not** return a partial inventory when the bounded listing is incomplete.
+>
+> **Method note:** BACKLOG §1.CC-ter **B6**, fifth product slice of the `93e03f28` unit (what catches this throw, and what does that catcher then disable?). Coverage is an extra phase of the existing non-resetting-deadline test: a `readNoteUncached` delay longer than `scanBudgetMs` must still return the five questions. The detector-missed catastrophic pattern in `redos-guard` must still throw. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Matching time is worker time.** `getOpenQuestions` charges `scanBudgetMs` only around `matchBatch`, not around `readNoteUncached`.
+- **The matching budget is still one walk.** Remaining milliseconds carry across sequential batches and are not reset per note.
+
 ### Per-path quarantine does not permanently skip HNSW persist
 
 > **TL;DR:** **One ordinary note's failed watcher commit no longer disables HNSW persistence (and the live graph) for every other note until restart.** After B0 dropped the process-wide `semanticUsable` latch, `quarantineFailedGeneration` still called `quarantineHnswGeneration` whenever EmbedDb and HNSW were both attached, and the md/pdf commit catchers also set `hnswPersistUnsafe` whenever `this.hnsw` existed. A Map-of-Content that trips `MAX_FTS_LINK_TARGETS` therefore stopped `flushHnswToDisk` for the life of the process even though brute EmbedDb search stayed up. Per-path quarantine now writes the EmbedDb marker with `quarantineSourceIfGeneration` and drops that source's live HNSW labels only while this watcher still owns the generation. Remaining notes can keep using and persisting the graph. A foreign EmbedDb epoch process-quarantines the graph instead of being published.

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -718,15 +718,16 @@ export const MAX_QUESTION_PATTERN_LEN = 200;
 
 /**
  * Hard wall-clock budget (ms) for matching a CALLER-SUPPLIED
- * `obsidian_open_questions` pattern against the vault, enforced by running the
- * match on a WORKER THREAD ({@link matchLinesBounded}). {@link isCatastrophicRegex}
- * is a best-effort static denylist (ReDoS detection is undecidable — a v3.10.0-rc.39
- * re-sweep confirmed a residual tail of nested patterns it under-flags); this is
- * the HARD backstop. Because matching runs off the main thread, the event loop can
- * NEVER hang regardless of pattern, and a pattern that blows the budget is rejected
+ * `obsidian_open_questions` pattern on a WORKER THREAD ({@link matchLinesBounded}).
+ * Charged only while the regex worker runs; uncached note reads and the bounded
+ * listing are not matching time. {@link isCatastrophicRegex} is a best-effort
+ * static denylist (ReDoS detection is undecidable — a v3.10.0-rc.39 re-sweep
+ * confirmed a residual tail of nested patterns it under-flags); this is the HARD
+ * backstop. Because matching runs off the main thread, the event loop can NEVER
+ * hang regardless of pattern, and a pattern that blows the budget is rejected
  * fail-closed. Generous enough that a legit linear pattern over a large vault
  * finishes well under it, while a catastrophic-backtracking pattern (effectively
- * unbounded) is killed.
+ * unbounded) is killed. The budget is not reset per note.
  * @internal v3.10.0-rc.39 — the hard ReDoS sink-bound (closes the static-detector
  *   residual the rc.36 re-sweep surfaced).
  */
@@ -1919,7 +1920,10 @@ export async function getOpenQuestions(
   const now = Date.now();
   const defaultMatcher = new RegExp(defaultPat, "i");
   const matchBatch = execution.matchBatch ?? matchLinesBounded;
-  const matchDeadline = args.pattern === undefined ? 0 : Date.now() + scanBudgetMs;
+  // Remaining matching budget is charged only around matchBatch. Starting a
+  // wall-clock deadline before the uncached walk would reject a legitimate
+  // pattern as ReDoS after a slow note read.
+  let matchingRemainingMs = args.pattern === undefined ? 0 : scanBudgetMs;
   const heap: RankedOpenQuestion[] = [];
   let retainedResultBytes = 0;
   let sequence = 0;
@@ -1959,11 +1963,11 @@ export async function getOpenQuestions(
 
   const flushCandidateBatch = async (): Promise<void> => {
     if (batch.length === 0 || args.pattern === undefined) return;
-    const remaining = Math.floor(matchDeadline - Date.now());
-    if (remaining < 1) throw matchingTimeout();
+    if (matchingRemainingMs < 1) throw matchingTimeout();
     const batchLines = batch.map((candidate) => candidate.text);
-    const rawMatches = await matchBatch(args.pattern, batchLines, Math.min(scanBudgetMs, remaining));
-    if (Date.now() > matchDeadline) throw matchingTimeout();
+    const matchingStartedMs = Date.now();
+    const rawMatches = await matchBatch(args.pattern, batchLines, Math.min(scanBudgetMs, matchingRemainingMs));
+    matchingRemainingMs -= Date.now() - matchingStartedMs;
     for (const match of validateOpenQuestionMatches(rawMatches, batch.length)) {
       const candidate = batch[match.idx];
       if (!candidate) throw new Error("obsidian_open_questions: regex worker returned an invalid match index");
@@ -1974,7 +1978,6 @@ export async function getOpenQuestions(
   };
 
   for (const entry of listing.entries) {
-    if (args.pattern !== undefined && Date.now() >= matchDeadline) throw matchingTimeout();
     const { content, parsed, mtimeMs } = await vault.readNoteUncached(entry.absPath, entry.mtimeMs);
     if (!Number.isFinite(mtimeMs) || Number.isNaN(new Date(mtimeMs).getTime())) {
       throw new Error("obsidian_open_questions: note has an invalid modification time");

--- a/tests/open-questions-admission.test.ts
+++ b/tests/open-questions-admission.test.ts
@@ -105,6 +105,32 @@ describe("getOpenQuestions bounded producer admission", () => {
     expect(budgets.every((budget) => budget > 0 && budget <= 1000)).toBe(true);
     expect(budgets.every((budget, index) => index === 0 || budget <= (budgets[index - 1] ?? 0))).toBe(true);
     expect(out.map((question) => question.question)).toEqual(["one", "two", "three", "four", "five"]);
+
+    const originalRead = vault.readNoteUncached.bind(vault);
+    const read = vi.spyOn(vault, "readNoteUncached").mockImplementation(async (...args) => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return originalRead(...args);
+    });
+    try {
+      const delayed = await getOpenQuestions(
+        vault,
+        { pattern: "^Q: (.+)$", scanBudgetMs: 80 },
+        {
+          limits: { maxWorkerBatchCandidates: 2, maxWorkerBatchUtf8Bytes: 32 },
+          matchBatch: async (pattern, lines) => {
+            const regex = new RegExp(pattern, "i");
+            return lines.flatMap((line, idx) => {
+              const match = regex.exec(line);
+              return match?.[1] === undefined ? [] : [{ idx, q: match[1] }];
+            });
+          }
+        }
+      );
+      expect(read).toHaveBeenCalled();
+      expect(delayed.map((question) => question.question)).toEqual(["one", "two", "three", "four", "five"]);
+    } finally {
+      read.mockRestore();
+    }
   });
 
   it("rejects an invalid batch result instead of trusting an amplified worker payload", async () => {


### PR DESCRIPTION
## Why

B6 slice 4 shipped as squash `cd8805e` (PR #536). Fifth slice of the `93e03f28` unit: `matchingTimeout()` has no inner catcher, so vault I/O charged against `scanBudgetMs` was reported as ReDoS.

## What

- Charge remaining matching milliseconds only around `matchBatch`.
- Remove the pre-`readNoteUncached` wall-clock ReDoS throw.
- Do not reset the matching budget per note.
- Extra phase of the existing non-resetting-deadline test: delay `readNoteUncached` past `scanBudgetMs`; a cheap pattern still returns the five questions.

## Bound

Does not raise `MAX_QUESTION_SCAN_MS`, weaken `isCatastrophicRegex`, or remove the worker sink-bound. Incomplete listing still fails closed. Default inline matcher stays uncharged. No new `it()`.

CHANGELOG is the bound document.

## D-73

Pass 1 CONFIRMED `42deb0891e5615a64f9a9de36625f1ee27680512` (session `01a046ae-3eb4-7c20-8bf0-5e70f7521496`). Cited `file:line` re-opened.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `cd8805e` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
