### PR TITLE
fix: listPdfs must keep unreadable PDFs using walker size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### listPdfs keeps unreadable PDFs and uses the walker size
+
+> **TL;DR:** **`obsidian_list_pdfs` no longer drops a PDF the directory walk already admitted.** `listCanvases` keeps a malformed or unreadable canvas with `size_bytes` from the successful read or `0` on open failure. `listPdfs` re-read every file for size and `continue`d on that open, so a permission race or unreadable PDF vanished from the listing. The walker already recorded `sizeBytes`.
+>
+> **Bounded claim.** This does **not** change `readPdf` extraction, OCR, or canvas/base listings. Canvas and `.base` listings still open files because they need node/view counts. It does **not** reopen H5.
+>
+> **Method note:** BACKLOG §1.CC-ter **B2**. Coverage is an extra phase of the existing `lists PDFs with size + mtime` test: `readBinaryFile` throws after the walk, the row stays, and `size_bytes` matches the first listing. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Listing size comes from the walk.** `listPdfs` publishes `FileEntry.sizeBytes` instead of opening each PDF again.
+- **Unreadable PDFs stay in the listing.** An open failure after the walk no longer removes the row.
+
+### HTTP catch paths end a response that already sent headers
+
 ### HTTP catch paths end a response that already sent headers
 
 > **TL;DR:** **A post-header HTTP transport error no longer leaves the client socket open.** Catch paths on stateful POST, initialize, DELETE, the outer handler, stateless dispatch, and SSE logged the error and called `sendJsonRpcError` only when headers were still unsent. Once the SDK had started the response, the handler returned without `res.end()`. Stateful DELETE swallowed `handleRequest` rejection and closed only protocol objects.

--- a/src/tools/media.ts
+++ b/src/tools/media.ts
@@ -385,7 +385,7 @@ export interface PdfSummary {
   path: string;
   /** Filename minus the `.pdf` extension. */
   name: string;
-  /** File size in bytes. */
+  /** File size in bytes from the directory walk. `0` if the walker omitted it. */
   size_bytes: number;
   /** Last-modified ISO timestamp. */
   mtime: string;
@@ -398,7 +398,8 @@ export interface PdfSummary {
  * PDFs are the #1 non-markdown content kind in real research vaults. Same
  * privacy filter (`--exclude-glob` / `--read-paths`) applies. Returns
  * lightweight metadata only — for full text extraction call {@link readPdf}.
- * Unreadable PDFs are skipped without poisoning the listing.
+ * Unreadable PDFs stay in the listing with the walker's `sizeBytes` (or `0`
+ * when a synthetic `FileEntry` omitted it). The listing does not open files.
  *
  * @param vault - The vault.
  * @param args - All optional. `folder` restricts the scan. `limit`
@@ -421,18 +422,13 @@ export async function listPdfs(vault: Vault, args: { folder?: string; limit?: nu
   const out: PdfSummary[] = [];
   for (const e of all) {
     if (out.length >= limit) break;
-    let size = 0;
-    try {
-      const buf = await vault.readBinaryFile(e.absPath);
-      size = buf.byteLength;
-    } catch {
-      // Unreadable PDF — skip without poisoning the listing.
-      continue;
-    }
+    // Walker already captured `sizeBytes`. Do not re-read the file for a
+    // listing size, and do not drop the row when a later open fails —
+    // listCanvases keeps malformed/unreadable canvases with counts at 0.
     out.push({
       path: e.relPath,
       name: e.basename.replace(/\.pdf$/i, ""),
-      size_bytes: size,
+      size_bytes: e.sizeBytes ?? 0,
       mtime: new Date(e.mtimeMs).toISOString()
     });
   }

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -265,6 +265,19 @@ describe("listPdfs (v2.7.0)", () => {
     expect(first?.name).toBe("paper");
     expect(first?.size_bytes).toBeGreaterThan(0);
     expect(first?.mtime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const orig = v.readBinaryFile.bind(v);
+    v.readBinaryFile = async () => {
+      throw new Error("injected unread");
+    };
+    try {
+      const unread = await listPdfs(v, {});
+      expect(unread).toHaveLength(1);
+      expect(unread[0]?.path).toBe("paper.pdf");
+      expect(unread[0]?.size_bytes).toBe(first?.size_bytes);
+    } finally {
+      v.readBinaryFile = orig;
+    }
   });
 
   it("walks recursively into subfolders", async () => {


### PR DESCRIPTION
## Bound claim

`obsidian_list_pdfs` no longer drops a PDF the directory walk already admitted.

`listCanvases` keeps a malformed or unreadable canvas. `listPdfs` re-read every file for size and skipped on that open, so a permission race or unreadable PDF vanished from the listing. The walker already recorded `sizeBytes`.

## Product

- `listPdfs` publishes `FileEntry.sizeBytes` instead of opening each PDF again.
- An open failure after the walk no longer removes the row.
- Does not change `readPdf`, OCR, or canvas/base listings (those still open files for node/view counts).

## Proof

Extra phase of `lists PDFs with size + mtime`. No new `it()`.

- After the happy-path listing, `readBinaryFile` throws.
- The row stays, and `size_bytes` matches the first listing.

## Non-claims

Does not change H5, A5, or canvas/base listing shape.

BACKLOG §1.CC-ter **B2**. D-45: executable proof is GitHub-hosted.
