### PR TITLE
fix: erase startup HNSW family after persist-time EmbedDb drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Startup HNSW persist erases the family when EmbedDb drifts after saveTo
+
+> **TL;DR:** **Startup `--use-hnsw` persistence no longer leaves a just-published generation on disk after EmbedDb drifts and the in-memory graph is discarded.** `saveTo` already committed the immutable binary plus meta pointer; a later receipt mismatch only logged and dropped the candidate. The watcher flush already erases that family. Startup now calls the same eraser, best-effort, when persist actually committed. Compact v4 pointers omit `text_preview`; native vectors in the generation remain sensitive.
+>
+> **Bounded claim.** This does **not** erase on build-time drift (no `saveTo`) or `saveTo(false)` (pointer never committed). It does **not** change watcher `hnswPersistUnsafe`, load-time discard, or the empty-index erase. It does **not** reopen A5 schema 3→5 vector drop.
+>
+> **Method note:** BACKLOG §1.CC-HOLD **H3**. Coverage is an extra phase of the existing `saveTo(false)` persist test: `saveTo` commits a pointer, an unrelated EmbedDb upsert runs during that await, `prepareServerDeps` must return `hnswContext: null`, brute search stays up, and the just-written meta pointer is gone. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Post-save drift erases the published family.** After a committed startup `saveTo`, a changed HNSW receipt discards the candidate and clears the persist base.
+- **Brute-force search stays up.** The discarded graph is not a `semanticUsable` latch.
+
 ### Mutation-census CHANGELOG names the workflow and script residuals
 
 > **TL;DR:** **The repository-wide raw-mutation census does not cover every checked-in test that reads `.github/workflows/*.yml` or `scripts/*.mjs`.** The original rc.4 TL;DR said every structural-test source and a conservative `src/`-reader superset were inside one census. That class is unchanged. Tests admitted only because they read publication-authority workflows or scripts stay outside unless they already qualify as structural or `src/`-reader members. The current residuals are `release-metadata-gates.test.ts` and `check-audit.test.ts`. Both sinks were already fail-closed by their own oracles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented here. The format follows 
 
 ### Startup HNSW persist erases the family when EmbedDb drifts after saveTo
 
-> **TL;DR:** **Startup `--use-hnsw` persistence no longer leaves a just-published generation on disk after EmbedDb drifts and the in-memory graph is discarded.** `saveTo` already committed the immutable binary plus meta pointer; a later receipt mismatch only logged and dropped the candidate. The watcher flush already erases that family. Startup now calls the same eraser, best-effort, when persist actually committed. Compact v4 pointers omit `text_preview`; native vectors in the generation remain sensitive.
+> **TL;DR:** **Startup `--use-hnsw` persistence no longer leaves a published generation on disk after EmbedDb drifts and the in-memory graph is discarded.** `saveTo` can commit the immutable binary plus meta pointer and still throw on later lease-release; a receipt mismatch only logged and dropped the candidate. The watcher flush already erases that family. Startup now calls the same eraser, best-effort, when persist was attempted and the candidate is discarded. Compact v4 pointers omit `text_preview`; native vectors in the generation remain sensitive.
 >
-> **Bounded claim.** This does **not** erase on build-time drift (no `saveTo`) or `saveTo(false)` (pointer never committed). It does **not** change watcher `hnswPersistUnsafe`, load-time discard, or the empty-index erase. It does **not** reopen A5 schema 3→5 vector drop.
+> **Bounded claim.** This does **not** erase on build-time drift (no `saveTo`) or persist-disabled startup. Uncommitted `saveTo(false)` with matching receipts still keeps the in-memory candidate and the previous sidecar. It does **not** change watcher `hnswPersistUnsafe`, load-time discard, or the empty-index erase. It does **not** reopen A5 schema 3→5 vector drop.
 >
-> **Method note:** BACKLOG §1.CC-HOLD **H3**. Coverage is an extra phase of the existing `saveTo(false)` persist test: `saveTo` commits a pointer, an unrelated EmbedDb upsert runs during that await, `prepareServerDeps` must return `hnswContext: null`, brute search stays up, and the just-written meta pointer is gone. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+> **Method note:** BACKLOG §1.CC-HOLD **H3**. Coverage is extra phases of the existing `saveTo(false)` persist test: (1) `saveTo` commits a pointer, an unrelated EmbedDb upsert runs during that await; (2) `saveTo` writes the pointer then throws (lease-release shape) with the same upsert. Both must return `hnswContext: null`, keep brute search up, and leave the meta pointer gone. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
-- **Post-save drift erases the published family.** After a committed startup `saveTo`, a changed HNSW receipt discards the candidate and clears the persist base.
+- **Post-persist-attempt drift erases the family.** After a startup persist attempt, a changed HNSW receipt discards the candidate and clears the persist base, including when `saveTo` throws after the pointer commits.
 - **Brute-force search stays up.** The discarded graph is not a `semanticUsable` latch.
 
 ### Mutation-census CHANGELOG names the workflow and script residuals

--- a/src/server.ts
+++ b/src/server.ts
@@ -882,7 +882,7 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
                   });
                 }
               } else {
-                const { buildHnsw } = await import("./hnsw.js");
+                const { buildHnsw, clearHnswPersistedArtifacts } = await import("./hnsw.js");
                 const index = await buildHnsw(
                   rows.map((r) => ({ label: r.label, vector: r.vector })),
                   { dim: model.dim, maxElements: rows.length }
@@ -936,6 +936,19 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
                     process.stderr.write(
                       "enquire: embedding database changed while HNSW was persisting; discarding the stale candidate\n"
                     );
+                    // A post-publication DB drift makes the just-written graph stale
+                    // and may include native vectors that the new generation deleted.
+                    // Erase the family now instead of leaving privacy cleanup to a
+                    // future restart. Compact v4 pointers omit text_preview; the
+                    // immutable generation remains sensitive.
+                    if (persisted) {
+                      const persistenceScopes = db.getPersistenceFamilyScopes();
+                      await clearHnswPersistedArtifacts(persistFile, persistenceScopes).catch((err) => {
+                        process.stderr.write(
+                          `enquire: unable to erase stale HNSW artifacts after persist-time generation drift — ${err instanceof Error ? err.message : String(err)}\n`
+                        );
+                      });
+                    }
                   }
                 }
               }

--- a/src/server.ts
+++ b/src/server.ts
@@ -836,6 +836,7 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
               receipt: HnswPersistenceReceipt;
               origin: "loaded" | "built";
             } | null = null;
+            let persistAttempted = false;
             if (opts.hnswPersist !== false) {
               const beforeLoad = db.captureHnswLoadSnapshot();
               const { loadHnswFromDisk } = await import("./hnsw.js");
@@ -882,7 +883,7 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
                   });
                 }
               } else {
-                const { buildHnsw, clearHnswPersistedArtifacts } = await import("./hnsw.js");
+                const { buildHnsw } = await import("./hnsw.js");
                 const index = await buildHnsw(
                   rows.map((r) => ({ label: r.label, vector: r.vector })),
                   { dim: model.dim, maxElements: rows.length }
@@ -897,6 +898,7 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
                   let persisted = false;
                   try {
                     if (opts.hnswPersist !== false) {
+                      persistAttempted = true;
                       persisted =
                         (await index.saveTo(
                           persistFile,
@@ -936,19 +938,6 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
                     process.stderr.write(
                       "enquire: embedding database changed while HNSW was persisting; discarding the stale candidate\n"
                     );
-                    // A post-publication DB drift makes the just-written graph stale
-                    // and may include native vectors that the new generation deleted.
-                    // Erase the family now instead of leaving privacy cleanup to a
-                    // future restart. Compact v4 pointers omit text_preview; the
-                    // immutable generation remains sensitive.
-                    if (persisted) {
-                      const persistenceScopes = db.getPersistenceFamilyScopes();
-                      await clearHnswPersistedArtifacts(persistFile, persistenceScopes).catch((err) => {
-                        process.stderr.write(
-                          `enquire: unable to erase stale HNSW artifacts after persist-time generation drift — ${err instanceof Error ? err.message : String(err)}\n`
-                        );
-                      });
-                    }
                   }
                 }
               }
@@ -1003,6 +992,19 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
                   );
                 }
               }
+            } else if (persistAttempted) {
+              // saveTo can throw after the meta pointer commits (lease-release
+              // failure). Treat any persist attempt as possibly published, and
+              // erase outside the receipt→attach await window. Compact v4
+              // pointers omit text_preview; the immutable generation remains
+              // sensitive.
+              const { clearHnswPersistedArtifacts } = await import("./hnsw.js");
+              const persistenceScopes = db.getPersistenceFamilyScopes();
+              await clearHnswPersistedArtifacts(persistFile, persistenceScopes).catch((err) => {
+                process.stderr.write(
+                  `enquire: unable to erase stale HNSW artifacts after persist-time generation drift — ${err instanceof Error ? err.message : String(err)}\n`
+                );
+              });
             }
           } finally {
             await db.closeAndRelease();

--- a/tests/fixtures/release-mutation-transition.v3.json
+++ b/tests/fixtures/release-mutation-transition.v3.json
@@ -178,7 +178,7 @@
       "reason": "reviewed source bytes changed while catalogue identity stayed fixed",
       "witness": {
         "from": "sha256:c2a1b4125ec2836e34c38160ceff4676ea584e86acbe86edd1a0705dbb63c65e",
-        "to": "sha256:7184f7dcc459c3c849aea0b2bc28d86c7032bcde50d5db1a1f77d2f2d82c40b7"
+        "to": "sha256:a83588984e2f5248a8214ce5ff1cb663614539575536ca451ff292505bff343f"
       }
     },
     {

--- a/tests/fixtures/release-mutation-transition.v3.json
+++ b/tests/fixtures/release-mutation-transition.v3.json
@@ -178,7 +178,7 @@
       "reason": "reviewed source bytes changed while catalogue identity stayed fixed",
       "witness": {
         "from": "sha256:c2a1b4125ec2836e34c38160ceff4676ea584e86acbe86edd1a0705dbb63c65e",
-        "to": "sha256:a83588984e2f5248a8214ce5ff1cb663614539575536ca451ff292505bff343f"
+        "to": "sha256:c0c2411f54eec6ed8b269d0744c5fa34e502b005735e000be7e451f25b9b9a50"
       }
     },
     {

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -124,7 +124,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "./fts5.js|discoverFtsIndexConfig|discoverFtsIndexConfig"
     ],
     k1Opens: 3,
-    sha256: "87a38719e6f18cb70035322bc717daa55f6dc7fa2a3f702dd9a67fb545dfa664"
+    sha256: "47529d4ec9db5c8b005244f49370f6f4e8e910e3e07f1447c3b3a3dadb60d150"
   },
   "src/tools/search.ts": {
     constructors: { EmbedDb: 1, FtsIndex: 0 },

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -124,7 +124,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "./fts5.js|discoverFtsIndexConfig|discoverFtsIndexConfig"
     ],
     k1Opens: 3,
-    sha256: "47529d4ec9db5c8b005244f49370f6f4e8e910e3e07f1447c3b3a3dadb60d150"
+    sha256: "b03297c68205aeb7e26f873a182867b10c56e69a39336669c8cf56402026e708"
   },
   "src/tools/search.ts": {
     constructors: { EmbedDb: 1, FtsIndex: 0 },

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -34,7 +34,7 @@ import { releaseMutationVersionedTransitionAuditProblems } from "./release-mutat
 
 const repoRoot = path.resolve(__dirname, "..");
 const RELEASE_MUTATION_IDENTITY_FIXTURE_SHA256 = "8205d24e6d42dd4cb8986368611514131abe701434beb30150e33ea08f4b1288";
-const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "669db10763ccc17945c689a035d9996d77314408bc860e29e0ecf31f1f49b4b4";
+const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "3b62bcb6d999857c6027db81a5ba2efc406ed37a7505a102138902c1bbd0dffc";
 const releaseMutationIdentityFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-identity.v2.json");
 const releaseMutationTransitionFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-transition.v3.json");
 const releaseIntegritySourcePath = path.join(repoRoot, "tests/release-integrity.test.ts");
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "6dfca383de8d53508a3b93d9e07f73e019b63dffa0696486938c60b13c64bb1a" }
+    { count: 4, sha256: "bcd3542830e12f37b1e0e898e847a52f39e3a644ffb4f63ef8feac81e3ce1ae9" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "16d035dcb619ed86a565e7aa31d24ffe1eaf3be6126768a6934d95ffb5075997"],
   ["K-1 block-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
   ["K-1 line-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
-  ["K-1 module-extension normalization", "a8a82204030d1e2837f67cfca53062f14bf0a547434dcfa9de1b2d7903307757"],
-  ["K-1 source-path separator normalization", "c4c0053677a5715b9903b3b65d94de7939e89f5cd409e934c8976aa803b87bdf"],
+  ["K-1 module-extension normalization", "f5b771429286a2c274192c1dc3dd31528a92ace1e90521680e669358efdfa0d6"],
+  ["K-1 source-path separator normalization", "20ec0e7ec8876317dccb52b79369ad71c2e796600f34b04d0c691cf83ae794b6"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -34,7 +34,7 @@ import { releaseMutationVersionedTransitionAuditProblems } from "./release-mutat
 
 const repoRoot = path.resolve(__dirname, "..");
 const RELEASE_MUTATION_IDENTITY_FIXTURE_SHA256 = "8205d24e6d42dd4cb8986368611514131abe701434beb30150e33ea08f4b1288";
-const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "3b62bcb6d999857c6027db81a5ba2efc406ed37a7505a102138902c1bbd0dffc";
+const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "70c33477bbd3071ec4caf47fcd3913b7704b53c5e0fb6f19e21e35a64df433e8";
 const releaseMutationIdentityFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-identity.v2.json");
 const releaseMutationTransitionFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-transition.v3.json");
 const releaseIntegritySourcePath = path.join(repoRoot, "tests/release-integrity.test.ts");
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "bcd3542830e12f37b1e0e898e847a52f39e3a644ffb4f63ef8feac81e3ce1ae9" }
+    { count: 4, sha256: "2fc773a8836e9c9fbcef8b7699e40c015f5bf14df6e3b86c76625ab2b50135cd" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "16d035dcb619ed86a565e7aa31d24ffe1eaf3be6126768a6934d95ffb5075997"],
   ["K-1 block-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
   ["K-1 line-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
-  ["K-1 module-extension normalization", "f5b771429286a2c274192c1dc3dd31528a92ace1e90521680e669358efdfa0d6"],
-  ["K-1 source-path separator normalization", "20ec0e7ec8876317dccb52b79369ad71c2e796600f34b04d0c691cf83ae794b6"],
+  ["K-1 module-extension normalization", "514e6393d0473cee06747aee6d0868c5006f43d55d7f35692ada27a49b2daacd"],
+  ["K-1 source-path separator normalization", "42e6682e7388c1a75810d8a7922ccaef610094260b19b15ed3ea736d0cc802c5"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -2197,5 +2197,87 @@ describe("prepareServerDeps — complete semantic-generation admission", () => {
       resetSemanticAdmissionRuntimeMocks();
       await removeSemanticAdmissionFixture(drift);
     }
+
+    const throwDrift = await createSemanticAdmissionFixture();
+    const throwPersistFile = hnswPersistBase(throwDrift.embedFile);
+    const throwPersistEvents: string[] = [];
+    const throwClear = vi.fn(async (file: unknown, scopes: unknown) => {
+      throwPersistEvents.push("clear");
+      const actual = await vi.importActual<typeof import("../src/hnsw.js")>("../src/hnsw.js");
+      return actual.clearHnswPersistedArtifacts(file as string, scopes as never);
+    });
+    const throwSaveTo = vi.fn(async (file: unknown, ..._args: unknown[]) => {
+      throwPersistEvents.push("save");
+      await fs.writeFile(`${String(file)}.meta.json`, '{"formatVersion":4}\n');
+      const writer = new EmbedDb({
+        file: throwDrift.embedFile,
+        vaultRoot: throwDrift.vaultRoot,
+        modelAlias: "multilingual",
+        dim: 384,
+        quantization: "f32"
+      });
+      await writer.open();
+      try {
+        const vector = new Float32Array(384);
+        vector[0] = 1;
+        writer.upsertNote("Unrelated.md", Date.now(), [
+          {
+            chunkIndex: 0,
+            lineStart: 1,
+            lineEnd: 1,
+            textPreview: "unrelated note indexed during HNSW persist",
+            vector
+          }
+        ]);
+      } finally {
+        await writer.closeAndRelease();
+      }
+      throw new Error("injected publisher lease-release failure");
+    });
+    const throwBuild = vi.fn(async (..._args: unknown[]) => ({
+      dim: 384,
+      size: 1,
+      searchKnn: () => ({ labels: [1], distances: [0] }),
+      setEf: () => {},
+      applyDiff: async () => {},
+      saveTo: throwSaveTo
+    }));
+    installSemanticAdmissionRuntimeMocks(throwBuild, { clearHnswPersistedArtifacts: throwClear });
+    const throwStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const [{ prepareServerDeps }, { embeddingsSearch: isolatedEmbeddingsSearch }] = await Promise.all([
+        import("../src/server.js"),
+        import("../src/tools/search.js")
+      ]);
+      const deps = await prepareServerDeps({ vault: throwDrift.vaultRoot, useHnsw: true });
+
+      expect(throwBuild).toHaveBeenCalledTimes(1);
+      expect(throwSaveTo).toHaveBeenCalledTimes(1);
+      expect(throwSaveTo.mock.calls[0]?.[0]).toBe(throwPersistFile);
+      expect(throwPersistEvents).toEqual(["save", "clear"]);
+      expect(throwClear).toHaveBeenCalledWith(throwPersistFile, throwSaveTo.mock.calls[0]?.[4]);
+      expect(deps.hnswContext).toBeNull();
+      expect(deps.watcherHealth).toMatchObject({ semanticUsable: true, hnswUsable: true });
+      await expect(fs.lstat(`${throwPersistFile}.meta.json`)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const result = await isolatedEmbeddingsSearch(
+        deps.vault,
+        { query: "semantic admission marker", limit: 1 },
+        throwDrift.embedFile,
+        deps.hnswContext,
+        deps.watcherHealth
+      );
+      expect(result.method).toBe("embeddings-cosine");
+      expect(result.matches.map((match) => match.path)).toEqual(["Semantic.md"]);
+
+      const log = throwStderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(log).toMatch(/HNSW persist failed.*injected publisher lease-release failure/is);
+      expect(log).toMatch(/embedding database changed while HNSW was persisting/i);
+      expect(log).not.toMatch(/immutable generation \+ meta pointer persisted/i);
+    } finally {
+      throwStderr.mockRestore();
+      resetSemanticAdmissionRuntimeMocks();
+      await removeSemanticAdmissionFixture(throwDrift);
+    }
   });
 });

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -83,7 +83,10 @@ async function removeSemanticAdmissionFixture(fixture: SemanticAdmissionFixture)
   await fs.rm(fixture.scratch, { recursive: true, force: true });
 }
 
-function installSemanticAdmissionRuntimeMocks(buildHnsw: (...args: unknown[]) => Promise<unknown>): void {
+function installSemanticAdmissionRuntimeMocks(
+  buildHnsw: (...args: unknown[]) => Promise<unknown>,
+  hnswOverrides: Record<string, unknown> = {}
+): void {
   vi.resetModules();
   vi.doMock("@huggingface/transformers", () => ({
     env: { allowRemoteModels: true, allowLocalModels: true },
@@ -96,7 +99,7 @@ function installSemanticAdmissionRuntimeMocks(buildHnsw: (...args: unknown[]) =>
   }));
   vi.doMock("../src/hnsw.js", async () => {
     const actual = await vi.importActual<typeof import("../src/hnsw.js")>("../src/hnsw.js");
-    return { ...actual, buildHnsw };
+    return { ...actual, buildHnsw, ...hnswOverrides };
   });
 }
 
@@ -2112,6 +2115,87 @@ describe("prepareServerDeps — complete semantic-generation admission", () => {
       stderr.mockRestore();
       resetSemanticAdmissionRuntimeMocks();
       await removeSemanticAdmissionFixture(fixture);
+    }
+
+    const drift = await createSemanticAdmissionFixture();
+    const driftPersistFile = hnswPersistBase(drift.embedFile);
+    const persistEvents: string[] = [];
+    const clear = vi.fn(async (file: unknown, scopes: unknown) => {
+      persistEvents.push("clear");
+      const actual = await vi.importActual<typeof import("../src/hnsw.js")>("../src/hnsw.js");
+      return actual.clearHnswPersistedArtifacts(file as string, scopes as never);
+    });
+    const driftSaveTo = vi.fn(async (file: unknown, ..._args: unknown[]) => {
+      persistEvents.push("save");
+      await fs.writeFile(`${String(file)}.meta.json`, '{"formatVersion":4}\n');
+      const writer = new EmbedDb({
+        file: drift.embedFile,
+        vaultRoot: drift.vaultRoot,
+        modelAlias: "multilingual",
+        dim: 384,
+        quantization: "f32"
+      });
+      await writer.open();
+      try {
+        const vector = new Float32Array(384);
+        vector[0] = 1;
+        writer.upsertNote("Unrelated.md", Date.now(), [
+          {
+            chunkIndex: 0,
+            lineStart: 1,
+            lineEnd: 1,
+            textPreview: "unrelated note indexed during HNSW persist",
+            vector
+          }
+        ]);
+      } finally {
+        await writer.closeAndRelease();
+      }
+      return true;
+    });
+    const driftBuild = vi.fn(async (..._args: unknown[]) => ({
+      dim: 384,
+      size: 1,
+      searchKnn: () => ({ labels: [1], distances: [0] }),
+      setEf: () => {},
+      applyDiff: async () => {},
+      saveTo: driftSaveTo
+    }));
+    installSemanticAdmissionRuntimeMocks(driftBuild, { clearHnswPersistedArtifacts: clear });
+    const driftStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const [{ prepareServerDeps }, { embeddingsSearch: isolatedEmbeddingsSearch }] = await Promise.all([
+        import("../src/server.js"),
+        import("../src/tools/search.js")
+      ]);
+      const deps = await prepareServerDeps({ vault: drift.vaultRoot, useHnsw: true });
+
+      expect(driftBuild).toHaveBeenCalledTimes(1);
+      expect(driftSaveTo).toHaveBeenCalledTimes(1);
+      expect(driftSaveTo.mock.calls[0]?.[0]).toBe(driftPersistFile);
+      expect(persistEvents).toEqual(["save", "clear"]);
+      expect(clear).toHaveBeenCalledWith(driftPersistFile, driftSaveTo.mock.calls[0]?.[4]);
+      expect(deps.hnswContext).toBeNull();
+      expect(deps.watcherHealth).toMatchObject({ semanticUsable: true, hnswUsable: true });
+      await expect(fs.lstat(`${driftPersistFile}.meta.json`)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const result = await isolatedEmbeddingsSearch(
+        deps.vault,
+        { query: "semantic admission marker", limit: 1 },
+        drift.embedFile,
+        deps.hnswContext,
+        deps.watcherHealth
+      );
+      expect(result.method).toBe("embeddings-cosine");
+      expect(result.matches.map((match) => match.path)).toEqual(["Semantic.md"]);
+
+      const log = driftStderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(log).toMatch(/embedding database changed while HNSW was persisting/i);
+      expect(log).not.toMatch(/immutable generation \+ meta pointer persisted/i);
+    } finally {
+      driftStderr.mockRestore();
+      resetSemanticAdmissionRuntimeMocks();
+      await removeSemanticAdmissionFixture(drift);
     }
   });
 });


### PR DESCRIPTION
## Bound claim

Startup `--use-hnsw` persistence no longer leaves a published HNSW generation on disk after EmbedDb drifts and the in-memory graph is discarded.

`prepareServerDeps` already refused the candidate when `captureHnswReceiptSnapshot()` drifted after `saveTo`. It did **not** call `clearHnswPersistedArtifacts` when `saveTo` threw after the meta pointer committed (lease-release failure leaves `persisted === false`). Watcher `flushHnswToDisk` already erases that family. Compact v4 pointers omit `text_preview`; the immutable native generation remains sensitive.

## Product

- After a startup persist **attempt**, a changed HNSW receipt discards the candidate **and** clears the persist base (best-effort). That includes `saveTo` throwing after the pointer commits.
- Persist-disabled startup and build-time drift (no `saveTo`) still do not erase.
- Uncommitted `saveTo(false)` with matching receipts still keeps the in-memory candidate and the previous sidecar.
- The erase sits on the discarded-candidate arm, outside the receipt→attach await window, so it is not a publish/attach suspension.
- Brute-force search stays up (`hnswContext: null`, no `semanticUsable` latch).

## Proof

Extra phases of `treats saveTo(false) as an uncommitted optimization without a persisted-success receipt`. No new `it()`.

1. `saveTo` writes a meta pointer then upserts `Unrelated.md` and returns `true`.
2. `saveTo` writes a meta pointer, upserts, then throws (lease-release shape).

Both must return `hnswContext: null`, run the eraser after `saveTo`, leave the pointer gone, and keep brute search returning `Semantic.md`.

## Pins

`src/server.ts` is a K-1 production pin and schema-v3 `source.server-ts`. This commit refreshes:

- K-1 `src/server.ts` sha256
- schema-v3 `source.server-ts` `witness.to`
- `RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256`
- k1-ast mutation-helper census identity (count stays 4)
- K-1 ordinary-transform owner digests (whole-file of `k1-ast-invariant.test.ts`)

## Non-claims

Does not change watcher `hnswPersistUnsafe`, load-time discard, empty-index erase, or A5 schema 3→5 vector drop. Watcher flush has the same post-commit lease-release hole; that is a sibling residual, not this PR.

BACKLOG §1.CC-HOLD **H3**. D-45: executable proof is GitHub-hosted.
