### PR TITLE
fix: stamp HTTP session activity when the request finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### HTTP session activity is stamped when the request finishes
+
+> **TL;DR:** **Stateful `serve-http` now records `lastActivityMs` when a session's `handleRequest` occupancy ends, not when it begins.** The idle sweep compares that stamp to `now - sessionIdleTimeoutMs`. A request longer than the TTL used to leave a start-time stamp, so the next request's lazy sweep could evict the session it had just used. Occupancy still skips the sweep while `inFlight > 0`.
+>
+> **Bounded claim.** This does **not** bound legacy stateful `transport.close`/`server.close` (A9). It does **not** change the request-driven lazy sweep, DELETE drain, or SSE `inFlight` skip. It does **not** reopen H1 process-listener teardown.
+>
+> **Method note:** BACKLOG §1.CC-HOLD **H2**. Coverage is an extra phase of the existing session-reuse test: initialize occupies longer than a 25ms idle TTL, then the immediate follow-up POST must still be accepted. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Idle TTL measures quiet time after the last occupancy.** `runWithRefcount` stamps `lastActivityMs` in `finally` before dropping `inFlight`.
+- **Initialize, POST, GET, and DELETE share that occupancy.** Constructor `lastActivityMs` remains the pre-first-occupancy value.
+
 ### HTTP shutdown drops the process listeners it installed
 
 > **TL;DR:** **Normal `serve-http` shutdown now removes the SIGINT, SIGTERM, and `beforeExit` listeners it installed after listen.** Those `removeListener` calls lived only in the startup `catch`, so a later server in the same process could be terminated by a previous server's handler. `shutdownHttpServer` now drops the exact owners it published, including on the successful path.

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -95,6 +95,8 @@ export interface HttpTransportInternals {
   afterDeleteMarkedClosing?: (sessionId: string) => void | Promise<void>;
   /** Pause after a modern request owns an in-flight slot; used only by lifecycle tests. */
   afterModernRequestAdmitted?: () => void | Promise<void>;
+  /** Pause after a stateful session occupies an in-flight slot; used only by lifecycle tests. */
+  afterStatefulRequestAdmitted?: () => void | Promise<void>;
   /** Fault-injection point after listen and owner installation but before startup commits. */
   beforeStartupCommit?: (server: HttpServer, deps: ServerDeps) => void | Promise<void>;
   /** Replace TCP listener construction in ownership tests without binding an operating-system socket. */
@@ -668,7 +670,7 @@ function applyCors(req: IncomingMessage, res: ServerResponse, allowOrigins: stri
 interface StatefulSession {
   server: ReturnType<typeof buildMcpServer>;
   transport: InstanceType<typeof NodeStreamableHTTPServerTransport>;
-  /** Epoch-ms of the last `handleRequest` for this session. */
+  /** Epoch-ms of the last completed `handleRequest` occupancy for this session. */
   lastActivityMs: number;
   /**
    * v3.8.7 — count of ALL handlers currently inside `transport.handleRequest`
@@ -898,14 +900,17 @@ async function runWithRefcount<T>(
   session: StatefulSession,
   fn: () => Promise<T>,
   isCall = true,
-  isWrite = false
+  isWrite = false,
+  afterAdmitted?: () => void | Promise<void>
 ): Promise<T> {
   session.inFlight += 1;
   if (isCall) session.inFlightCalls += 1;
   if (isWrite) session.inFlightWrites = (session.inFlightWrites ?? 0) + 1;
   try {
+    if (afterAdmitted) await afterAdmitted();
     return await fn();
   } finally {
+    session.lastActivityMs = Date.now();
     session.inFlight -= 1;
     if (isCall) session.inFlightCalls -= 1;
     if (isWrite) {
@@ -1393,7 +1398,13 @@ export function createHttpHandler(
         registry.sessions.delete(sessionId);
         try {
           // The DELETE itself is a lifecycle op, not a drainable call.
-          await runWithRefcount(session, () => session.transport.handleRequest(req, res), false);
+          await runWithRefcount(
+            session,
+            () => session.transport.handleRequest(req, res),
+            false,
+            false,
+            internals.afterStatefulRequestAdmitted
+          );
         } catch {
           /* shutdown errors don't matter — we're killing the session anyway */
         }
@@ -1419,14 +1430,19 @@ export function createHttpHandler(
           sendJsonRpcError(res, 404, -32000, `Unknown session ${sessionId}`);
           return;
         }
-        session.lastActivityMs = Date.now();
         try {
           // v3.11.6-rc.21 (rc.20 re-sweep F1) — the SSE stream is `isCall: false`:
           // `handleRequest` stays pending for the whole stream lifetime, so it
           // must NOT be part of the DELETE/closeAll drain (which it would pin
           // forever). It still bumps `inFlight` so idle-sweep treats the session
           // as active; teardown TERMINATES this stream rather than waiting on it.
-          await runWithRefcount(session, () => session.transport.handleRequest(req, res), false);
+          await runWithRefcount(
+            session,
+            () => session.transport.handleRequest(req, res),
+            false,
+            false,
+            internals.afterStatefulRequestAdmitted
+          );
         } catch (err) {
           process.stderr.write(`enquire http: SSE error — ${err instanceof Error ? err.message : String(err)}\n`);
         }
@@ -1455,13 +1471,13 @@ export function createHttpHandler(
           sendJsonRpcError(res, 404, -32000, `Unknown session ${sessionId} (it may have expired)`);
           return;
         }
-        session.lastActivityMs = Date.now();
         try {
           await runWithRefcount(
             session,
             () => session.transport.handleRequest(req, res, body),
             true,
-            isPersistentWriteRequest(body)
+            isPersistentWriteRequest(body),
+            internals.afterStatefulRequestAdmitted
           );
         } catch (err) {
           process.stderr.write(
@@ -1582,7 +1598,13 @@ export function createHttpHandler(
               }
             };
             await server.connect(tr);
-            await runWithRefcount(session, () => tr.handleRequest(req, res, body));
+            await runWithRefcount(
+              session,
+              () => tr.handleRequest(req, res, body),
+              true,
+              false,
+              internals.afterStatefulRequestAdmitted
+            );
             if (session.closing) {
               await tr.close().catch(() => {});
               await server.close().catch(() => {});

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -1918,6 +1918,52 @@ describe("startHttpServer stateful sessions (v2.14.0)", () => {
     } finally {
       await s.close();
     }
+
+    const idleTimeoutMs = 25;
+    const occupied = await startHttpServer(
+      {
+        vault: root,
+        port: 0,
+        host: "127.0.0.1",
+        bearerToken: TOKEN,
+        mcpPath: "/mcp",
+        healthPath: "/health",
+        rateLimitPerMinute: 0,
+        corsOrigins: [],
+        stateful: true,
+        maxSessions: 100,
+        sessionIdleTimeoutMs: idleTimeoutMs,
+        installSignalHandlers: false
+      },
+      {
+        afterStatefulRequestAdmitted: async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, idleTimeoutMs + 20));
+        }
+      }
+    );
+    try {
+      const addr = occupied.address() as AddressInfo;
+      const url = `http://127.0.0.1:${addr.port}`;
+      const { sessionId, rawResponse } = await initSession(url);
+      await rawResponse.text();
+      const followUp = await fetch(`${url}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: `Bearer ${TOKEN}`,
+          "Mcp-Session-Id": sessionId
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized"
+        })
+      });
+      expect(followUp.status).toBeLessThan(300);
+      await followUp.text();
+    } finally {
+      await shutdownHttpServer(occupied);
+    }
   });
 
   it("POST with unknown session id returns 404", async () => {

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "0276f4406c407b89058d3ad9af18307358cf148c86e92e9ca8ff8d13c2852400" }],
+  ["http-transport.test.ts", { count: 1, sha256: "e1f814a425ca262484e83656804cae13529cf0093959627932a7087123927912" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }


### PR DESCRIPTION
## What's in this PR

**A stateful request longer than the idle TTL could make the next request evict the session it had just used.** `lastActivityMs` was set at request start. The lazy sweep compares that stamp to `now - sessionIdleTimeoutMs`, and `inFlight` only protects while the request is still running.

`runWithRefcount` now stamps `lastActivityMs` in `finally` before dropping `inFlight`. Initialize, POST, GET, and DELETE share that occupancy.

## Bound

Does not bound legacy stateful `transport.close`/`server.close` (A9). Does not change the request-driven lazy sweep, DELETE drain, or SSE `inFlight` skip. Does not reopen H1 process-listener teardown.

Coverage is an extra phase of the existing session-reuse test: initialize occupies longer than a 25ms idle TTL, then the immediate follow-up POST must still be accepted. No new `it()`. Census stays 2228.

CHANGELOG is the bound document. BACKLOG §1.CC-HOLD **H2**.

## D-73

Pass 1 CONFIRMED `56d7fdda0a029cd0d0e8277f0f057a7141943bc8` (session `01a04873-206f-7810-b0bf-a4b5a3285028`). Cited `file:line` re-opened.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `77bf4bb` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
