### PR TITLE
fix: do not reject write or rename after the bytes are durable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Write and rename do not report failure after the bytes are durable
+
+> **TL;DR:** **`writeNoteContent` and `renameFile` no longer reject after the durable mutation because a later `stat` failed.** Callers treat a rejected primitive as uncommitted and skip rollback, so a published note or completed move could be left outside the restore set. The receipt now prefers a live dest stat and otherwise uses the inode snapshot taken beside the commit, the same shape as `sensitive-artifact` publication.
+>
+> **Bounded claim.** This does **not** fold `appendNote` post-write stat/close (H4). It does **not** move caller-side `committedBacklinks.push` before `await` (A12). It does **not** reopen exclusive-move source unlink (A3).
+>
+> **Method note:** BACKLOG §1.CC **A4**. Coverage is extra phases of existing tests: overwrite `writeNote` must resolve while dest `statSafe` rejects, and exclusive `renameFile` must return `{ from, to }` after source removal when dest `statSafe` rejects. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Post-commit receipt-stat is not a commit flag.** `publishedReceiptStat` returns live dest metadata when it can, otherwise the snapshot from the durable mutation.
+- **`renameNote` can still record `renamed=true` after a completed move.** Exclusive unlink remains the move commit; dest receipt-stat no longer hides it.
+
 ### Exclusive rename does not report success when source unlink fails
 
 > **TL;DR:** **`renameFile` no longer returns success when the default exclusive move linked the destination but failed to remove the source path.** The swallowed `fs.unlink(fromAbs).catch(() => {})` left the note at both paths as two hardlinks; `renameNote` then rewrote vault-wide backlinks on a false premise, and the watcher never saw an unlink. Source removal now goes through `unlinkSafe` and the error surfaces. The leftover pair remains recoverable; the receipt is no longer a lie.

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -1525,6 +1525,24 @@ export class Vault {
       throw this.sanitizeFsError(err);
     }
   }
+  // Publication committed at rename/wx write/unlink. A receipt-stat failure
+  // must not turn that committed success into a reported failure/retry
+  // (sensitive-artifact.ts:122-127). Prefer a live dest stat; otherwise the
+  // inode snapshot taken beside the durable mutation.
+  private async publishedReceiptStat(
+    abs: string,
+    fallback: import("node:fs").Stats | undefined,
+    fallbackSize?: number
+  ): Promise<{ mtimeMs: number; size: number }> {
+    try {
+      const live = await this.statSafe(abs);
+      return { mtimeMs: live.mtimeMs, size: live.size };
+    } catch {
+      if (fallback) return { mtimeMs: fallback.mtimeMs, size: fallback.size };
+      if (fallbackSize !== undefined) return { mtimeMs: Date.now(), size: fallbackSize };
+      throw new Error(`published path is not statable: ${vaultRelative(this.root, abs)}`);
+    }
+  }
 
   async readBinaryFile(relOrAbs: string): Promise<Buffer> {
     const abs = await this.resolveSafePath(relOrAbs);
@@ -1772,6 +1790,7 @@ export class Vault {
     // user-facing "Note already exists" error for back-compat).
     const targetLstat = await this.assertMutationLeafNotSymlink(abs, "write");
     await this.assertMutationPathPublic(abs, "write", "destination");
+    let publishedStat: import("node:fs").Stats | undefined;
     if (opts.overwrite) {
       // v3.11.0-rc.12 (rc.11-audit L-7) — atomic overwrite: write a sibling tmp then
       // rename(2) over the target, so a crash/SIGKILL mid-write can never truncate the
@@ -1798,6 +1817,7 @@ export class Vault {
         await this.assertMutationPathPublic(tmp, "write", "temporary destination");
         if (Buffer.isBuffer(content)) await fh.writeFile(content);
         else await fh.writeFile(content, "utf8");
+        publishedStat = await fh.stat();
         await fh.close();
         fh = undefined;
         await this.assertMutationLeafNotSymlink(abs, "write");
@@ -1816,6 +1836,11 @@ export class Vault {
         await this.assertMutationPathPublic(abs, "write", "destination");
         if (Buffer.isBuffer(content)) await fh.writeFile(content);
         else await fh.writeFile(content, "utf8");
+        try {
+          publishedStat = await fh.stat();
+        } catch {
+          publishedStat = undefined;
+        }
       } catch (err) {
         if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST") {
           throw new Error(`Note already exists: ${targetRel} (pass overwrite=true to replace)`);
@@ -1826,12 +1851,12 @@ export class Vault {
       }
     }
     this.deleteCacheEntry(abs);
-    const stat = await this.statSafe(abs);
+    const receipt = await this.publishedReceiptStat(abs, publishedStat, contentBytes);
     return {
       absPath: abs,
       relPath: vaultRelative(this.root, abs),
-      mtimeMs: stat.mtimeMs,
-      bytes: stat.size
+      mtimeMs: receipt.mtimeMs,
+      bytes: receipt.size
     };
   }
 
@@ -2184,17 +2209,21 @@ export class Vault {
     // Plain rename is reserved for confirmed case aliases and for a distinct
     // destination that already existed when overwrite authority was planned.
     let needsExclusiveMove = false;
+    let publishedStat: import("node:fs").Stats | undefined;
     if (exactSamePath) {
       if (!opts.overwrite) {
         throw new Error(`Destination already exists: ${toRelNorm} (pass overwrite=true to replace)`);
       }
+      publishedStat = await this.statSafe(fromAbs);
       await this.renameSafe(fromAbs, toAbs);
     } else if (currentDestination?.kind === "same-canonical-case-alias") {
+      publishedStat = await this.statSafe(fromAbs);
       await this.renameSafe(fromAbs, toAbs);
     } else if (currentDestination?.kind === "distinct") {
       if (!opts.overwrite) {
         throw new Error(`Destination already exists: ${toRelNorm} (pass overwrite=true to replace)`);
       }
+      publishedStat = await this.statSafe(fromAbs);
       await this.renameSafe(fromAbs, toAbs);
     } else {
       needsExclusiveMove = true;
@@ -2229,6 +2258,7 @@ export class Vault {
             }
             throw copyErr;
           }
+          publishedStat = await this.statSafe(toAbs);
           await this.unlinkSafe(fromAbs);
         } else {
           throw err;
@@ -2241,16 +2271,17 @@ export class Vault {
       // The EXDEV copy path already unlinked; a second unlinkSafe would ENOENT
       // after a completed move (the swallowed fs.unlink.catch used to hide both).
       if (linked) {
+        publishedStat = await this.statSafe(fromAbs);
         await this.unlinkSafe(fromAbs);
       }
     }
     this.deleteCacheEntry(fromAbs);
     this.deleteCacheEntry(toAbs);
-    const stat = await this.statSafe(toAbs);
+    const receipt = await this.publishedReceiptStat(toAbs, publishedStat);
     return {
       from: vaultRelative(this.root, fromAbs),
       to: vaultRelative(this.root, toAbs),
-      mtimeMs: stat.mtimeMs
+      mtimeMs: receipt.mtimeMs
     };
   }
 

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -409,7 +409,10 @@ describe("createNote", () => {
     const overwriteStatSafe = overwriteInternals.statSafe.bind(v);
     const overwriteStatSpy = vi.spyOn(overwriteInternals, "statSafe").mockImplementation(async (target: string) => {
       if (String(target).replace(/\\/g, "/").endsWith("StatOverwrite.md")) {
-        throw new Error("synthetic post-commit stat failure");
+        const live = await fs.readFile(target, "utf8").catch(() => "");
+        if (live === "after\n") {
+          throw new Error("synthetic post-commit stat failure");
+        }
       }
       return overwriteStatSafe(target);
     });

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -328,6 +328,37 @@ describe("createNote", () => {
       unlinkSpy.mockRestore();
     }
 
+    const statRoot = path.join(root, "F2-post-commit-stat-root");
+    await fs.mkdir(statRoot, { recursive: true });
+    const statSourceRel = "StatSource.md";
+    const statDestRel = "StatDest.md";
+    const statSourceBytes = "post-commit stat sentinel\n";
+    await fs.writeFile(path.join(statRoot, statSourceRel), statSourceBytes);
+    const statVault = new Vault(statRoot, { enableWrite: true });
+    await statVault.ensureExists();
+    const statInternals = statVault as unknown as {
+      statSafe(target: string): Promise<import("node:fs").Stats>;
+    };
+    const statSafe = statInternals.statSafe.bind(statVault);
+    const statSpy = vi.spyOn(statInternals, "statSafe").mockImplementation(async (target: string) => {
+      if (String(target).replace(/\\/g, "/").endsWith("StatDest.md")) {
+        const sourcePresent = await fs.stat(path.join(statRoot, statSourceRel)).catch(() => null);
+        if (!sourcePresent) {
+          throw new Error("synthetic post-commit stat failure");
+        }
+      }
+      return statSafe(target);
+    });
+    try {
+      const receipt = await statVault.renameFile(statSourceRel, statDestRel);
+      expect(receipt.from).toBe(statSourceRel);
+      expect(receipt.to).toBe(statDestRel);
+      expect(await fs.stat(path.join(statRoot, statSourceRel)).catch(() => null)).toBeNull();
+      expect(await fs.readFile(path.join(statRoot, statDestRel), "utf8")).toBe(statSourceBytes);
+    } finally {
+      statSpy.mockRestore();
+    }
+
     // Cleanup
     await fs.rm(raceRoot, { recursive: true, force: true });
   });
@@ -369,6 +400,26 @@ describe("createNote", () => {
     expect(text).toBe("second");
     if (process.platform !== "win32") {
       expect((await fs.stat(path.join(root, "Twice.md"))).mode & 0o777).toBe(0o600);
+    }
+
+    await fs.writeFile(path.join(root, "StatOverwrite.md"), "before\n");
+    const overwriteInternals = v as unknown as {
+      statSafe(target: string): Promise<import("node:fs").Stats>;
+    };
+    const overwriteStatSafe = overwriteInternals.statSafe.bind(v);
+    const overwriteStatSpy = vi.spyOn(overwriteInternals, "statSafe").mockImplementation(async (target: string) => {
+      if (String(target).replace(/\\/g, "/").endsWith("StatOverwrite.md")) {
+        throw new Error("synthetic post-commit stat failure");
+      }
+      return overwriteStatSafe(target);
+    });
+    try {
+      const receipt = await v.writeNote("StatOverwrite.md", "after\n", { overwrite: true });
+      expect(receipt.relPath).toBe("StatOverwrite.md");
+      expect(receipt.bytes).toBe(Buffer.byteLength("after\n"));
+      expect(await fs.readFile(path.join(root, "StatOverwrite.md"), "utf8")).toBe("after\n");
+    } finally {
+      overwriteStatSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Why

A3 shipped as squash `5e2dea6` (PR #539). Sibling sweep ALLOW: no remaining swallowed source-unlink on a success path. Next existing-authority card is BACKLOG §1.CC **A4**.

## What

- After `writeNoteContent` rename/wx write and `renameFile` unlink/rename, a failed dest `stat` no longer rejects the primitive.
- `publishedReceiptStat` prefers a live dest stat and otherwise uses the inode snapshot taken beside the durable mutation.
- Extra phases: overwrite `writeNote` must resolve while dest `statSafe` rejects after published bytes land; exclusive `renameFile` must return `{ from, to }` after source removal when dest `statSafe` rejects.

## Bound

Does not fold `appendNote` post-write stat/close (H4). Does not move caller-side `committedBacklinks.push` before `await` (A12). Does not reopen exclusive-move source unlink (A3). No new `it()`.

CHANGELOG is the bound document.

## D-73

Pass 1 CONFIRMED `cbb983b2459215dee40d221ecc58a2c80231a2d8` (session `01a046f0-070c-7510-ac78-5f1dfbd7d5a7`). Hosted macOS failed: dest `statSafe` spy fired in `canonicalRelForPrivacyCheck` before `renameSafe`. Test retarget `085c428` throws only after dest bytes are the published content. Pass 2 CONFIRMED `085c428cffd9d1a57204cf6ae5098b25bd9708d7` (session `01a046f8-a5a0-7370-8146-4bcaded885a9`). Cited `file:line` re-opened.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `5e2dea6` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
