### PR TITLE
fix: drop HTTP process listeners on successful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### HTTP shutdown drops the process listeners it installed
+
+> **TL;DR:** **Normal `serve-http` shutdown now removes the SIGINT, SIGTERM, and `beforeExit` listeners it installed after listen.** Those `removeListener` calls lived only in the startup `catch`, so a later server in the same process could be terminated by a previous server's handler. `shutdownHttpServer` now drops the exact owners it published, including on the successful path.
+>
+> **Bounded claim.** This does **not** fold session-idle stamping at request start (H2). It does **not** bound legacy stateful `transport.close`/`server.close` (A9). It does **not** change `installSignalHandlers: false`.
+>
+> **Method note:** BACKLOG §1.CC-HOLD **H1**. Coverage is an extra phase of the existing stateless-shutdown test: after a successful listen with `installSignalHandlers: true`, `shutdownHttpServer` must restore the process listener counts. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Process owners die with the listener.** `HttpServerExtras` holds the exact SIGINT/SIGTERM/`beforeExit` functions; shutdown removes them before protocol drain.
+- **Startup-failure rollback is unchanged.** The ownership `catch` still removes any partially installed handlers.
+
 ### Append does not report failure after the bytes are durable
 
 > **TL;DR:** **`appendNote` no longer rejects after a successful `writeFile` because a later handle `stat` or `close` failed.** A rejected append looks uncommitted to the caller, so a retry appends twice. The write is the commit; receipt metadata prefers a live dest stat and otherwise uses the pre-write size plus the appended byte count. Close after that write is best-effort.

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -1711,6 +1711,10 @@ interface HttpServerExtras {
   listenerClosed: boolean;
   /** Lazily captured dependency owner, retained until every stage succeeds. */
   cleanupOwner?: PreparedServerCleanupOwner;
+  /** SIGINT/SIGTERM owner installed after listen; dropped on every shutdown. */
+  onSignal?: () => void;
+  /** beforeExit owner installed after listen; dropped on every shutdown. */
+  onBeforeExit?: () => void;
 }
 const httpServerExtras = new WeakMap<HttpServer, HttpServerExtras>();
 /** One teardown promise per server so concurrent programmatic callers join the
@@ -1798,13 +1802,15 @@ export function closeServerBounded(server: HttpServer, graceMs: number = HTTP_CL
  * `prepareServerDeps` opens once at boot.
  *
  * Order matters:
- *   1. `registry.closeAll()` — bounded ordinary request drain, followed by
+ *   1. Drop this generation's SIGINT/SIGTERM/`beforeExit` owners so a later
+ *      server in the same process cannot be terminated by this listener.
+ *   2. `registry.closeAll()` — bounded ordinary request drain, followed by
  *      cancellation/rollback or completion of persistent writes, then close
  *      every transport + McpServer in stateful mode.
- *   2. `httpServer.close()` — stop accepting new connections + wait for
+ *   3. `httpServer.close()` — stop accepting new connections + wait for
  *      existing ones to drain. Node's http.Server doesn't actively
  *      terminate keep-alive sockets unless we ask it to.
- *   3. Close feedback lifetime, watcher, watcherEmbedDb, vault cache, and fts5
+ *   4. Close feedback lifetime, watcher, watcherEmbedDb, vault cache, and fts5
  *      index — the same dependency order as the stdio cleanup chain.
  *
  * Idempotent: sequential and concurrent calls on the same server join the
@@ -1820,6 +1826,15 @@ export async function shutdownHttpServer(server: HttpServer): Promise<void> {
       // Not from startHttpServer. Still close the TCP listener for safety.
       await closeServerBounded(server);
       return;
+    }
+    if (extras.onSignal) {
+      process.removeListener("SIGINT", extras.onSignal);
+      process.removeListener("SIGTERM", extras.onSignal);
+      extras.onSignal = undefined;
+    }
+    if (extras.onBeforeExit) {
+      process.removeListener("beforeExit", extras.onBeforeExit);
+      extras.onBeforeExit = undefined;
     }
     const cleanupErrors: unknown[] = [];
     // Close both era gates synchronously, then drain independently. Legacy
@@ -2027,6 +2042,8 @@ export async function startHttpServer(
       };
       process.on("beforeExit", onBeforeExit);
       beforeExitInstalled = true;
+      startupExtras.onSignal = onSignal;
+      startupExtras.onBeforeExit = onBeforeExit;
     }
 
     const addr = listener.address();

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -2293,6 +2293,32 @@ describe("startHttpServer stateful sessions (v2.14.0)", () => {
     const addr = httpServer.address();
     // After close, .address() returns null on a server that has been closed.
     expect(addr).toBeNull();
+
+    const signalCounts = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      beforeExit: process.listenerCount("beforeExit")
+    };
+    const owned = await startHttpServer({
+      vault: root,
+      port: 0,
+      host: "127.0.0.1",
+      bearerToken: TOKEN,
+      mcpPath: "/mcp",
+      rateLimitPerMinute: 0,
+      stateful: false,
+      installSignalHandlers: true
+    });
+    try {
+      expect(process.listenerCount("SIGINT")).toBeGreaterThan(signalCounts.sigint);
+      expect(process.listenerCount("SIGTERM")).toBeGreaterThan(signalCounts.sigterm);
+      expect(process.listenerCount("beforeExit")).toBeGreaterThan(signalCounts.beforeExit);
+    } finally {
+      await shutdownHttpServer(owned);
+    }
+    expect(process.listenerCount("SIGINT")).toBe(signalCounts.sigint);
+    expect(process.listenerCount("SIGTERM")).toBe(signalCounts.sigterm);
+    expect(process.listenerCount("beforeExit")).toBe(signalCounts.beforeExit);
   });
 
   // v3.8.7 P2-11 + v4 — concurrent/later shutdown calls join one safe task.

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "08b50871e63451decf0a616987d5c2ca2bacf79a6bdf28399177d8b66cb5f0b3" }],
+  ["http-transport.test.ts", { count: 1, sha256: "0276f4406c407b89058d3ad9af18307358cf148c86e92e9ca8ff8d13c2852400" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }


### PR DESCRIPTION
## What's in this PR

**Normal `serve-http` shutdown left the SIGINT, SIGTERM, and `beforeExit` listeners it installed after listen.** Those `removeListener` calls lived only in the startup `catch`, so a later server in the same process could be terminated by a previous server's handler.

`HttpServerExtras` now holds the exact owners. `shutdownHttpServer` drops them before protocol drain, including on the successful path.

## Bound

Does not fold session-idle stamping at request start (H2). Does not bound legacy stateful `transport.close`/`server.close` (A9). Does not change `installSignalHandlers: false`.

Coverage is an extra phase of the existing stateless-shutdown test: after a successful listen with `installSignalHandlers: true`, `shutdownHttpServer` must restore the process listener counts. No new `it()`. Census stays 2228.

CHANGELOG is the bound document. BACKLOG §1.CC-HOLD **H1**.

## D-73

Pass 1 CONFIRMED `3dbab2b8ae6db4642c3a9fc7b23f1aceeb16820e` (session `01a04794-49e5-74b0-ae41-e549bd5bfc18`). Cited `file:line` re-opened. Pin-only follow-up `93c1e39` retargets the `http-transport.test.ts` mutation-helper identity after the extra phase; claim surface unchanged.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `31fa983` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
