### PR TITLE
fix: project TF-IDF onto block chunk ids before RRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented here. The format follows 
 
 > **TL;DR:** **`granularity: "block"` no longer keeps TF-IDF on a bare note path while BM25 and embeddings fuse on `path#chunk`.** Reciprocal Rank Fusion keys on `id`, so a TF-IDF hit could not share a row with either chunk ranker. `min_signals: 2` then dropped the TF-IDF contribution, and `min_signals: 3` was unsatisfiable.
 >
-> **Bounded claim.** This does **not** turn TF-IDF into a chunker. It projects each note-level hit onto the block ids BM25/embeddings already produced for that path, or `path#0` when no sibling ranker named a chunk. It does **not** change note-granularity fusion, graph-boost α, or combining-mark inline tags. It does **not** reopen the lastIndexOf strip.
+> **Bounded claim.** This does **not** turn TF-IDF into a chunker. It projects each note-level hit onto the block ids BM25/embeddings already produced for that path, or `path#0` when no sibling ranker named a chunk. At block granularity a TF-IDF-only hit therefore reports `chunk_index: 0` from the fusion key; that is not a TF-IDF source span. Note-granularity TF-IDF-only hits still omit `chunk_index`. It does **not** change note-granularity fusion, graph-boost α, or combining-mark inline tags. It does **not** reopen the lastIndexOf strip.
 >
 > **Method note:** BACKLOG §1.CC-ter **B3**. Coverage is an extra phase of the existing `min_signals=2` consensus test: the same query at `granularity: "block"` must still return hits that carry both `bm25` and `tfidf`. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### TF-IDF block hits fuse on the same path#chunk key as BM25
+
+> **TL;DR:** **`granularity: "block"` no longer keeps TF-IDF on a bare note path while BM25 and embeddings fuse on `path#chunk`.** Reciprocal Rank Fusion keys on `id`, so a TF-IDF hit could not share a row with either chunk ranker. `min_signals: 2` then dropped the TF-IDF contribution, and `min_signals: 3` was unsatisfiable.
+>
+> **Bounded claim.** This does **not** turn TF-IDF into a chunker. It projects each note-level hit onto the block ids BM25/embeddings already produced for that path, or `path#0` when no sibling ranker named a chunk. It does **not** change note-granularity fusion, graph-boost α, or combining-mark inline tags. It does **not** reopen the lastIndexOf strip.
+>
+> **Method note:** BACKLOG §1.CC-ter **B3**. Coverage is an extra phase of the existing `min_signals=2` consensus test: the same query at `granularity: "block"` must still return hits that carry both `bm25` and `tfidf`. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Block fusion keys are shared.** TF-IDF notes are projected onto sibling `path#chunk` ids before RRF.
+
 ### Search block ids strip only a numeric chunk suffix
 
 > **TL;DR:** **Block-granularity search no longer treats a `#` inside a filename as a chunk separator.** Graph boost already used `/#\d+$/`. Fusion prune, live-vault path, recency, feedback, the terminal privacy filter, and response split still used `lastIndexOf("#")`, so an unsuffixed id like `C# Notes.md` became `C`.

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1969,7 +1969,11 @@ export interface SearchHybridHit {
   score: number;
   /** Snippet from whichever signal produced the best chunk hit. */
   snippet: string;
-  /** Zero-based source chunk, omitted when the contributing signal is note-level TF-IDF. */
+  /**
+   * Zero-based fusion-key chunk. At `granularity: "block"` this is the sibling
+   * BM25/embeddings index, or `0` when only TF-IDF named the note. Omitted at
+   * note granularity when no BM25/embeddings chunk supplied it. Not a TF-IDF span.
+   */
   chunk_index?: number;
   /** One-based source line start, omitted when no chunk-level signal supplied it. */
   line_start?: number;

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2983,6 +2983,35 @@ export async function searchHybrid(
     }
   }
 
+  // B3 — TF-IDF is note-scoped. At block granularity BM25 and embeddings
+  // fuse on `path#chunk`. Project each TF-IDF note onto the block ids those
+  // rankers already produced for that path; if none exist, emit `path#0`
+  // (the same fallback embeddings uses for a missing chunk_index).
+  if (granularity === "block" && tfidfRanked.length > 0) {
+    const blockIdsByPath = new Map<string, string[]>();
+    const recordBlockId = (id: string): void => {
+      const notePath = stripChunkSuffix(id);
+      const existing = blockIdsByPath.get(notePath);
+      if (existing) {
+        if (!existing.includes(id)) existing.push(id);
+      } else {
+        blockIdsByPath.set(notePath, [id]);
+      }
+    };
+    for (const h of bm25Ranked) recordBlockId(h.id);
+    for (const h of embedRanked) recordBlockId(h.id);
+    const projected: typeof tfidfRanked = [];
+    for (const hit of tfidfRanked) {
+      const targets = blockIdsByPath.get(hit.id);
+      if (targets === undefined || targets.length === 0) {
+        projected.push({ ...hit, id: `${hit.id}#0` });
+        continue;
+      }
+      for (const id of targets) projected.push({ ...hit, id });
+    }
+    tfidfRanked = projected;
+  }
+
   // ─── RRF fusion ─────────────────────────────────────────────────────────
   let fused = reciprocalRankFusion(
     {

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -140,7 +140,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "../embeddings.js|resolveStoredEmbeddingConfiguration|resolveStoredEmbeddingConfiguration"
     ],
     k1Opens: 1,
-    sha256: "4ccc1499cb1452c944ca3a56dd29db241fa24cdd2570cd0da677634c82a9499e"
+    sha256: "9e322066954a24d33eb68ce21837e5c4e3ed7a13f25f80a19ed93d42f495f216"
   }
 };
 

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -140,7 +140,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "../embeddings.js|resolveStoredEmbeddingConfiguration|resolveStoredEmbeddingConfiguration"
     ],
     k1Opens: 1,
-    sha256: "3adbcd9c2cd89a1d13b7107331ef47b103ea8291e1845022a54cc791e3e1abf1"
+    sha256: "4ccc1499cb1452c944ca3a56dd29db241fa24cdd2570cd0da677634c82a9499e"
   }
 };
 

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "d3b151324e21a96bde7e7c266f7a9b02901c9d7be8713397a89be61d671b581f" }
+    { count: 4, sha256: "cc31b4e9e2bc4e70b5b098694e28bef73e5da5ba8f422f5b14bd171b27287cad" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "16d035dcb619ed86a565e7aa31d24ffe1eaf3be6126768a6934d95ffb5075997"],
   ["K-1 block-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
   ["K-1 line-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
-  ["K-1 module-extension normalization", "4eef29e7038904a792e8d7c3d90651a61d88af3c59dac2b8052313ef483c31cb"],
-  ["K-1 source-path separator normalization", "d15c168824e1182feda29614b45648efbfc418f84a3421eee3abffa225f5c058"],
+  ["K-1 module-extension normalization", "243c06cf58dfa9547db41f50e521d418d056584ca7ca465cd12f8598216678be"],
+  ["K-1 source-path separator normalization", "a1ca75e6b2c06e020c879a51845c2fde984fe49324cbf7a940f48b17d611d6c6"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "cc31b4e9e2bc4e70b5b098694e28bef73e5da5ba8f422f5b14bd171b27287cad" }
+    { count: 4, sha256: "567c0f09cb4ad261f3f28b25535bf1f15f36f20fc6f4a44ef13446517cede76c" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "16d035dcb619ed86a565e7aa31d24ffe1eaf3be6126768a6934d95ffb5075997"],
   ["K-1 block-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
   ["K-1 line-comment stripping", "c95678067a8bf775dec72803fda97aeda6b12479bf8420e9566259b4b42ce4db"],
-  ["K-1 module-extension normalization", "243c06cf58dfa9547db41f50e521d418d056584ca7ca465cd12f8598216678be"],
-  ["K-1 source-path separator normalization", "a1ca75e6b2c06e020c879a51845c2fde984fe49324cbf7a940f48b17d611d6c6"],
+  ["K-1 module-extension normalization", "52da3058e5f96bf49545cd9a300136c38f2aaaf0447fbf8d7c3a0507157fb918"],
+  ["K-1 source-path separator normalization", "bef9f06be76234553863046ac2b1fab391368dd4212e448b9e52e4696e5d8b44"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -694,6 +694,17 @@ describe("searchHybrid — BM25 + TF-IDF fusion path", () => {
       const numSignals = Object.keys(m.per_signal).length;
       expect(numSignals).toBeGreaterThanOrEqual(2);
     }
+
+    const block = await searchHybrid(
+      v,
+      { query: "OAuth JWT tokens", limit: 10, min_signals: 2, granularity: "block" },
+      { ftsIndex: idx, embedFile: path.join(ftsRoot, "nonexistent.embed.db") }
+    );
+    expect(block.matches.length).toBeGreaterThan(0);
+    for (const m of block.matches) {
+      expect(m.per_signal.bm25).toBeDefined();
+      expect(m.per_signal.tfidf).toBeDefined();
+    }
   });
 
   it("BM25 chunk-collapse: per_signal.bm25 carries chunk_index from the best chunk", async () => {


### PR DESCRIPTION
## What's in this PR

**`granularity: "block"` no longer keeps TF-IDF on a bare note path while BM25 and embeddings fuse on `path#chunk`.**

Reciprocal Rank Fusion keys on `id`. BM25 already emits `` `${rel_path}#${chunk_index}` `` and embeddings emit `` `${path}#${chunk_index ?? 0}` ``. TF-IDF always used `m.path`, so a TF-IDF hit could not share a row with either chunk ranker. `min_signals: 2` then dropped the TF-IDF contribution, and `min_signals: 3` was unsatisfiable whenever embeddings also ran.

After all three rankers return and **before RRF**, when `granularity === "block"`, each TF-IDF note is projected onto the block ids BM25/embeddings already produced for that path (`stripChunkSuffix` grouping). If no sibling ranker named a chunk, the note is emitted as `path#0` — the same fallback embeddings already uses for a missing `chunk_index`. Note-granularity fusion is unchanged. TF-IDF is not turned into a chunker. At block granularity a TF-IDF-only hit reports `chunk_index: 0` from the fusion key; that is not a TF-IDF source span.

Coverage is an extra phase of the existing `min_signals=2 returns only multi-ranker consensus hits` test: the same query at `granularity: "block"` must still return hits that carry both `bm25` and `tfidf`. No new `it()`. Census stays 2228.

K-1 `src/tools/search.ts` pin, the two k1-ast ordinary-transform owner hashes, and the k1-ast mutation-helper census move because the pin hex is hashed as the whole `k1-ast-invariant.test.ts` file.

## Bounded claim

This does **not** change note-granularity fusion, graph-boost α, or combining-mark inline tags. It does **not** reopen the lastIndexOf strip. It does **not** change `searchHybridMulti`, which still fuses sub-query lists by note path (documented rc.12 caveat). It does **not** invent TF-IDF chunks other than projecting onto sibling BM25/embed ids or `#0`.

## Proof

- Extra phase of `tests/search-hybrid.test.ts` `min_signals=2 returns only multi-ranker consensus hits`.
- D-73 pass 1 session `01a04c20-77cb-7d01-a9fb-4593c1ca776e` **REFUTED** `328e822` on `SearchHybridHit.chunk_index` TSDoc ("omitted when the contributing signal is note-level TF-IDF"). Honesty follow-up `6a6fc7c`.
- D-73 pass 2 session `01a04c28-82b4-7ff2-b597-439b93ef3f97` **CONFIRMED** `6a6fc7c`.
- Hosted CI on product `328e822` run `33206431398` was green including coverage + OIA + smoke. Replay on `6a6fc7c` required before squash. D-45: no local package-manager, lint, or test workload.

## Merge

Squash only after D-73 CONFIRMED **and** coverage + OIA + smoke are green on this exact candidate. Then replay exact-main CI. One product PR. A5/A8/AH-4/m165 remain HOLD. Do not tag or publish.
