### PR TITLE
fix: do not reject append after the bytes are durable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Append does not report failure after the bytes are durable
+
+> **TL;DR:** **`appendNote` no longer rejects after a successful `writeFile` because a later handle `stat` or `close` failed.** A rejected append looks uncommitted to the caller, so a retry appends twice. The write is the commit; receipt metadata prefers a live dest stat and otherwise uses the pre-write size plus the appended byte count. Close after that write is best-effort.
+>
+> **Bounded claim.** This does **not** move caller-side `committedBacklinks.push` before `await` (A12). It does **not** reopen A3 source unlink or A4 write/rename receipts.
+>
+> **Method note:** BACKLOG §1.CC **H4**, sibling of A4. Coverage is an extra phase of the existing custom-separator append test: after `writeFile`, handle `stat` and `close` reject and `appendNote` must still resolve with the appended bytes on disk. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Post-write stat/close is not a commit flag.** `appendNote` uses `publishedReceiptStat` after `writeFile`.
+- **Retry cannot double-append from a false failure.** The primitive returns success once the bytes are on the descriptor.
+
 ### Write and rename do not report failure after the bytes are durable
 
 > **TL;DR:** **`writeNoteContent` and `renameFile` no longer reject after the durable mutation because a later `stat` failed.** Callers treat a rejected primitive as uncommitted and skip rollback, so a published note or completed move could be left outside the restore set. The receipt now prefers a live dest stat and otherwise uses the inode snapshot taken beside the commit, the same shape as `sensitive-artifact` publication.

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -2355,7 +2355,8 @@ export class Vault {
 
       const handle = await this.openSafe(abs, appendFlags);
       const additionBytes = Buffer.byteLength(addition, "utf8");
-      let after: import("node:fs").Stats;
+      let after: import("node:fs").Stats | undefined;
+      let publishedSize: number | undefined;
       try {
         const before = await handle.stat();
         if (!before.isFile()) {
@@ -2388,15 +2389,21 @@ export class Vault {
           throw new Error(`Refusing to grow ${vaultRelative(this.root, abs)} past ${this.maxFileBytes} bytes`);
         }
         await handle.writeFile(addition, "utf8");
-        after = await handle.stat();
+        publishedSize = before.size + additionBytes;
+        try {
+          after = await handle.stat();
+        } catch {
+          after = undefined;
+        }
       } finally {
-        await handle.close();
+        await handle.close().catch(() => {});
       }
       this.deleteCacheEntry(abs);
+      const receipt = await this.publishedReceiptStat(abs, after, publishedSize);
       return {
         absPath: abs,
         relPath: vaultRelative(this.root, abs),
-        mtimeMs: after.mtimeMs,
+        mtimeMs: receipt.mtimeMs,
         appended_bytes: additionBytes
       };
     });

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -655,6 +655,40 @@ describe("appendToNote", () => {
     await appendToNote(v, { path: "Log.md", content: "second", separator: "\n---\n" });
     const text = await fs.readFile(path.join(root, "Log.md"), "utf8");
     expect(text).toBe("first\n---\nsecond");
+
+    await createNote(v, { path: "AppendStat.md", content: "first" });
+    const appendInternals = v as unknown as {
+      openSafe(p: string, flags: string | number, mode?: number): Promise<import("node:fs/promises").FileHandle>;
+    };
+    const openSafe = appendInternals.openSafe.bind(v);
+    const openSpy = vi.spyOn(appendInternals, "openSafe").mockImplementation(async (p, flags, mode) => {
+      const handle = await openSafe(p, flags, mode);
+      let published = false;
+      const writeFile = handle.writeFile.bind(handle);
+      const stat = handle.stat.bind(handle);
+      const close = handle.close.bind(handle);
+      handle.writeFile = (async (...args: Parameters<typeof handle.writeFile>) => {
+        const result = await writeFile(...args);
+        published = true;
+        return result;
+      }) as typeof handle.writeFile;
+      handle.stat = (async (...args: Parameters<typeof handle.stat>) => {
+        if (published) throw new Error("synthetic post-commit append stat failure");
+        return stat(...args);
+      }) as typeof handle.stat;
+      handle.close = (async () => {
+        if (published) throw new Error("synthetic post-commit append close failure");
+        return close();
+      }) as typeof handle.close;
+      return handle;
+    });
+    try {
+      const receipt = await v.appendNote("AppendStat.md", "\nsecond");
+      expect(receipt.appended_bytes).toBe(Buffer.byteLength("\nsecond"));
+      expect(await fs.readFile(path.join(root, "AppendStat.md"), "utf8")).toBe("first\nsecond");
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it("can resolve target by title", async () => {


### PR DESCRIPTION
## Why

A4 shipped as squash `9ca78f3` (PR #540). Sibling sweep of the post-commit receipt-stat class found BACKLOG §1.CC **H4**: `appendNote` can still reject after `writeFile`.

## What

- After `writeFile`, handle `stat` failure is not a commit flag; receipt uses `publishedReceiptStat`.
- Handle `close` after that write is best-effort.
- Extra phase of `supports custom separator`: after `writeFile`, handle `stat` and `close` reject and `appendNote` must still resolve with the appended bytes on disk.

## Bound

Does not fold A12 caller-side `committedBacklinks.push`. Does not reopen A3/A4. No new `it()`.

CHANGELOG is the bound document.

## D-73

Pass 1 CONFIRMED `1b073e78b78badb7c4b1e23ad65d3fa1a62c54dd` (session `01a04770-cec6-7702-8fcc-fb0e28f8c726`). Cited `file:line` re-opened.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `9ca78f3` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
