### PR TITLE
fix: bound legacy HTTP session protocol close during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### HTTP shutdown bounds legacy session protocol close
+
+> **TL;DR:** **Stateful `closeAll` no longer awaits hung SDK `transport.close` / `server.close` with no deadline.** Those awaits sat after the bounded call drain and write-integrity tail, and they blocked `shutdownHttpServer` before TCP force-close. Each session's protocol close now races the same 3s class as modern handler close and stdio protocol close, in parallel, so a stuck SDK close cannot pin teardown.
+>
+> **Bounded claim.** This does **not** bound DELETE-path or initialize-rollback `transport.close` / `server.close`. It does **not** change idle-sweep's fire-and-forget `void close()`. It does **not** reopen H1 process listeners or H2 activity stamps.
+>
+> **Method note:** BACKLOG §1.CC **A9**. Coverage is an extra phase of the existing `closeAll` drain test: one session's `transport.close` never settles, `closeAll(0)` must still return, and the hang is then released. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Legacy protocol close is bounded.** `closeAll` uses `waitForBoundedSettlement` with `LEGACY_SESSION_CLOSE_MS` (3000).
+- **Hung closes run in parallel.** One stuck session cannot serialize every other session's 3s budget.
+
 ### HTTP session activity is stamped when the request finishes
 
 > **TL;DR:** **Stateful `serve-http` now records `lastActivityMs` when a session's `handleRequest` occupancy ends, not when it begins.** The idle sweep compares that stamp to `now - sessionIdleTimeoutMs`. A request longer than the TTL used to leave a start-time stamp, so the next request's lazy sweep could evict the session it had just used. Occupancy still skips the sweep while `inFlight > 0`.

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -59,6 +59,8 @@ const DELETE_DRAIN_MS = 5000;
 const MODERN_DRAIN_MS = 5000;
 /** Bound for the SDK handler's graceful protocol close after write integrity settles. */
 const MODERN_CLOSE_MS = 3000;
+/** Bound for one legacy stateful session's transport.close / server.close under closeAll. */
+const LEGACY_SESSION_CLOSE_MS = 3000;
 /** Minimum request budget retained for ordinary MCP envelopes. */
 const MIN_HTTP_JSON_BODY_BYTES = 4 * 1024 * 1024;
 /** Worst-case JSON string expansion: one decoded control byte becomes `\u00xx`. */
@@ -767,13 +769,16 @@ export interface SessionRegistry {
   /**
    * Graceful drain: mark all sessions as `closing`, wait up to `timeoutMs`
    * for ordinary in-flight requests, then preserve persistent-write integrity
-   * through rollback/finish before closing every transport + McpServer pair.
+   * through rollback/finish before bounding every transport + McpServer close.
    * Returns the number of sessions closed. Idempotent.
    */
   closeAll(timeoutMs?: number): Promise<number>;
 }
 
-export function createSessionRegistry(idleTimeoutMs: number): SessionRegistry {
+export function createSessionRegistry(
+  idleTimeoutMs: number,
+  protocolCloseMs: number = LEGACY_SESSION_CLOSE_MS
+): SessionRegistry {
   const sessions = new Map<string, StatefulSession>();
   let pendingInits = 0;
   let acceptingInits = true;
@@ -863,10 +868,16 @@ export function createSessionRegistry(idleTimeoutMs: number): SessionRegistry {
       // Close everything regardless — best-effort. After timeoutMs an
       // in-flight READ handler may be stuck and we'd rather hand back the port
       // than wait forever. Persistent mutations have completed or rolled back.
-      for (const s of snapshot) {
-        await s.transport.close().catch(() => {});
-        await s.server.close().catch(() => {});
-      }
+      // Protocol close is bounded: a hung SDK close must not pin shutdown
+      // ahead of TCP force-close.
+      await Promise.all(
+        snapshot.map(async (s) => {
+          await Promise.all([
+            waitForBoundedSettlement(Promise.resolve().then(() => s.transport.close()).catch(() => {}), protocolCloseMs),
+            waitForBoundedSettlement(Promise.resolve().then(() => s.server.close()).catch(() => {}), protocolCloseMs)
+          ]);
+        })
+      );
       return snapshot.length;
     }
   };

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -873,8 +873,18 @@ export function createSessionRegistry(
       await Promise.all(
         snapshot.map(async (s) => {
           await Promise.all([
-            waitForBoundedSettlement(Promise.resolve().then(() => s.transport.close()).catch(() => {}), protocolCloseMs),
-            waitForBoundedSettlement(Promise.resolve().then(() => s.server.close()).catch(() => {}), protocolCloseMs)
+            waitForBoundedSettlement(
+              Promise.resolve()
+                .then(() => s.transport.close())
+                .catch(() => {}),
+              protocolCloseMs
+            ),
+            waitForBoundedSettlement(
+              Promise.resolve()
+                .then(() => s.server.close())
+                .catch(() => {}),
+              protocolCloseMs
+            )
           ]);
         })
       );

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -386,6 +386,28 @@ describe("SessionRegistry (v2.14.0)", () => {
     expect(transportClosed).toBe(2);
     expect(serverClosed).toBe(2);
     expect(r.size()).toBe(0);
+
+    const hung = createSessionRegistry(60_000, 25);
+    let resolveHang: (() => void) | undefined;
+    const hang = new Promise<void>((resolve) => {
+      resolveHang = resolve;
+    });
+    hung.sessions.set("stuck", {
+      transport: {
+        close: async () => hang
+      },
+      server: {
+        close: async () => {}
+      },
+      lastActivityMs: Date.now(),
+      inFlight: 0,
+      closing: false
+    } as unknown as Parameters<typeof hung.sessions.set>[1]);
+    const started = Date.now();
+    const hungClosed = await hung.closeAll(0);
+    expect(hungClosed).toBe(1);
+    expect(Date.now() - started).toBeLessThan(1000);
+    resolveHang?.();
   });
 
   // v3.8.7 P2-11 — closeAll waits for in-flight handlers up to timeoutMs

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "e1f814a425ca262484e83656804cae13529cf0093959627932a7087123927912" }],
+  ["http-transport.test.ts", { count: 1, sha256: "891a03bf908a6a4d2419eb105bfd290a9a7ae9fccbd3695efe182ac7fb9b21c9" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }


### PR DESCRIPTION
## What's in this PR

**Stateful `closeAll` awaited hung SDK `transport.close` / `server.close` with no deadline.** Those awaits sat after the bounded call drain and write-integrity tail, and they blocked `shutdownHttpServer` before TCP force-close.

Each session's protocol close now races `LEGACY_SESSION_CLOSE_MS` (3000), in parallel, so a stuck SDK close cannot pin teardown.

## Bound

Does not bound DELETE-path or initialize-rollback `transport.close` / `server.close`. Does not change idle-sweep's fire-and-forget `void close()`. Does not reopen H1 or H2.

Coverage is an extra phase of the existing `closeAll` drain test: one session's `transport.close` never settles, `closeAll(0)` must still return. No new `it()`. Census stays 2228.

CHANGELOG is the bound document. BACKLOG §1.CC **A9**.

## D-73

Pass 1 CONFIRMED `c586c8ed6278592fb05e3165e1590d32e1dbf8e6` (session `01a04891-2cdf-73b0-878b-23c69af6a7f8`). Cited `file:line` re-opened. Format-only follow-up `5145544` wraps the `waitForBoundedSettlement` calls; claim surface unchanged.

## D-45 / D-72

Hosted CI is the executable proof. Exact-main replay of `84f8686` may overlap. Do not tag or publish. `@latest` stays 3.11.6. `@rc` 4.0.0-rc.5 remains gated on A5.
