### PR TITLE
fix: strip search block ids with numeric chunk suffix only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Search block ids strip only a numeric chunk suffix
+
+> **TL;DR:** **Block-granularity search no longer treats a `#` inside a filename as a chunk separator.** Graph boost already used `/#\d+$/`. Fusion prune, live-vault path, recency, feedback, the terminal privacy filter, and response split still used `lastIndexOf("#")`, so an unsuffixed id like `C# Notes.md` became `C`.
+>
+> **Bounded claim.** This does **not** give TF-IDF a `path#chunk` fusion key at block granularity (B3). It does **not** reopen Bases `tag`/`tags` folding or listPdfs walker size.
+>
+> **Method note:** BACKLOG §1.CC-ter **B2**. Coverage is an extra phase of the existing `C# Notes.md` prune test: block granularity must exclude the full name and must not consult path `C`. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Chunk stripping is the numeric suffix only.** Shared `stripChunkSuffix` / `splitChunkSuffix` replace the five `lastIndexOf("#")` sites.
+
 ### Bases tag filters see the singular `tag` frontmatter key
 
 > **TL;DR:** **A Bases `tag ==` / `taggedWith` filter no longer misses notes that only declare `tag:`.** `extractFrontmatterTags`, `list_tags`, and write-path tag reads already fold `["tags", "tag"]`. Bases `collectTags` only looked up `tags`, so the Obsidian-documented singular key was invisible to `.base` filters.

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2251,6 +2251,27 @@ async function filterCurrentHybridHits(
  * ```
  */
 /**
+ * Strip a trailing `#<digits>` chunk suffix from a fused search id.
+ * A literal `#` inside the filename is kept (`C# Notes.md#3` → `C# Notes.md`).
+ * `lastIndexOf("#")` would turn unsuffixed `C# Notes.md` into `C`.
+ */
+function splitChunkSuffix(id: string): { path: string; chunk?: number } {
+  const match = /#(\d+)$/.exec(id);
+  if (match === null || match.index === 0 || match[1] === undefined) return { path: id };
+  const parsed = Number.parseInt(match[1], 10);
+  if (!Number.isInteger(parsed) || parsed < 0) return { path: id };
+  return { path: id.slice(0, match.index), chunk: parsed };
+}
+
+function stripChunkSuffix(id: string): string {
+  return splitChunkSuffix(id).path;
+}
+
+function vaultPathOfHit(id: string, granularity: "note" | "block"): string {
+  return granularity === "block" ? stripChunkSuffix(id) : id;
+}
+
+/**
  * v3.10.0-rc.8 — prune excluded paths from a fused ranking list, at the
  * fusion-stage source. Defense-in-depth parity with the rc.18 L-HYB-1
  * response-build guard: the fusion-stage consumers of the fused list
@@ -2259,9 +2280,9 @@ async function filterCurrentHybridHits(
  * if a future ranker arm forgets its own per-arm filter.
  *
  * Pure (the `isExcluded` predicate is injected) and granularity-aware: for
- * `"block"` ids of the form `path#chunk`, the chunk suffix is stripped before
- * the membership test — matching the response-build guard's `lastIndexOf("#")`
- * logic exactly so the two layers never disagree.
+ * `"block"` ids of the form `path#<digits>`, the numeric chunk suffix is stripped
+ * before the membership test — matching graph-boost / response-build
+ * `stripChunkSuffix` so a literal `#` in the filename is not treated as a chunk.
  *
  * @param hits - fused ranking entries (each carries an `id` = path or `path#chunk`).
  * @param isExcluded - returns true if a vault-relative path is excluded (`vault.isExcluded`).
@@ -2273,14 +2294,7 @@ export function pruneExcludedHits<T extends { id: string }>(
   isExcluded: (relPath: string) => boolean,
   granularity: "note" | "block"
 ): T[] {
-  return hits.filter((h) => {
-    let p = h.id;
-    if (granularity === "block") {
-      const hashIdx = h.id.lastIndexOf("#");
-      if (hashIdx > 0) p = h.id.slice(0, hashIdx);
-    }
-    return !isExcluded(p);
-  });
+  return hits.filter((h) => !isExcluded(vaultPathOfHit(h.id, granularity)));
 }
 
 /**
@@ -2997,11 +3011,7 @@ export async function searchHybrid(
   fused = await filterLiveVaultHits(
     vault,
     fused,
-    (hit) => {
-      if (granularity !== "block") return hit.id;
-      const hashIdx = hit.id.lastIndexOf("#");
-      return hashIdx > 0 ? hit.id.slice(0, hashIdx) : hit.id;
-    },
+    (hit) => vaultPathOfHit(hit.id, granularity),
     fused.length
   );
 
@@ -3026,9 +3036,8 @@ export async function searchHybrid(
     // v3.7.16 P2-16 — strip the `#chunk-N` suffix ONLY when it's a chunk
     // marker, not a literal `#` in the filename. Pre-3.7.16 `f.id.split("#")[0]`
     // mangled `C# Notes.md` → `C` and broke graph boost for any filename
-    // containing `#`. The post-3.7.16 regex strips `#<digits>` ONLY at the
+    // containing `#`. The shared helper strips `#<digits>` ONLY at the
     // end of the id, matching the chunker's `${path}#${chunkIndex}` format.
-    const stripChunkSuffix = (id: string): string => id.replace(/#\d+$/, "");
     const candidatePaths = new Set<string>();
     for (const f of fused) {
       const candidatePath = stripChunkSuffix(f.id);
@@ -3230,11 +3239,7 @@ export async function searchHybrid(
       const staleDays = ctx.recency.staleDays;
       const now =
         typeof ctx.recency.nowMs === "number" && Number.isFinite(ctx.recency.nowMs) ? ctx.recency.nowMs : Date.now();
-      const pathOf = (id: string): string => {
-        if (granularity !== "block") return id;
-        const h = id.lastIndexOf("#");
-        return h > 0 ? id.slice(0, h) : id;
-      };
+      const pathOf = (id: string): string => vaultPathOfHit(id, granularity);
       const uniquePaths = [...new Set(fused.map((f) => pathOf(f.id)))];
       const ageByPath = new Map<string, number>();
       await Promise.all(
@@ -3297,11 +3302,7 @@ export async function searchHybrid(
   if (ctx.feedback && ctx.feedback.weight > 0 && ctx.feedback.scores.size > 0 && fused.length > 1) {
     const w = Math.min(1, Math.max(0, ctx.feedback.weight));
     const fbScores = ctx.feedback.scores;
-    const fbPathOf = (id: string): string => {
-      if (granularity !== "block") return id;
-      const h = id.lastIndexOf("#");
-      return h > 0 ? id.slice(0, h) : id;
-    };
+    const fbPathOf = (id: string): string => vaultPathOfHit(id, granularity);
     const exFbTmp = exFeedback ? new Map<string, number>() : undefined;
     const blended = fused.map((f, pos) => {
       const fb = fbScores.get(fbPathOf(f.id)) ?? 0;
@@ -3340,11 +3341,7 @@ export async function searchHybrid(
     // ships without the per-arm filter, this terminal guard prevents leakage
     // into the final SearchHybridHit[]. Cheap (string-glob match) and closes
     // the ε-class sibling gap noted by the audit.
-    let pathForFilter = f.id;
-    if (granularity === "block") {
-      const hashIdx = f.id.lastIndexOf("#");
-      if (hashIdx > 0) pathForFilter = f.id.slice(0, hashIdx);
-    }
+    const pathForFilter = vaultPathOfHit(f.id, granularity);
     if (vault.isExcluded(pathForFilter)) continue;
     try {
       const live = await vault.stat(pathForFilter);
@@ -3399,16 +3396,14 @@ export async function searchHybrid(
     }
     // v2.2.0: when granularity is "block", f.id is "path#chunk_index" — split
     // back into path + chunk_index for the response. When "note", f.id is
-    // just the path.
+    // just the path. Use the numeric-suffix helper so `C# Notes.md#3` keeps
+    // the filename hash.
     let pathPart = f.id;
     let chunkFromId: number | undefined;
     if (granularity === "block") {
-      const hashIdx = f.id.lastIndexOf("#");
-      if (hashIdx > 0) {
-        pathPart = f.id.slice(0, hashIdx);
-        const parsed = Number.parseInt(f.id.slice(hashIdx + 1), 10);
-        if (Number.isInteger(parsed) && parsed >= 0) chunkFromId = parsed;
-      }
+      const split = splitChunkSuffix(f.id);
+      pathPart = split.path;
+      chunkFromId = split.chunk;
     }
     // v2.8.0: derive content-source kind. BM25 / embeddings hits carry it
     // explicitly; TF-IDF doesn't (it only runs over markdown). Either

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -3008,12 +3008,7 @@ export async function searchHybrid(
   // path can't inject an excluded id into `fused` (the per-arm filters already
   // prevent it), so an integration test of this layer would be vacuous.
   fused = pruneExcludedHits(fused, (p) => vault.isExcluded(p), granularity);
-  fused = await filterLiveVaultHits(
-    vault,
-    fused,
-    (hit) => vaultPathOfHit(hit.id, granularity),
-    fused.length
-  );
+  fused = await filterLiveVaultHits(vault, fused, (hit) => vaultPathOfHit(hit.id, granularity), fused.length);
 
   // S-5 — snapshot the pure-RRF order/score BEFORE any re-rank stage runs.
   if (exRrf) {

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -140,7 +140,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "../embeddings.js|resolveStoredEmbeddingConfiguration|resolveStoredEmbeddingConfiguration"
     ],
     k1Opens: 1,
-    sha256: "71a70c3bca76e12154fb4de8a3b2f7936bee1425c3c03bae760d63159ec5028d"
+    sha256: "3adbcd9c2cd89a1d13b7107331ef47b103ea8291e1845022a54cc791e3e1abf1"
   }
 };
 

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -140,7 +140,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "../embeddings.js|resolveStoredEmbeddingConfiguration|resolveStoredEmbeddingConfiguration"
     ],
     k1Opens: 1,
-    sha256: "c4de59e78d822312b6be3f762ab8cd8e572b451ff2b11d270bb2fa5e8ec12fe8"
+    sha256: "71a70c3bca76e12154fb4de8a3b2f7936bee1425c3c03bae760d63159ec5028d"
   }
 };
 

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "2fc773a8836e9c9fbcef8b7699e40c015f5bf14df6e3b86c76625ab2b50135cd" }
+    { count: 4, sha256: "c4897746713eece5b058cfff1701d3e22fd17b5468d8897c5492d4872e3d2481" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "16d035dcb619ed86a565e7aa31d24ffe1eaf3be6126768a6934d95ffb5075997"],
   ["K-1 block-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
   ["K-1 line-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
-  ["K-1 module-extension normalization", "514e6393d0473cee06747aee6d0868c5006f43d55d7f35692ada27a49b2daacd"],
-  ["K-1 source-path separator normalization", "42e6682e7388c1a75810d8a7922ccaef610094260b19b15ed3ea736d0cc802c5"],
+  ["K-1 module-extension normalization", "4eef29e7038904a792e8d7c3d90651a61d88af3c59dac2b8052313ef483c31cb"],
+  ["K-1 source-path separator normalization", "d15c168824e1182feda29614b45648efbfc418f84a3421eee3abffa225f5c058"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "c4897746713eece5b058cfff1701d3e22fd17b5468d8897c5492d4872e3d2481" }
+    { count: 4, sha256: "d3b151324e21a96bde7e7c266f7a9b02901c9d7be8713397a89be61d671b581f" }
   ],
   [
     "k1-class-invariant.test.ts",

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -1151,6 +1151,14 @@ describe("pruneExcludedHits (v3.10 rc.8 — fusion-stage isExcluded parity)", ()
     expect(pruneExcludedHits(csharp, () => false, "note").map((h) => h.id)).toEqual(["C# Notes.md"]);
     // And it's correctly excluded when the predicate matches the full name.
     expect(pruneExcludedHits(csharp, (p) => p === "C# Notes.md", "note")).toEqual([]);
+
+    // Block ids may be unsuffixed (TF-IDF) or `path#<digits>`. lastIndexOf("#")
+    // would treat `C# Notes.md` as path `C` and miss the exclusion.
+    expect(pruneExcludedHits(csharp, (p) => p === "C# Notes.md", "block")).toEqual([]);
+    expect(pruneExcludedHits(csharp, (p) => p === "C", "block").map((h) => h.id)).toEqual(["C# Notes.md"]);
+    const csharpChunk = [{ id: "C# Notes.md#0" }];
+    expect(pruneExcludedHits(csharpChunk, (p) => p === "C# Notes.md", "block")).toEqual([]);
+    expect(pruneExcludedHits(csharpChunk, (p) => p === "C", "block").map((h) => h.id)).toEqual(["C# Notes.md#0"]);
   });
 
   // NEGATIVE control: the prune MUST be driven by the predicate. A predicate


### PR DESCRIPTION
## Bound claim

Block-granularity search no longer treats a `#` inside a filename as a chunk separator.

Graph boost already used `/#\d+$/`. Fusion prune, live-vault path, recency, feedback, the terminal privacy filter, and response split used `lastIndexOf("#")`, so an unsuffixed id like `C# Notes.md` became `C`.

## Product

- Shared `splitChunkSuffix` / `stripChunkSuffix` / `vaultPathOfHit` replace those five sites.
- Does not give TF-IDF a `path#chunk` fusion key at block granularity (B3).
- Does not reopen Bases `tag`/`tags` folding or listPdfs walker size.

## Proof

Extra phase of `does NOT strip a literal '#' in a note-granularity filename (C# Notes.md)`. No new `it()`.

- Block granularity must exclude `C# Notes.md` by the full name.
- The predicate `p === "C"` must not drop it.
- `C# Notes.md#0` still strips to `C# Notes.md`.

## Non-claims

Does not change TF-IDF block fusion keys. Canvas/base listings still open files for counts.

BACKLOG §1.CC-ter **B2**. D-45: executable proof is GitHub-hosted.
K-1 pin `src/tools/search.ts` retargeted.
