### PR TITLE
fix: Bases tag filters must read the singular tag key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Bases tag filters see the singular `tag` frontmatter key
+
+> **TL;DR:** **A Bases `tag ==` / `taggedWith` filter no longer misses notes that only declare `tag:`.** `extractFrontmatterTags`, `list_tags`, and write-path tag reads already fold `["tags", "tag"]`. Bases `collectTags` only looked up `tags`, so the Obsidian-documented singular key was invisible to `.base` filters.
+>
+> **Bounded claim.** This does **not** change inline `#tag` extraction, NFC/case folding, or search `lastIndexOf("#")` chunk stripping. Canvas/base listings still open files for counts. It does **not** reopen the listPdfs walker-size slice.
+>
+> **Method note:** BACKLOG §1.CC-ter **B2**. Coverage is extra phases of the existing `tag == "book"` and `taggedWith(file.file, "book")` tests: a note with only `tag: book` must match both filters. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Bases tag collection reads both keys.** `collectTags` uses the same `["tags", "tag"]` folded lookup as the other producers.
+
 ### listPdfs keeps unreadable PDFs and uses the walker size
 
 > **TL;DR:** **`obsidian_list_pdfs` no longer drops a PDF the directory walk already admitted.** `listCanvases` keeps a malformed or unreadable canvas with `size_bytes` from the successful read or `0` on open failure. `listPdfs` re-read every file for size and `continue`d on that open, so a permission race or unreadable PDF vanished from the listing. The walker already recorded `sizeBytes`.

--- a/src/bases.ts
+++ b/src/bases.ts
@@ -925,13 +925,14 @@ function literalEqual(a: unknown, b: unknown): boolean {
   return false;
 }
 
-/** Collect tags from frontmatter `tags:` (string or array) AND inline
+/** Collect tags from frontmatter `tags:` / `tag:` (string or array) AND inline
  *  `#tags` in the body. Lowercased + leading-# stripped. */
 function collectTags(fm: Record<string, unknown>, body: string): string[] {
   const out = new Set<string>();
-  // v3.11.0-rc.13 (rc.12-audit AUD-03) — fold the `tags` KEY so a `Tags:` frontmatter
-  // property is visible to Bases tag filters (the producer sibling of the H1 key-fold class).
-  const fmTags = lookupFoldedAny(fm, ["tags"]);
+  // v3.11.0-rc.13 (rc.12-audit AUD-03) — fold the `tags`/`tag` KEY so a `Tags:` /
+  // `Tag:` frontmatter property is visible to Bases tag filters (the producer
+  // sibling of the H1 key-fold class).
+  const fmTags = lookupFoldedAny(fm, ["tags", "tag"]);
   // v3.11.0-rc.9 (L-TAG-1) — foldTag (NFC + case fold + strip) so a Unicode
   // frontmatter tag canonicalizes identically to the predicate side.
   if (typeof fmTags === "string") {

--- a/tests/bases.test.ts
+++ b/tests/bases.test.ts
@@ -347,6 +347,15 @@ views:
     // open.md + done.md (frontmatter tag) AND Notes/inline.md (inline #book)
     expect(out.matches.map((m) => m.path).sort()).toEqual(["Notes/inline.md", "done.md", "open.md"]);
     expect(out.unevaluated_predicates).toEqual([]);
+
+    await fs.writeFile(path.join(root, "singular.md"), "---\nstatus: open\ntag: book\n---\nsingular key\n");
+    const withSingular = await queryBase(vault, { path: "q.base" });
+    expect(withSingular.matches.map((m) => m.path).sort()).toEqual([
+      "Notes/inline.md",
+      "done.md",
+      "open.md",
+      "singular.md"
+    ]);
   });
 
   it("filters by taggedWith(file.file, ...)", async () => {
@@ -361,6 +370,10 @@ views:
     const out = await queryBase(vault, { path: "q.base" });
     expect(out.matches.map((m) => m.path).sort()).toContain("open.md");
     expect(out.matches.map((m) => m.path).sort()).toContain("done.md");
+
+    await fs.writeFile(path.join(root, "singular.md"), "---\nstatus: open\ntag: book\n---\nsingular key\n");
+    const withSingular = await queryBase(vault, { path: "q.base" });
+    expect(withSingular.matches.map((m) => m.path)).toContain("singular.md");
   });
 
   it("filters by frontmatter equality", async () => {


### PR DESCRIPTION
## Bound claim

A Bases `tag ==` / `taggedWith` filter no longer misses notes that only declare the singular `tag:` frontmatter key.

`extractFrontmatterTags`, `list_tags`, and write-path tag reads already fold `["tags", "tag"]`. Bases `collectTags` only looked up `tags`.

## Product

- `collectTags` uses the same `["tags", "tag"]` folded lookup as the other producers.
- Does not change inline `#tag` extraction, NFC/case folding, search chunk stripping, or listing-size behavior.

## Proof

Extra phases of `filters by tag equality (tag == "book")` and `filters by taggedWith(file.file, ...)`. No new `it()`.

- After each happy path, a note with only `tag: book` must match.

## Non-claims

Does not change search `lastIndexOf("#")` vs `stripChunkSuffix`. Canvas/base listings still open files for counts.

BACKLOG §1.CC-ter **B2**. D-45: executable proof is GitHub-hosted.
