### PR TITLE
fix: fail closed when queryBase cannot read a listed note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Query-base exact totals do not skip an unreadable listed note
+
+> **TL;DR:** **`obsidian_query_base` no longer reports `total_matched` after silently skipping a listed note whose `readFile` failed.** Incomplete bounded listing already throws so a prefix cannot be called exact. 93e left `catch { continue }` around the per-note read, so an unreadable admitted note vanished from the exact total with no error. An unreadable listed note now fails closed with the same exact-total error class. Malformed frontmatter after a successful read is not this slice.
+>
+> **Bounded claim.** This does **not** invert `if (!listing.complete)` fail-closed. It does **not** invent a skipped-count that still claims exactness over the readable subset. It does **not** change `listBases` malformed-base fallthrough.
+>
+> **Method note:** BACKLOG §1.CC-ter **B6**, sixth product slice of the `93e03f28` unit (what catches this throw, and what does that catcher then disable?). Coverage is an extra phase of the existing incomplete-walk test: after the incomplete-listing spy, a complete listing with one unreadable `done.md` must throw `/cannot report an exact total.*done\\.md/`. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Unreadable listed notes fail closed.** `queryBase` throws instead of `continue` when `readFile` fails for an admitted markdown path.
+- **Incomplete listing is unchanged.** A bounded walk with `complete: false` still throws before any note read.
+
 ### Open-questions matching budget does not charge vault I/O as ReDoS
 
 > **TL;DR:** **`obsidian_open_questions` with a caller-supplied pattern no longer rejects a legitimate regex as catastrophic backtracking merely because uncached note reads consumed the matching wall clock.** After 93e rewrote the envelope, `matchDeadline` was `Date.now() + scanBudgetMs` before the uncached walk, and both the pre-`readNoteUncached` check and `flushCandidateBatch` remaining-time math treated vault I/O as matching. `matchingTimeout()` has no inner catcher, so one slow read returned zero questions with a ReDoS error. The budget now decrements only around `matchBatch` and is not reset per note. Incomplete listing still fails closed. The default inline matcher stays uncharged.

--- a/src/bases.ts
+++ b/src/bases.ts
@@ -587,10 +587,16 @@ export async function queryBase(vault: Vault, args: QueryBaseArgs): Promise<Base
   }
   const notes = listing.entries;
   for (const e of notes) {
+    let raw: string;
+    try {
+      raw = await vault.readFile(e.absPath);
+    } catch {
+      // A listed note that cannot be read makes total_matched inexact.
+      throw new Error(`obsidian_query_base cannot report an exact total; unreadable note ${e.relPath}`);
+    }
     let fm: Record<string, unknown> = {};
     let body = "";
     try {
-      const raw = await vault.readFile(e.absPath);
       const parsed = parseFrontmatter(raw);
       assertBoundedBaseJson(parsed.data, `Frontmatter in ${e.relPath}`);
       fm = (parsed.data as Record<string, unknown>) ?? {};

--- a/tests/bases.test.ts
+++ b/tests/bases.test.ts
@@ -668,6 +668,21 @@ views:
     await expect(queryBase(vault, { path: "q.base" })).rejects.toThrow(/cannot report an exact total.*23/u);
     expect(bounded).toHaveBeenCalledWith([".md"], 50_000, 200_000, undefined);
     expect(readFile).not.toHaveBeenCalled();
+
+    bounded.mockRestore();
+    readFile.mockRestore();
+    const originalRead = vault.readFile.bind(vault);
+    const unreadable = vi.spyOn(vault, "readFile").mockImplementation(async (relOrAbs) => {
+      if (String(relOrAbs).replace(/\\/g, "/").endsWith("done.md")) {
+        throw new Error("synthetic unreadable note");
+      }
+      return originalRead(relOrAbs);
+    });
+    try {
+      await expect(queryBase(vault, { path: "q.base" })).rejects.toThrow(/cannot report an exact total.*done\.md/u);
+    } finally {
+      unreadable.mockRestore();
+    }
   });
 
   it("skips cyclic and aliased note frontmatter before recursive filter evaluation", async () => {


### PR DESCRIPTION
## Why

B6 slice 5 shipped as squash `928bff1` (PR #537). Sixth slice of the `93e03f28` unit: incomplete listing already throws so `total_matched` cannot lie about a prefix, but `catch { continue }` still omitted an unreadable listed note.

## What

- Split the per-note try: `readFile` failure throws `obsidian_query_base cannot report an exact total; unreadable note …`.
- Frontmatter/assertBoundedBaseJson failures after a successful read still `continue`.
- Extra phase of the existing incomplete-walk test: complete listing, `readFile` throws on `done.md`.

## Bound

Does not invert incomplete-listing fail-closed. Does not invent a skipped-count. Does not change `listBases` malformed-base fallthrough. No new `it()`.

CHANGELOG is the bound document.

## D-73

Pass 1 CONFIRMED `805ea7948459b7a771b2cd9d0940da7f560410d4` (session `01a046c3-19fb-7fa3-bafd-9d3b56c925f2`). Cited `file:line` re-opened.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `928bff1` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
