### PR TITLE
fix: do not report rename success when source unlink fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Exclusive rename does not report success when source unlink fails
+
+> **TL;DR:** **`renameFile` no longer returns success when the default exclusive move linked the destination but failed to remove the source path.** The swallowed `fs.unlink(fromAbs).catch(() => {})` left the note at both paths as two hardlinks; `renameNote` then rewrote vault-wide backlinks on a false premise, and the watcher never saw an unlink. Source removal now goes through `unlinkSafe` and the error surfaces. The leftover pair remains recoverable; the receipt is no longer a lie.
+>
+> **Bounded claim.** This does **not** change the EXDEV copy+unlink path (already `unlinkSafe`, still a single unlink). It does **not** reset commit flags after a later fallible `stat` (A4). It does **not** fold `appendNote` post-write stat/close (H4).
+>
+> **Method note:** BACKLOG §1.CC **A3**. Coverage is an extra phase of the existing exclusive-admission test: after a successful `linkSafe` to a missing destination, `unlinkSafe` rejects and `renameFile` must throw while both paths still hold the source bytes. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Source unlink is part of the move receipt.** Post-`linkSafe` cleanup uses `unlinkSafe` instead of a swallowed raw `fs.unlink`.
+- **`renameNote` cannot rewrite backlinks on a false move.** A failed source removal throws before `{ from, to }` is returned.
+
 ### Query-base exact totals do not skip an unreadable listed note
 
 > **TL;DR:** **`obsidian_query_base` no longer reports `total_matched` after silently skipping a listed note whose `readFile` failed.** Incomplete bounded listing already throws so a prefix cannot be called exact. 93e left `catch { continue }` around the per-note read, so an unreadable admitted note vanished from the exact total with no error. An unreadable listed note now fails closed with the same exact-total error class. Malformed frontmatter after a successful read is not this slice.

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -2200,8 +2200,10 @@ export class Vault {
       needsExclusiveMove = true;
     }
     if (needsExclusiveMove) {
+      let linked = false;
       try {
         await this.linkSafe(fromAbs, toAbs);
+        linked = true;
       } catch (err) {
         if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST") {
           if (destinationWasPlannedMissing) throw new RenameDestinationChangedError(toRelNorm);
@@ -2233,14 +2235,14 @@ export class Vault {
         }
       }
       // link() succeeded — source still exists at fromAbs as a hard link.
-      // Unlink it to complete the move semantic. If unlink fails the user
-      // sees a still-present fromAbs alongside the new toAbs (hard-linked,
-      // same inode on POSIX); re-running renameFile will see toAbs exists
-      // and reject — but the duplicate is a recoverable state, not data
-      // loss, which is the v3.7.13 M1 recovery posture.
-      await fs.unlink(fromAbs).catch(() => {
-        // Best-effort cleanup; toAbs is the canonical truth.
-      });
+      // Unlink through unlinkSafe so a failed source removal is not reported
+      // as a completed rename. The leftover hardlink pair is recoverable, but
+      // renameNote must not rewrite backlinks on a false move receipt.
+      // The EXDEV copy path already unlinked; a second unlinkSafe would ENOENT
+      // after a completed move (the swallowed fs.unlink.catch used to hide both).
+      if (linked) {
+        await this.unlinkSafe(fromAbs);
+      }
     }
     this.deleteCacheEntry(fromAbs);
     this.deleteCacheEntry(toAbs);

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -299,6 +299,35 @@ describe("createNote", () => {
     } else if (process.platform === "linux" && process.env.CI) {
       throw new Error("mandatory Linux case-sensitive filesystem precondition failed for Hardlink.md/hardlink.md");
     }
+
+    const unlinkRoot = path.join(root, "F2-source-unlink-root");
+    await fs.mkdir(unlinkRoot, { recursive: true });
+    const unlinkSourceRel = "UnlinkSource.md";
+    const unlinkDestRel = "UnlinkDest.md";
+    const unlinkSourceBytes = "source unlink sentinel\n";
+    await fs.writeFile(path.join(unlinkRoot, unlinkSourceRel), unlinkSourceBytes);
+    const unlinkVault = new Vault(unlinkRoot, { enableWrite: true });
+    await unlinkVault.ensureExists();
+    const unlinkInternals = unlinkVault as unknown as {
+      unlinkSafe(target: string): Promise<void>;
+    };
+    const unlinkSafe = unlinkInternals.unlinkSafe.bind(unlinkVault);
+    const unlinkSpy = vi.spyOn(unlinkInternals, "unlinkSafe").mockImplementation(async (target: string) => {
+      if (String(target).replace(/\\/g, "/").endsWith("UnlinkSource.md")) {
+        throw new Error("synthetic source unlink failure");
+      }
+      return unlinkSafe(target);
+    });
+    try {
+      await expect(unlinkVault.renameFile(unlinkSourceRel, unlinkDestRel)).rejects.toThrow(
+        /synthetic source unlink failure/
+      );
+      expect(await fs.readFile(path.join(unlinkRoot, unlinkSourceRel), "utf8")).toBe(unlinkSourceBytes);
+      expect(await fs.readFile(path.join(unlinkRoot, unlinkDestRel), "utf8")).toBe(unlinkSourceBytes);
+    } finally {
+      unlinkSpy.mockRestore();
+    }
+
     // Cleanup
     await fs.rm(raceRoot, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Why

B6 shipped as squash `34e2892` (PR #538). Sibling sweep of the exact-total unreadable-note class ALLOW'd: remaining whole-vault scanners already throw on note-read failure. Next existing-authority card is BACKLOG §1.CC **A3**.

## What

- Exclusive-move `renameFile` no longer swallows `fs.unlink(fromAbs).catch(() => {})` after a successful `linkSafe`.
- Source removal goes through `unlinkSafe` so a failed unlink is not reported as a completed rename.
- After an EXDEV copy the source is still unlinked once; this PR does not call unlink again on that path (the old `.catch` hid both a real unlink failure and the post-EXDEV ENOENT).
- Extra phase of `renameFile uses exclusive admission and refuses distinct destination entries`: after successful `linkSafe` to a missing destination, `unlinkSafe` rejects and `renameFile` must throw while both paths still hold the source bytes.

## Bound

Does not change EXDEV copy+`unlinkSafe`. Does not reset commit flags after a later fallible `stat` (A4). Does not fold `appendNote` post-write stat/close (H4). No new `it()`.

CHANGELOG is the bound document.

## D-73

Pass 1 CONFIRMED `cfc7b1cd6fbad7463d978cacb0e6963ad544aaf6` (session `01a046d9-2b65-7531-83a1-8ae559260717`). Cited `file:line` re-opened.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `34e2892` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
