### PR TITLE
fix: end HTTP responses after post-header transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented here. The format follows 
 >
 > **Bounded claim.** This does **not** change JSON-RPC error bodies for pre-header failures. It does **not** change H6 (`connect` overwriting stateful `onclose`). It does **not** reopen A9 bounded session close.
 >
-> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: `writeHead` then throws, `fetch` must finish within 3s, and stderr names the injected failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: `writeHead` sends a close-delimited status then throws, `fetch` must finish within 3s, and stderr names the injected failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
 - **Caught transport errors finish the HTTP response.** If headers are already sent, the catch path ends the body instead of returning with the socket still open.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented here. The format follows 
 >
 > **Bounded claim.** This does **not** change JSON-RPC error bodies for pre-header failures. It does **not** change H6 (`connect` overwriting stateful `onclose`). It does **not** reopen A9 bounded session close.
 >
-> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: `writeHead` sends a close-delimited status then throws, `fetch` must finish within 3s, and stderr names the injected failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: `writeHead` sends a close-delimited status, the first later `write`/`end` throws into the product catch (not inside `writeHead`, which `@hono/node-server` swallows), `fetch` must finish within 3s, and stderr names the injected initialize failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
 - **Caught transport errors finish the HTTP response.** If headers are already sent, the catch path ends the body instead of returning with the socket still open.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### HTTP catch paths end a response that already sent headers
+
+> **TL;DR:** **A post-header HTTP transport error no longer leaves the client socket open.** Catch paths on stateful POST, initialize, the outer handler, stateless dispatch, and SSE logged the error and called `sendJsonRpcError` only when headers were still unsent. Once the SDK had started the response, the handler returned without `res.end()`.
+>
+> **Bounded claim.** This does **not** change JSON-RPC error bodies for pre-header failures. It does **not** change H6 (`connect` overwriting stateful `onclose`). It does **not** reopen A9 bounded session close.
+>
+> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: `writeHead` then throws, `fetch` must finish within 3s, and stderr names the injected failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Caught transport errors finish the HTTP response.** If headers are already sent, the catch path ends the body instead of returning with the socket still open.
+
 ### Startup HNSW persist erases the family when EmbedDb drifts after saveTo
 
 > **TL;DR:** **Startup `--use-hnsw` persistence no longer leaves a published generation on disk after EmbedDb drifts and the in-memory graph is discarded.** `saveTo` can commit the immutable binary plus meta pointer and still throw on later lease-release; a receipt mismatch only logged and dropped the candidate. The watcher flush already erases that family. Startup now calls the same eraser, best-effort, when persist was attempted and the candidate is discarded. Compact v4 pointers omit `text_preview`; native vectors in the generation remain sensitive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented here. The format follows 
 >
 > **Bounded claim.** This does **not** change JSON-RPC error bodies for pre-header failures. It does **not** change H6 (`connect` overwriting stateful `onclose`). It does **not** reopen A9 bounded session close.
 >
-> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: `writeHead` sends a close-delimited status, the first later `write`/`end` throws into the product catch (not inside `writeHead`, which `@hono/node-server` swallows), `fetch` must finish within 3s, and stderr names the injected initialize failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: a per-response wrap of `NodeStreamableHTTPServerTransport.handleRequest` sends a close-delimited `writeHead`, leaves `end` uncommitted during the Hono listener (which swallows `write`/`end` throws), then throws `injected post-header failure` after that listener returns so the product initialize catch runs. `fetch` must finish within 3s, and stderr names the injected initialize failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
 - **Caught transport errors finish the HTTP response.** If headers are already sent, the catch path ends the body instead of returning with the socket still open.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented here. The format follows 
 
 ### HTTP catch paths end a response that already sent headers
 
-> **TL;DR:** **A post-header HTTP transport error no longer leaves the client socket open.** Catch paths on stateful POST, initialize, the outer handler, stateless dispatch, and SSE logged the error and called `sendJsonRpcError` only when headers were still unsent. Once the SDK had started the response, the handler returned without `res.end()`.
+> **TL;DR:** **A post-header HTTP transport error no longer leaves the client socket open.** Catch paths on stateful POST, initialize, DELETE, the outer handler, stateless dispatch, and SSE logged the error and called `sendJsonRpcError` only when headers were still unsent. Once the SDK had started the response, the handler returned without `res.end()`. Stateful DELETE swallowed `handleRequest` rejection and closed only protocol objects.
 >
 > **Bounded claim.** This does **not** change JSON-RPC error bodies for pre-header failures. It does **not** change H6 (`connect` overwriting stateful `onclose`). It does **not** reopen A9 bounded session close.
 >
-> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is an extra phase of the existing late-publication handler test: a per-response wrap of `NodeStreamableHTTPServerTransport.handleRequest` sends a close-delimited `writeHead`, leaves `end` uncommitted during the Hono listener (which swallows `write`/`end` throws), then throws `injected post-header failure` after that listener returns so the product initialize catch runs. `fetch` must finish within 3s, and stderr names the injected initialize failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+> **Method note:** BACKLOG §1.CC-HOLD **H5**. Coverage is extra phases of the existing late-publication handler test and the real-session DELETE test: a per-response wrap of `NodeStreamableHTTPServerTransport.handleRequest` sends a close-delimited `writeHead`, leaves `end` uncommitted during the Hono listener (which swallows `write`/`end` throws), then throws `injected post-header failure` after that listener returns so the product initialize and DELETE catches run. `fetch` must finish within 3s, and stderr names the injected failure. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
 - **Caught transport errors finish the HTTP response.** If headers are already sent, the catch path ends the body instead of returning with the socket still open.
 

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -1435,8 +1435,11 @@ export function createHttpHandler(
             false,
             internals.afterStatefulRequestAdmitted
           );
-        } catch {
-          /* shutdown errors don't matter — we're killing the session anyway */
+        } catch (err) {
+          process.stderr.write(
+            `enquire http: stateful DELETE error — ${err instanceof Error ? err.message : String(err)}\n`
+          );
+          finishCaughtHttpResponse(res);
         }
         await session.transport.close().catch(() => {});
         await session.server.close().catch(() => {});

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -604,6 +604,15 @@ function sendJsonRpcError(res: ServerResponse, httpStatus: number, code: number,
   );
 }
 
+/** After a caught transport error, never leave a started HTTP response open. */
+function finishCaughtHttpResponse(res: ServerResponse): void {
+  if (!res.headersSent) {
+    sendJsonRpcError(res, 500, -32603, "Internal server error");
+    return;
+  }
+  if (!res.writableEnded) res.end();
+}
+
 /**
  * Apply browser CORS response headers after Origin admission succeeds.
  *
@@ -1466,6 +1475,7 @@ export function createHttpHandler(
           );
         } catch (err) {
           process.stderr.write(`enquire http: SSE error — ${err instanceof Error ? err.message : String(err)}\n`);
+          finishCaughtHttpResponse(res);
         }
         return;
       }
@@ -1504,9 +1514,7 @@ export function createHttpHandler(
           process.stderr.write(
             `enquire http: stateful transport error — ${err instanceof Error ? err.message : String(err)}\n`
           );
-          if (!res.headersSent) {
-            sendJsonRpcError(res, 500, -32603, "Internal server error");
-          }
+          finishCaughtHttpResponse(res);
         }
         return;
       }
@@ -1642,9 +1650,7 @@ export function createHttpHandler(
             if (sid) registry.sessions.delete(sid);
             if (transport) void transport.close().catch(() => {});
             if (server) void server.close().catch(() => {});
-            if (!res.headersSent) {
-              sendJsonRpcError(res, 500, -32603, "Internal server error");
-            }
+            finishCaughtHttpResponse(res);
           }
         });
       } catch (err) {
@@ -1667,9 +1673,7 @@ export function createHttpHandler(
       process.stderr.write(
         `enquire http: handler error — ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`
       );
-      if (!res.headersSent) {
-        sendJsonRpcError(res, 500, -32603, "Internal server error");
-      }
+      finishCaughtHttpResponse(res);
     }
   };
 }
@@ -1710,9 +1714,7 @@ async function handleStatelessRequest(
     await transport.handleRequest(req, res, body);
   } catch (err) {
     process.stderr.write(`enquire http: transport error — ${err instanceof Error ? err.message : String(err)}\n`);
-    if (!res.headersSent) {
-      sendJsonRpcError(res, 500, -32603, "Internal server error");
-    }
+    finishCaughtHttpResponse(res);
     // Belt-and-suspenders: if the response stream never emits 'close' (e.g.
     // connect threw before the socket was wired), free the handles now.
     cleanup();

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -634,22 +634,22 @@ describe("SessionRegistry (v2.14.0)", () => {
       await closeServerBounded(httpServer);
     }
 
-    const hangHandler = createHttpHandler(
-      deps,
-      {
-        vault: root,
-        port: 0,
-        host: "127.0.0.1",
-        bearerToken: "late-registration-test-token-1234567890",
-        stateful: true,
-        rateLimitPerMinute: 0,
-        installSignalHandlers: false
-      }
-    );
+    const hangHandler = createHttpHandler(deps, {
+      vault: root,
+      port: 0,
+      host: "127.0.0.1",
+      bearerToken: "late-registration-test-token-1234567890",
+      stateful: true,
+      rateLimitPerMinute: 0,
+      installSignalHandlers: false
+    });
     const hangServer = createServer((req, res) => {
       const writeHead = res.writeHead.bind(res);
-      res.writeHead = ((...args: unknown[]) => {
-        (writeHead as (...inner: unknown[]) => unknown)(...args);
+      // Forwarding the SDK's Content-Length then throwing leaves an unfinished
+      // body; undici reports "other side closed". A close-delimited head is
+      // the post-header state finishCaughtHttpResponse can complete.
+      res.writeHead = ((statusCode: number, ..._rest: unknown[]) => {
+        writeHead(statusCode, { Connection: "close" });
         throw new Error("injected post-header failure");
       }) as typeof res.writeHead;
       void hangHandler(req, res);

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -633,6 +633,57 @@ describe("SessionRegistry (v2.14.0)", () => {
     } finally {
       await closeServerBounded(httpServer);
     }
+
+    const hangHandler = createHttpHandler(
+      deps,
+      {
+        vault: root,
+        port: 0,
+        host: "127.0.0.1",
+        bearerToken: "late-registration-test-token-1234567890",
+        stateful: true,
+        rateLimitPerMinute: 0,
+        installSignalHandlers: false
+      }
+    );
+    const hangServer = createServer((req, res) => {
+      const writeHead = res.writeHead.bind(res);
+      res.writeHead = ((...args: unknown[]) => {
+        (writeHead as (...inner: unknown[]) => unknown)(...args);
+        throw new Error("injected post-header failure");
+      }) as typeof res.writeHead;
+      void hangHandler(req, res);
+    });
+    await new Promise<void>((resolve) => hangServer.listen(0, "127.0.0.1", resolve));
+    const hangStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const addr = hangServer.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${addr.port}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: "Bearer late-registration-test-token-1234567890"
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "late-registration-test", version: "0" }
+          }
+        }),
+        signal: AbortSignal.timeout(3000)
+      });
+      await response.text();
+      const log = hangStderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(log).toMatch(/stateful initialize error.*injected post-header failure/is);
+    } finally {
+      hangStderr.mockRestore();
+      await closeServerBounded(hangServer);
+    }
   });
 });
 

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -645,13 +645,29 @@ describe("SessionRegistry (v2.14.0)", () => {
     });
     const hangServer = createServer((req, res) => {
       const writeHead = res.writeHead.bind(res);
-      // Forwarding the SDK's Content-Length then throwing leaves an unfinished
-      // body; undici reports "other side closed". A close-delimited head is
-      // the post-header state finishCaughtHttpResponse can complete.
-      res.writeHead = ((statusCode: number, ..._rest: unknown[]) => {
-        writeHead(statusCode, { Connection: "close" });
+      const write = res.write.bind(res);
+      const end = res.end.bind(res);
+      let injected = false;
+      const injectAfterHeaders = (): void => {
+        if (injected || !res.headersSent) return;
+        injected = true;
         throw new Error("injected post-header failure");
-      }) as typeof res.writeHead;
+      };
+      // Close-delimited head so finishCaughtHttpResponse can complete the
+      // body. Throw on the first write/end AFTER writeHead returns — a throw
+      // inside writeHead is swallowed by @hono/node-server and never reaches
+      // the product catch.
+      res.writeHead = ((statusCode: number, ..._rest: unknown[]) =>
+        writeHead(statusCode, { Connection: "close" })) as typeof res.writeHead;
+      res.write = ((...args: unknown[]) => {
+        injectAfterHeaders();
+        return (write as (...inner: unknown[]) => boolean)(...args);
+      }) as typeof res.write;
+      res.end = ((...args: unknown[]) => {
+        if (!res.headersSent) writeHead(res.statusCode || 200, { Connection: "close" });
+        injectAfterHeaders();
+        return (end as (...inner: unknown[]) => unknown)(...args);
+      }) as typeof res.end;
       void hangHandler(req, res);
     });
     await new Promise<void>((resolve) => hangServer.listen(0, "127.0.0.1", resolve));

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -14,11 +14,12 @@
 
 import { EventEmitter } from "node:events";
 import { promises as fs } from "node:fs";
-import { createServer } from "node:http";
+import { createServer, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   closeServerBounded,
@@ -643,36 +644,38 @@ describe("SessionRegistry (v2.14.0)", () => {
       rateLimitPerMinute: 0,
       installSignalHandlers: false
     });
-    const hangServer = createServer((req, res) => {
+    const originalHandleRequest = NodeStreamableHTTPServerTransport.prototype.handleRequest;
+    const injectResponses = new WeakSet<ServerResponse>();
+    NodeStreamableHTTPServerTransport.prototype.handleRequest = async function (req, res, parsedBody) {
+      if (!injectResponses.has(res)) {
+        return originalHandleRequest.call(this, req, res, parsedBody);
+      }
       const writeHead = res.writeHead.bind(res);
-      const write = res.write.bind(res);
       const end = res.end.bind(res);
-      let injected = false;
-      const injectAfterHeaders = (): void => {
-        if (injected || !res.headersSent) return;
-        injected = true;
-        throw new Error("injected post-header failure");
-      };
-      // Close-delimited head so finishCaughtHttpResponse can complete the
-      // body. Throw on the first write/end AFTER writeHead returns — a throw
-      // inside writeHead is swallowed by @hono/node-server and never reaches
-      // the product catch.
+      // Close-delimited head so finishCaughtHttpResponse can complete the body.
+      // Leave end uncommitted during the Hono listener — a throw from
+      // write/end is swallowed by @hono/node-server and never reaches the
+      // product catch. Throw after that listener returns, still inside the
+      // product's await tr.handleRequest.
       res.writeHead = ((statusCode: number, ..._rest: unknown[]) =>
         writeHead(statusCode, { Connection: "close" })) as typeof res.writeHead;
-      res.write = ((...args: unknown[]) => {
-        injectAfterHeaders();
-        return (write as (...inner: unknown[]) => boolean)(...args);
-      }) as typeof res.write;
-      res.end = ((...args: unknown[]) => {
-        if (!res.headersSent) writeHead(res.statusCode || 200, { Connection: "close" });
-        injectAfterHeaders();
-        return (end as (...inner: unknown[]) => unknown)(...args);
-      }) as typeof res.end;
+      res.end = ((..._args: unknown[]) => res) as typeof res.end;
+      try {
+        await originalHandleRequest.call(this, req, res, parsedBody);
+      } finally {
+        res.end = end;
+      }
+      if (res.headersSent && !res.writableEnded) {
+        throw new Error("injected post-header failure");
+      }
+    };
+    const hangServer = createServer((req, res) => {
+      injectResponses.add(res);
       void hangHandler(req, res);
     });
-    await new Promise<void>((resolve) => hangServer.listen(0, "127.0.0.1", resolve));
     const hangStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     try {
+      await new Promise<void>((resolve) => hangServer.listen(0, "127.0.0.1", resolve));
       const addr = hangServer.address() as AddressInfo;
       const response = await fetch(`http://127.0.0.1:${addr.port}/mcp`, {
         method: "POST",
@@ -697,6 +700,7 @@ describe("SessionRegistry (v2.14.0)", () => {
       const log = hangStderr.mock.calls.map(([chunk]) => String(chunk)).join("");
       expect(log).toMatch(/stateful initialize error.*injected post-header failure/is);
     } finally {
+      NodeStreamableHTTPServerTransport.prototype.handleRequest = originalHandleRequest;
       hangStderr.mockRestore();
       await closeServerBounded(hangServer);
     }

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -97,6 +97,41 @@ function createStartupListenerFixture(options: { listenError?: Error; closeError
   return { server, closeCalls: () => closes };
 }
 
+/** Extra-phase seam: Hono swallows write/end throws, so reject after it returns. */
+function installInjectedPostHeaderHandleRequestFailure(): {
+  track(res: ServerResponse): void;
+  restore(): void;
+} {
+  const originalHandleRequest = NodeStreamableHTTPServerTransport.prototype.handleRequest;
+  const injectResponses = new WeakSet<ServerResponse>();
+  NodeStreamableHTTPServerTransport.prototype.handleRequest = async function (req, res, parsedBody) {
+    if (!injectResponses.has(res)) {
+      return originalHandleRequest.call(this, req, res, parsedBody);
+    }
+    const writeHead = res.writeHead.bind(res);
+    const end = res.end.bind(res);
+    res.writeHead = ((statusCode: number, ..._rest: unknown[]) =>
+      writeHead(statusCode, { Connection: "close" })) as typeof res.writeHead;
+    res.end = ((..._args: unknown[]) => res) as typeof res.end;
+    try {
+      await originalHandleRequest.call(this, req, res, parsedBody);
+    } finally {
+      res.end = end;
+    }
+    if (res.headersSent && !res.writableEnded) {
+      throw new Error("injected post-header failure");
+    }
+  };
+  return {
+    track(res) {
+      injectResponses.add(res);
+    },
+    restore() {
+      NodeStreamableHTTPServerTransport.prototype.handleRequest = originalHandleRequest;
+    }
+  };
+}
+
 function modernHttpV2Problems(source: string): string[] {
   const problems: string[] = [];
   const lifecycleStart = source.indexOf("function createModernHttpLifecycle(");
@@ -644,33 +679,9 @@ describe("SessionRegistry (v2.14.0)", () => {
       rateLimitPerMinute: 0,
       installSignalHandlers: false
     });
-    const originalHandleRequest = NodeStreamableHTTPServerTransport.prototype.handleRequest;
-    const injectResponses = new WeakSet<ServerResponse>();
-    NodeStreamableHTTPServerTransport.prototype.handleRequest = async function (req, res, parsedBody) {
-      if (!injectResponses.has(res)) {
-        return originalHandleRequest.call(this, req, res, parsedBody);
-      }
-      const writeHead = res.writeHead.bind(res);
-      const end = res.end.bind(res);
-      // Close-delimited head so finishCaughtHttpResponse can complete the body.
-      // Leave end uncommitted during the Hono listener — a throw from
-      // write/end is swallowed by @hono/node-server and never reaches the
-      // product catch. Throw after that listener returns, still inside the
-      // product's await tr.handleRequest.
-      res.writeHead = ((statusCode: number, ..._rest: unknown[]) =>
-        writeHead(statusCode, { Connection: "close" })) as typeof res.writeHead;
-      res.end = ((..._args: unknown[]) => res) as typeof res.end;
-      try {
-        await originalHandleRequest.call(this, req, res, parsedBody);
-      } finally {
-        res.end = end;
-      }
-      if (res.headersSent && !res.writableEnded) {
-        throw new Error("injected post-header failure");
-      }
-    };
+    const injected = installInjectedPostHeaderHandleRequestFailure();
     const hangServer = createServer((req, res) => {
-      injectResponses.add(res);
+      injected.track(res);
       void hangHandler(req, res);
     });
     const hangStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -700,7 +711,7 @@ describe("SessionRegistry (v2.14.0)", () => {
       const log = hangStderr.mock.calls.map(([chunk]) => String(chunk)).join("");
       expect(log).toMatch(/stateful initialize error.*injected post-header failure/is);
     } finally {
-      NodeStreamableHTTPServerTransport.prototype.handleRequest = originalHandleRequest;
+      injected.restore();
       hangStderr.mockRestore();
       await closeServerBounded(hangServer);
     }
@@ -2141,6 +2152,69 @@ describe("startHttpServer stateful sessions (v2.14.0)", () => {
       await after.text();
     } finally {
       await s.close();
+    }
+
+    const vault = new Vault(root);
+    await vault.ensureExists();
+    const deps: Parameters<typeof createHttpHandler>[0] = {
+      vault,
+      ftsIndex: null,
+      watcher: null,
+      watcherEmbedDb: null,
+      feedbackStore: null,
+      disabledTools: new Set(),
+      enabledTools: new Set(),
+      warningTracker: { printed: false },
+      hnswContext: null
+    };
+    const hangHandler = createHttpHandler(deps, {
+      vault: root,
+      port: 0,
+      host: "127.0.0.1",
+      bearerToken: TOKEN,
+      stateful: true,
+      rateLimitPerMinute: 0,
+      installSignalHandlers: false
+    });
+    const injected = installInjectedPostHeaderHandleRequestFailure();
+    const hangServer = createServer((req, res) => {
+      if (req.method === "DELETE") injected.track(res);
+      void hangHandler(req, res);
+    });
+    const hangStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await new Promise<void>((resolve) => hangServer.listen(0, "127.0.0.1", resolve));
+      const addr = hangServer.address() as AddressInfo;
+      const url = `http://127.0.0.1:${addr.port}`;
+      const { sessionId, rawResponse } = await initSession(url);
+      await rawResponse.text();
+      const del = await fetch(`${url}/mcp`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          "Mcp-Session-Id": sessionId
+        },
+        signal: AbortSignal.timeout(3000)
+      });
+      await del.text();
+      const log = hangStderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(log).toMatch(/stateful DELETE error.*injected post-header failure/is);
+      const after = await fetch(`${url}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: `Bearer ${TOKEN}`,
+          "Mcp-Session-Id": sessionId
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 })
+      });
+      expect(after.status).toBe(404);
+      await after.text();
+    } finally {
+      injected.restore();
+      hangStderr.mockRestore();
+      await closeServerBounded(hangServer);
     }
   });
 

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "27a837fa65cdfee66af4d3b41a938c060b094fc4e5afb153ea32b89206a21830" }],
+  ["http-transport.test.ts", { count: 1, sha256: "6d212dbfd4dc7aa471e0a04e3876c4aa868b80fb68701db5060d1a9bae92eca3" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "6d212dbfd4dc7aa471e0a04e3876c4aa868b80fb68701db5060d1a9bae92eca3" }],
+  ["http-transport.test.ts", { count: 1, sha256: "8b3b5920dc09e2bf89385ec1dfa43df673c6156129b545cdec2418ab5c79279e" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "8b3b5920dc09e2bf89385ec1dfa43df673c6156129b545cdec2418ab5c79279e" }],
+  ["http-transport.test.ts", { count: 1, sha256: "4a199f3e843d763b7dcd9c1ea40088b3d91ca045b7c7ef6b44cec38fda3cbe5c" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "891a03bf908a6a4d2419eb105bfd290a9a7ae9fccbd3695efe182ac7fb9b21c9" }],
+  ["http-transport.test.ts", { count: 1, sha256: "93d3e97f0ea4ddf738b8adb1c2bfd7c07796a9d84f9f85195414a326628c1f04" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -309,7 +309,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
   ["fts5.test.ts", { count: 5, sha256: "be662228a553da37b716611c7cc83e4a9d05b3532c77db61397e2d8db6ead21f" }],
-  ["http-transport.test.ts", { count: 1, sha256: "93d3e97f0ea4ddf738b8adb1c2bfd7c07796a9d84f9f85195414a326628c1f04" }],
+  ["http-transport.test.ts", { count: 1, sha256: "27a837fa65cdfee66af4d3b41a938c060b094fc4e5afb153ea32b89206a21830" }],
   [
     "hnsw-sync-critical-section.test.ts",
     { count: 6, sha256: "c8d9ddbc97806bdbf377279de1c49f62d801a5b1e7969ff98a56beb6878f8103" }


### PR DESCRIPTION
## Bound claim

A post-header HTTP transport error no longer leaves the client socket open.

Catch paths on stateful POST, initialize, DELETE, the outer handler, stateless dispatch, and SSE logged the error and called `sendJsonRpcError` only when headers were still unsent. Once the SDK had started the response, the handler returned without `res.end()`. Stateful DELETE swallowed `handleRequest` rejection and closed only protocol objects.

## Product

- `finishCaughtHttpResponse` sends the existing 500 JSON-RPC error when headers are unsent, otherwise `res.end()` if the body is still open.
- Stateful DELETE catch logs and calls `finishCaughtHttpResponse` before protocol close.
- Pre-header JSON-RPC errors are unchanged.
- Does not change H6 (`connect` overwriting stateful `onclose`).

## Proof

Extra phases of the existing late-publication handler test and `DELETE on a real session terminates it`. No new `it()`.

- Per-response wrap of `NodeStreamableHTTPServerTransport.handleRequest` (WeakSet-gated so parallel tests keep the original).
- `writeHead` sends a close-delimited status (does not forward SDK `Content-Length`).
- `end` is left uncommitted during the Hono listener. A throw from `write`/`end` is swallowed by `@hono/node-server` and is not this fixture.
- After that listener returns, the wrapper throws `injected post-header failure` into the product initialize and DELETE catches.
- `fetch` must finish within 3s (`AbortSignal.timeout`).
- stderr names the matching catch prefix plus the injected failure.

## Non-claims

Does not change H6, A9 bounded session close, or A5.

BACKLOG §1.CC-HOLD **H5**. D-45: executable proof is GitHub-hosted.
