### PR TITLE
fix: keep non-composing combining marks in inline tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Inline `#tag` keeps combining marks that NFC cannot compose
+
+> **TL;DR:** **An inline `#tag` no longer truncates at a combining mark that has no canonical composition.** NFC-before-match already recovered `#café` (NFD `e` + U+0301 → `é`). The regex continuation class still excluded `\p{M}`, so `#q` + U+0308 (`q̈`, no precomposed form) captured `q` while the TSDoc claimed NFC recovers any combining mark.
+>
+> **Bounded claim.** This does **not** treat a combining mark as a tag lead (`#1` is still not a tag; the first character remains `\p{L}`). It does **not** change frontmatter `tags`/`tag` folding, graph-boost ranking, or TF-IDF block fusion keys. NFC-before-match remains; `\p{M}` is additive.
+>
+> **Method note:** BACKLOG §1.CC-ter **B3**. Coverage is an extra phase of the existing NFD `#café` producer test: `#q` + U+0308 must extract the two-code-point tag. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Continuation class includes combining marks.** `INLINE_TAG_RE` is `[\p{L}][\p{L}\p{N}\p{M}_/-]*`.
+
 ### Wikilink graph-boost no longer overrides RRF scores
 
 > **TL;DR:** **Wikilink graph-boost is a post-RRF sort key, not a score addend.** `α × in_degree` with `α = 0.005` exceeded the whole Reciprocal Rank Fusion range, so expanding `limit` (and therefore the fused top-K used to count in-links) could reorder hits past a stronger ranker signal. The comment claimed a tie-break; the addend was not one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to this project will be documented here. The format follows 
 
 ### Inline `#tag` keeps combining marks that NFC cannot compose
 
-> **TL;DR:** **An inline `#tag` no longer truncates at a combining mark that has no canonical composition.** NFC-before-match already recovered `#café` (NFD `e` + U+0301 → `é`). The regex continuation class still excluded `\p{M}`, so `#q` + U+0308 (`q̈`, no precomposed form) captured `q` while the TSDoc claimed NFC recovers any combining mark.
+> **TL;DR:** **An inline `#tag` no longer truncates at a combining mark that has no canonical composition.** NFC-before-match already recovered `#café` (NFD `e` + U+0301 → `é`). The parser `INLINE_TAG_RE` and the Bases `collectTags` continuation classes still excluded `\p{M}`, so `#q` + U+0308 (`q̈`, no precomposed form) captured `q` while the parser TSDoc claimed NFC recovers any combining mark.
 >
-> **Bounded claim.** This does **not** treat a combining mark as a tag lead (`#1` is still not a tag; the first character remains `\p{L}`). It does **not** change frontmatter `tags`/`tag` folding, graph-boost ranking, or TF-IDF block fusion keys. NFC-before-match remains; `\p{M}` is additive.
+> **Bounded claim.** This does **not** treat a combining mark as a tag lead (`#1` is still not a tag; the first character remains `\p{L}`). It does **not** change frontmatter `tags`/`tag` folding, graph-boost ranking, or TF-IDF block fusion keys. NFC-before-match remains; `\p{M}` is additive. Bases still uses its own regex (not the shared `INLINE_TAG_RE`); both continuation classes now include `\p{M}`.
 >
-> **Method note:** BACKLOG §1.CC-ter **B3**. Coverage is an extra phase of the existing NFD `#café` producer test: `#q` + U+0308 must extract the two-code-point tag. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+> **Method note:** BACKLOG §1.CC-ter **B3**. Coverage is extra phases of the existing NFD `#café` producer test and the existing Bases `taggedWith` inline-tag test: `#q` + U+0308 must extract/match the two-code-point tag. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
-- **Continuation class includes combining marks.** `INLINE_TAG_RE` is `[\p{L}][\p{L}\p{N}\p{M}_/-]*`.
+- **Continuation class includes combining marks.** `INLINE_TAG_RE` and Bases `collectTags` are `[\p{L}][\p{L}\p{N}\p{M}_/-]*`.
 
 ### Wikilink graph-boost no longer overrides RRF scores
 

--- a/src/bases.ts
+++ b/src/bases.ts
@@ -951,7 +951,9 @@ function collectTags(fm: Record<string, unknown>, body: string): string[] {
     // `#日本語` → no match). Now Unicode-aware (`\p{L}` + `u` flag), and the line is
     // NFC-normalized FIRST so an NFD `#café` (macOS APFS) composes its combining mark
     // into the base letter before matching (parity with parser's extractInlineTags).
-    for (const m of line.normalize("NFC").matchAll(/(?:^|\s)(#[\p{L}][\p{L}\p{N}_/-]*)/gu)) {
+    // Continuation includes `\p{M}` so a mark with no canonical composition stays in
+    // the capture (sibling of INLINE_TAG_RE).
+    for (const m of line.normalize("NFC").matchAll(/(?:^|\s)(#[\p{L}][\p{L}\p{N}\p{M}_/-]*)/gu)) {
       const tag = foldTag(m[1] ?? ""); // strip `#` + NFC + lowercase
       if (tag) out.add(tag);
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -449,28 +449,23 @@ function matchLinks(text: string, embed: boolean, budget: ParserBudget, sourceOf
 /**
  * Inline `#tag` extraction regex (shared — imported by `tools/meta.ts` so the
  * two extractors cannot drift; was a byte-identical copy before v3.11.0-rc.10).
- * Tag = a leading Unicode LETTER then letters/digits/`_`/`/`/`-`. Preceded by
- * whitespace/bracket/BOL so `#1` in a heading is not a tag. The `u` flag is
- * required for `\p{L}`. `matchAll` clones the regex per call, so sharing this
+ * Tag = a leading Unicode LETTER then letters/digits/combining marks/`_`/`/`/`-`.
+ * Preceded by whitespace/bracket/BOL so `#1` in a heading is not a tag. The `u` flag is
+ * required for `\p{L}` / `\p{M}`. `matchAll` clones the regex per call, so sharing this
  * `/g` instance across modules is lastIndex-safe.
  *
- * v3.11.0-rc.10 (M1, external audit) — the character class deliberately does NOT
- * include `\p{M}` (combining marks); instead every caller NFC-normalizes the text
- * BEFORE matching (see {@link extractInlineTags}). On macOS APFS an inline `#café`
- * is stored DECOMPOSED (NFD: `e` + U+0301), and U+0301 is a `\p{M}` mark that the
- * class excludes — so a raw match would TRUNCATE the capture to `cafe` and the
- * accent would be lost BEFORE any downstream `nfc()`/`foldTag()` could recover it
- * (the rc.9 producer-`nfc()` ran on already-corrupted input). Normalizing the text
- * first composes the mark back into the base letter (`é` = `\p{L}`), so the capture
- * is complete and canonical. (Normalize-before-match recovers ANY combining mark,
- * not just the ones we could enumerate in a character class.)
+ * v3.11.0-rc.10 (M1, external audit) — callers NFC-normalize the text BEFORE matching
+ * (see {@link extractInlineTags}) so a macOS-APFS NFD `#café` (`e` + U+0301) composes
+ * to `é` (`\p{L}`) instead of truncating at the mark. NFC does not recover a combining
+ * mark that has no canonical composition (`q` + U+0308 stays two code points). The
+ * continuation class therefore includes `\p{M}` so those marks stay in the capture.
  */
-export const INLINE_TAG_RE = /(?:^|[\s([{>])#([\p{L}][\p{L}\p{N}_/-]*)/gu;
+export const INLINE_TAG_RE = /(?:^|[\s([{>])#([\p{L}][\p{L}\p{N}\p{M}_/-]*)/gu;
 
 /**
  * Extract `#hashtag` style inline tags from markdown body text. Tags must
  * be preceded by whitespace, bracket, or BOL — `#1` inside a markdown
- * heading is NOT a tag. Tag chars: Unicode letters/digits, `_`, `/`, `-`.
+ * heading is NOT a tag. Tag chars: Unicode letters, digits, combining marks, `_`, `/`, `-`.
  *
  * @param text - Markdown body (caller should have stripped code spans).
  * @param limits - Optional lower admission limits.
@@ -485,8 +480,8 @@ export function extractInlineTags(text: string, limits?: ParserLimits): string[]
 function extractInlineTagsWithBudget(text: string, budget: ParserBudget): string[] {
   const found = new Set<string>();
   // v3.11.0-rc.10 (M1) — NFC-normalize the BODY before matching so an NFD inline
-  // tag (`#café` = `cafe`+U+0301 on macOS APFS) composes to `café` and the regex
-  // captures the full accented token instead of truncating at the combining mark.
+  // tag (`#café` = `cafe`+U+0301 on macOS APFS) composes to `café`. Marks with no
+  // canonical composition stay in the capture via `\p{M}` on INLINE_TAG_RE.
   for (const m of text.normalize("NFC").matchAll(INLINE_TAG_RE)) {
     // nfc() is now belt-and-suspenders (the input is already NFC); kept so a future
     // caller passing un-normalized text still stores a canonical tag.

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -336,9 +336,8 @@ export async function validateNoteProposal(vault: Vault, args: ValidateProposalA
     for (const t of fmTags.split(/[\s,]+/)) if (t) proposedTagsRaw.add(t.replace(/^#/, ""));
   }
   // Inline tags. v3.11.0-rc.10 (M1) — shared INLINE_TAG_RE (was a byte-identical
-  // copy of parser's) + NFC-normalize BEFORE matching so an NFD inline tag isn't
-  // truncated at its combining mark (parity with extractInlineTags); the
-  // existing-vs-new classification below folds both sides via foldTag.
+  // copy of parser's) + NFC-normalize BEFORE matching so a composable NFD mark
+  // becomes a letter; `\p{M}` keeps marks that have no canonical composition.
   for (const m of sanitizedBodyAfterFm.normalize("NFC").matchAll(INLINE_TAG_RE)) {
     if (m[1]) proposedTagsRaw.add(m[1]);
   }

--- a/tests/bases.test.ts
+++ b/tests/bases.test.ts
@@ -611,6 +611,15 @@ views:
     );
     const out = await queryBase(vault, { path: "q.base" });
     expect(out.matches.map((m) => m.path)).toEqual(["Notes/inline.md"]);
+
+    const qDiaeresis = `q${String.fromCodePoint(0x308)}`;
+    await fs.writeFile(path.join(root, "Notes", "mark.md"), `see #${qDiaeresis} here\n`);
+    await fs.writeFile(
+      path.join(root, "q-mark.base"),
+      `filters: 'taggedWith(file.file, "${qDiaeresis}")'\nviews:\n  - type: table\n`
+    );
+    const marked = await queryBase(vault, { path: "q-mark.base" });
+    expect(marked.matches.map((m) => m.path)).toEqual(["Notes/mark.md"]);
   });
 
   it("throws on unknown view name", async () => {

--- a/tests/name-fold-invariant.test.ts
+++ b/tests/name-fold-invariant.test.ts
@@ -216,6 +216,10 @@ describe("M1 — tag PRODUCER recovers NFD / accented / non-Latin tags (rc.10, e
     expect(nfc4).not.toBe(nfd4);
     expect(extractInlineTags(`see #${nfd4} here`), "NFD #café must extract café, not cafe").toEqual([nfc4]);
     expect(extractInlineTags(`see #${nfc4} here`)).toEqual([nfc4]); // NFC unchanged
+    // Combining mark with no canonical composition stays two code points after NFC.
+    const qDiaeresis = `q${String.fromCodePoint(0x308)}`;
+    expect(qDiaeresis.normalize("NFC")).toBe(qDiaeresis);
+    expect(extractInlineTags(`see #${qDiaeresis} here`)).toEqual([qDiaeresis]);
   });
 
   it("extractInlineTags extracts non-Latin inline tags (POSITIVE)", () => {


### PR DESCRIPTION
## What's in this PR

**An inline `#tag` no longer truncates at a combining mark that has no canonical composition.**

NFC-before-match already recovered `#café` (NFD `e` + U+0301 → `é`). Both live producers still excluded `\p{M}` in the continuation class: shared `INLINE_TAG_RE` (`src/parser.ts`, used by `src/tools/meta.ts`) and Bases `collectTags` (`src/bases.ts`, consumed by `taggedWith` / `tag ==`). `#q` + U+0308 (`q̈`, two code points after NFC) captured `q` while the parser TSDoc claimed NFC recovers any combining mark.

The first character remains `\p{L}` (`#1` is still not a tag). NFC-before-match remains. `\p{M}` is additive. Bases still uses its own regex (not the shared `INLINE_TAG_RE`); both continuation classes now include `\p{M}`.

Coverage is extra phases of the existing NFD `#café` producer test and the existing Bases `taggedWith` inline-tag test. No new `it()`. Census stays 2228.

## Bounded claim

This does **not** change frontmatter `tags`/`tag` folding, graph-boost ranking, or TF-IDF block fusion keys. It does **not** make a combining mark a legal tag lead. It does **not** unify Bases onto `INLINE_TAG_RE`.

## Proof

- Extra phase of `tests/name-fold-invariant.test.ts` `extractInlineTags recovers an NFD inline tag instead of truncating at the mark`.
- Extra phase of `tests/bases.test.ts` `collects inline #tags from body for taggedWith() matching`.
- D-73 pass 1 session `01a04c5c-791a-7943-bf3f-780bf70d9e11` **REFUTED** `8764bf6` (CHANGELOG overclaimed globally while Bases `collectTags` still excluded `\p{M}`).
- D-73 pass 2 session `01a04c63-fbb4-7752-8dff-4bc04ffc4cab` **CONFIRMED** `5fae3de14004543c86b71b3e2ca008ba6825cf5c`.
- Hosted CI: coverage + OIA + smoke required before squash. D-45: no local package-manager, lint, or test workload.

## Merge

Squash only after D-73 CONFIRMED **and** coverage + OIA + smoke are green on this exact candidate. Then replay exact-main CI. One product PR. A5/A8/AH-4/m165 remain HOLD. Do not tag or publish.
