### PR TITLE
fix: keep compatible embed vectors across schema 3-to-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ All notable changes to this project will be documented here. The format follows 
 
 > **TL;DR:** **Startup `--use-hnsw` persistence no longer leaves a published generation on disk after EmbedDb drifts and the in-memory graph is discarded.** `saveTo` can commit the immutable binary plus meta pointer and still throw on later lease-release; a receipt mismatch only logged and dropped the candidate. The watcher flush already erases that family. Startup now calls the same eraser, best-effort, when persist was attempted and the candidate is discarded. Compact v4 pointers omit `text_preview`; native vectors in the generation remain sensitive.
 >
-> **Bounded claim.** This does **not** erase on build-time drift (no `saveTo`) or persist-disabled startup. Uncommitted `saveTo(false)` with matching receipts still keeps the in-memory candidate and the previous sidecar. It does **not** change watcher `hnswPersistUnsafe`, load-time discard, or the empty-index erase. It does **not** reopen A5 schema 3→5 vector drop.
+> **Bounded claim.** This does **not** erase on build-time drift (no `saveTo`) or persist-disabled startup. Uncommitted `saveTo(false)` with matching receipts still keeps the in-memory candidate and the previous sidecar. It does **not** change watcher `hnswPersistUnsafe`, load-time discard, or the empty-index erase. It does **not** change EmbedDb `bootstrapSchema`.
 >
 > **Method note:** BACKLOG §1.CC-HOLD **H3**. Coverage is extra phases of the existing `saveTo(false)` persist test: (1) `saveTo` commits a pointer, an unrelated EmbedDb upsert runs during that await; (2) `saveTo` writes the pointer then throws (lease-release shape) with the same upsert. Both must return `hnswContext: null`, keep brute search up, and leave the meta pointer gone. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 
@@ -113,7 +113,7 @@ All notable changes to this project will be documented here. The format follows 
 
 > **TL;DR:** **`embeddingsSearch` no longer treats the whole-database `mutation_epoch` as an equality key.** Indexing any note used to bump that counter on four tables, so a watcher (or a second writer) indexing an unrelated note during live-vault validation threw `Embedding index changed during search` and `obsidian_search` recorded `signal_errors.embeddings`. Terminal egress now keys the physical EmbedDb UUID plus the ranked source receipts. Reindexing a ranked hit still fails closed. HNSW still requires UUID+epoch before it is queried, and falls back to brute-force cosine when the graph is stale.
 >
-> **Bounded claim.** This does **not** stop bumping `mutation_epoch` on INSERT/UPDATE/DELETE. It does **not** change HNSW persist, watcher generation authority, or discovery stale-open equality. It does **not** reopen A5 schema 3→5 vector drop.
+> **Bounded claim.** This does **not** stop bumping `mutation_epoch` on INSERT/UPDATE/DELETE. It does **not** change HNSW persist, watcher generation authority, or discovery stale-open equality. It does **not** change EmbedDb `bootstrapSchema`.
 >
 > **Method note:** BACKLOG §1.CC **A10**. Coverage is an extra phase of the existing live-vault-validation test: upserting `Unrelated.md` during `vault.stat` must still return `Semantic.md`; reindexing `Semantic.md` in the same test must still throw. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Same-config embed schema upgrade keeps vectors
+
+> **TL;DR:** **A 3.11.6 embedding index is no longer emptied when v4 opens it.** Schema 3→5 admitted the store as owned, then `bootstrapSchema` dropped `embeddings` and stamped schema 5. Default serve does not run `syncEmbedDb`, so semantic search degraded to BM25+TF-IDF while `doctor` reported `ok` at 0 chunks. Same-config historical schemas whose vector table already has `kind` (v2/v3/v4) now keep their rows and only install v5 UUID/epoch metadata. v1 still rebuilds. Model, dimension, or quantization mismatch still rebuilds.
+>
+> **Bounded claim.** This does **not** auto-run `syncEmbedDb` on serve. It does **not** keep vectors across a model/dim/quantization change (AH-4 remains HOLD). It does **not** unify Bases tag regexes or change FTS5. A fresh UUID still rotates on the metadata upgrade so HNSW sidecars rebuild from the preserved embed-db.
+>
+> **Method note:** BACKLOG §1.CC **A5**. Coverage is extra phases of the existing `rebuilds supported same-root legacy schemas` test: v2/v3/v4 same-config opens keep `totalChunks() === 1`; v1 still rebuilds to 0. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Compatible historical schemas keep the vector table.** `bootstrapSchema` skips `DROP TABLE embeddings` when model/dim/quantization match and `schema_version >= 2`.
+
 ### Inline `#tag` keeps combining marks that NFC cannot compose
 
 > **TL;DR:** **An inline `#tag` no longer truncates at a combining mark that has no canonical composition.** NFC-before-match already recovered `#café` (NFD `e` + U+0301 → `é`). The parser `INLINE_TAG_RE` and the Bases `collectTags` continuation classes still excluded `\p{M}`, so `#q` + U+0308 (`q̈`, no precomposed form) captured `q` while the parser TSDoc claimed NFC recovers any combining mark.

--- a/src/embed-db.ts
+++ b/src/embed-db.ts
@@ -1742,12 +1742,7 @@ export class EmbedDb {
       // lack v5 UUID/epoch metadata; dropping the vector table emptied 3.11.6
       // indexes on the default non-`--watch` serve path (BACKLOG §1.CC A5).
       const keepCompatibleVectors =
-        !uninitialized &&
-        !versionMatch &&
-        modelMatch &&
-        dimMatch &&
-        quantMatch &&
-        Number(meta?.schema_version) >= 2;
+        !uninitialized && !versionMatch && modelMatch && dimMatch && quantMatch && Number(meta?.schema_version) >= 2;
 
       // Exact current schema + configuration is already a complete durable
       // generation. Reopening it must not rewrite metadata, rotate identity,

--- a/src/embed-db.ts
+++ b/src/embed-db.ts
@@ -67,6 +67,8 @@ function errnoCode(err: unknown): string | undefined {
 // layout is unchanged, every vector must be rebuilt in the new model space.
 // v5 gives every physical EmbedDb generation a cryptographic instance UUID and
 // installs exact table-level mutation triggers that advance one durable epoch.
+// A same-config v2/v3/v4 store keeps its vectors through that metadata upgrade;
+// v1 still rebuilds because its embeddings table has no `kind` column.
 
 /** Content-source kind. Mirrors ChunkKind in src/fts5.ts. */
 export type EmbedChunkKind = "md" | "pdf";
@@ -1286,9 +1288,11 @@ export function decodeInt8Vector(buf: Buffer, dim: number): Float32Array {
  *
  * `open()` admits only a truly schema-empty file or a structurally recognized
  * embedding index for the exact vault root. A recognized same-root index is
- * rebuilt for supported legacy-schema or model/dim/quantization mismatches;
- * foreign, malformed, and future-schema databases are refused without
- * Enquire-issued persistent PRAGMA, DDL, DML, chmod, or HNSW actions.
+ * upgraded in place when the vector table already matches the current v2 shape
+ * and only schema metadata is behind; rebuilt for v1 table-shape or
+ * model/dim/quantization mismatches; foreign, malformed, and future-schema
+ * databases are refused without Enquire-issued persistent PRAGMA, DDL, DML,
+ * chmod, or HNSW actions.
  *
  * @example
  * ```ts
@@ -1734,6 +1738,16 @@ export class EmbedDb {
       const existingQuant = meta?.quantization ?? "f32";
       const quantMatch = uninitialized || existingQuant === this.quantization;
       const requiresBootstrap = uninitialized || !versionMatch || !modelMatch || !dimMatch || !quantMatch;
+      // v2+ embeddings already have `kind`. Same-config historical 2/3/4 only
+      // lack v5 UUID/epoch metadata; dropping the vector table emptied 3.11.6
+      // indexes on the default non-`--watch` serve path (BACKLOG §1.CC A5).
+      const keepCompatibleVectors =
+        !uninitialized &&
+        !versionMatch &&
+        modelMatch &&
+        dimMatch &&
+        quantMatch &&
+        Number(meta?.schema_version) >= 2;
 
       // Exact current schema + configuration is already a complete durable
       // generation. Reopening it must not rewrite metadata, rotate identity,
@@ -1746,7 +1760,11 @@ export class EmbedDb {
         if (!modelMatch) reason.push("model configuration changed");
         if (!dimMatch) reason.push("vector dimension changed");
         if (!quantMatch) reason.push("quantization changed");
-        process.stderr.write(`enquire: rebuilding embed index (${reason.join("; ")})\n`);
+        process.stderr.write(
+          keepCompatibleVectors
+            ? `enquire: upgrading embed index schema in place (${reason.join("; ")})\n`
+            : `enquire: rebuilding embed index (${reason.join("; ")})\n`
+        );
       }
 
       // Remove every admitted mutation surface before dropping tables. Current
@@ -1755,7 +1773,7 @@ export class EmbedDb {
       for (const name of [...SOURCE_REVISION_TRIGGER_NAMES, ...MUTATION_EPOCH_TRIGGER_NAMES]) {
         db.exec(`DROP TRIGGER IF EXISTS ${name}`);
       }
-      if (!uninitialized) {
+      if (!uninitialized && !keepCompatibleVectors) {
         db.exec(`
           DROP TABLE IF EXISTS embeddings;
           DROP TABLE IF EXISTS source_state;
@@ -1784,8 +1802,9 @@ export class EmbedDb {
       `);
 
       // Identity metadata exists before the epoch triggers are installed. A
-      // new physical database or any destructive rebuild always receives a
-      // fresh cryptographic UUID and starts at epoch 1.
+      // new physical database, a destructive rebuild, or a same-config
+      // metadata upgrade always receives a fresh cryptographic UUID and starts
+      // at epoch 1.
       this.writeMeta({
         schema_version: String(EMBED_DB_SCHEMA_VERSION),
         vault_root: this.vaultRoot,

--- a/tests/embed-db.test.ts
+++ b/tests/embed-db.test.ts
@@ -2499,8 +2499,8 @@ describe("EmbedDb", () => {
     const Database = (await import("better-sqlite3")).default;
 
     // Explicitly supported historical v4 metadata remains readable even when
-    // its optional authority ledger is absent. The v5 upgrade is deliberately
-    // destructive: it rotates physical identity and discards old vectors.
+    // its optional authority ledger is absent. Same-config v4→v5 keeps the
+    // vector rows and rotates UUID/epoch metadata (BACKLOG §1.CC A5).
     const repairFile = path.join(dir, "v4-optional-repair.embed.db");
     await seedExactEmbedFile(repairFile, "repair.md");
     const repairRaw = new Database(repairFile);
@@ -2534,7 +2534,7 @@ describe("EmbedDb", () => {
 
     const repairedV4 = new EmbedDb({ file: repairFile, vaultRoot: "/v", modelAlias: "multilingual", dim: 4 });
     await repairedV4.open();
-    expect(repairedV4.totalChunks()).toBe(0);
+    expect(repairedV4.totalChunks()).toBe(1);
     await repairedV4.closeAndRelease();
     const repairedRaw = new Database(repairFile, { readonly: true, fileMustExist: true });
     try {
@@ -2546,8 +2546,7 @@ describe("EmbedDb", () => {
              ORDER BY id`
           )
           .all()
-      ).toEqual([]);
-      expect(repairPayloadBefore).not.toEqual([]);
+      ).toEqual(repairPayloadBefore);
       const currentMeta = new Map(
         repairedRaw
           .prepare("SELECT key, value FROM meta ORDER BY key")
@@ -2572,7 +2571,11 @@ describe("EmbedDb", () => {
         "typeof(revision) = 'integer'"
       );
       expect(repairedRaw.prepare("SELECT * FROM source_quarantine").all()).toEqual([]);
-      expect(repairedRaw.prepare("SELECT * FROM source_revision").all()).toEqual([]);
+      expect(
+        repairedRaw
+          .prepare("SELECT rel_path, kind, revision FROM source_revision ORDER BY rel_path")
+          .all()
+      ).toEqual([{ rel_path: "repair.md", kind: "md", revision: 1 }]);
       expect(
         repairedRaw
           .prepare(
@@ -2601,10 +2604,10 @@ describe("EmbedDb", () => {
     raw.prepare("DELETE FROM meta WHERE key IN ('instance_uuid', 'mutation_epoch')").run();
     raw.close();
 
-    // POSITIVE: rc.19's fp32 → q8 inference-contract migration discards old vectors.
+    // POSITIVE: same-config schema 4→5 keeps the existing vector (A5).
     const db3 = new EmbedDb({ file, vaultRoot: "/v", modelAlias: "multilingual", dim: 4 });
     await db3.open();
-    expect(db3.totalChunks()).toBe(0);
+    expect(db3.totalChunks()).toBe(1);
     db3.upsertNote("b.md", 2000, [
       { chunkIndex: 0, lineStart: 1, lineEnd: 1, textPreview: "y", vector: l2([0, 1, 0, 0]) }
     ]);
@@ -2677,11 +2680,8 @@ describe("EmbedDb", () => {
     await expectRefusalToPreserve(/ownership could not be verified/);
 
     // POSITIVE controls: genuine v1-v3 EmbedDb signatures with the exact
-    // root are supported legacy provenance and may be destructively rebuilt.
-    // The compact meta-table punctuation is intentional: SQLite preserves
-    // caller formatting in sqlite_master, but whitespace around `(`, `)` and
-    // `,` is not part of the historical class identity. The current v5
-    // preservation path was pinned by db2 above.
+    // root are supported legacy provenance. v1 still rebuilds (no `kind`
+    // column). v2/v3 already match the current vector table and keep rows.
     for (const legacyVersion of [1, 2, 3]) {
       const legacyFile = path.join(dir, `legacy-v${legacyVersion}.embed.db`);
       const legacy = new Database(legacyFile);
@@ -2737,7 +2737,7 @@ describe("EmbedDb", () => {
 
       const migrated = new EmbedDb({ file: legacyFile, vaultRoot: "/v", modelAlias: "multilingual", dim: 4 });
       await migrated.open();
-      expect(migrated.totalChunks()).toBe(0);
+      expect(migrated.totalChunks()).toBe(legacyVersion === 1 ? 0 : 1);
       await migrated.closeAndRelease();
     }
   });

--- a/tests/embed-db.test.ts
+++ b/tests/embed-db.test.ts
@@ -2572,9 +2572,7 @@ describe("EmbedDb", () => {
       );
       expect(repairedRaw.prepare("SELECT * FROM source_quarantine").all()).toEqual([]);
       expect(
-        repairedRaw
-          .prepare("SELECT rel_path, kind, revision FROM source_revision ORDER BY rel_path")
-          .all()
+        repairedRaw.prepare("SELECT rel_path, kind, revision FROM source_revision ORDER BY rel_path").all()
       ).toEqual([{ rel_path: "repair.md", kind: "md", revision: 1 }]);
       expect(
         repairedRaw

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -1005,12 +1005,12 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["ReDoS catastrophic control transform", "99358421ccbe92052218efb7bcf19e31029854d36548144c4a1ac4d68ec5540b"],
   [
     "Embed synchronous admission label normalization",
-    "76c4428d38e0aaaa78fee08081ba14ea1b395a65c6ad893faf81c166c57ae29f"
+    "c12ff82cc8bed1b45e5c3492c9d717173273956d9048bc35f6977cb53ef61b0a"
   ],
-  ["Embed sidecar route label normalization", "2a93ebc727dd8919aa7bb79d4af69aa09640c9a227138aae1caf08d0e6f1a3f2"],
+  ["Embed sidecar route label normalization", "5b48e9b9a2959c6bdb440467141377213fe900a9ef11863b34382af05d8e2c0d"],
   [
     "Embed malformed-generation value normalization",
-    "f8b62081dcdd4e75ba1bba3f41d2188d918fd934dba57b67f8fe1ac6cecb35fb"
+    "027d4839019f77948c3a19cdbba304b2087d49fe2903b02f0294c6598ae32c85"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
   ["FTS route slug normalization", "4c85c74d066bfaf4b0177ad8da61b867bc62ae819b9e5b98becb13d8fbf80028"],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -1005,12 +1005,12 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["ReDoS catastrophic control transform", "99358421ccbe92052218efb7bcf19e31029854d36548144c4a1ac4d68ec5540b"],
   [
     "Embed synchronous admission label normalization",
-    "f2bb42debb5e1c804d9620d6b240ead8504e6d06d49ce3769d6d65247fb8e00d"
+    "76c4428d38e0aaaa78fee08081ba14ea1b395a65c6ad893faf81c166c57ae29f"
   ],
-  ["Embed sidecar route label normalization", "8f31f04cb58453f0cc4296e397e77b2f320584de59e96c47718e070b00d06014"],
+  ["Embed sidecar route label normalization", "2a93ebc727dd8919aa7bb79d4af69aa09640c9a227138aae1caf08d0e6f1a3f2"],
   [
     "Embed malformed-generation value normalization",
-    "639096bed5316aae3c5145ee0abce73b64dc4b6bc80e7a31192c51a29f7dd81d"
+    "f8b62081dcdd4e75ba1bba3f41d2188d918fd934dba57b67f8fe1ac6cecb35fb"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
   ["FTS route slug normalization", "4c85c74d066bfaf4b0177ad8da61b867bc62ae819b9e5b98becb13d8fbf80028"],


### PR DESCRIPTION
## What's in this PR

**A 3.11.6 embedding index is no longer emptied when v4 opens it.**

`EMBED_DB_SCHEMA_VERSION` 3 → 5 admitted a 3.11.6 store as owned, then `bootstrapSchema` dropped `embeddings` and stamped schema 5. Default serve does not run `syncEmbedDb`, so semantic search degraded to BM25+TF-IDF while `doctor` reported `ok` at 0 chunks because the schema number now matched.

Same-config historical schemas whose vector table already has `kind` (v2/v3/v4) keep their rows and only install v5 UUID/epoch metadata. v1 still rebuilds (no `kind` column). Model, dimension, or quantization mismatch still rebuilds.

Coverage is extra phases of the existing `rebuilds supported same-root legacy schemas` test. No new `it()`. Census stays 2228.

## Bounded claim

This does **not** auto-run `syncEmbedDb` on serve. It does **not** keep vectors across a model/dim/quantization change (AH-4 remains HOLD). It does **not** keep v1 vectors. A fresh UUID still rotates on the metadata upgrade.

## Proof

- Extra phases of `tests/embed-db.test.ts` `rebuilds supported same-root legacy schemas but refuses missing/future authority metadata`.
- D-73 pass 1 session `01a04c7b-6716-7a10-aa3c-c89efb572eee` **REFUTED** `36fcda3` (live rc.4 H3/A10 bounds still named A5 as an unopened vector drop).
- D-73 pass 2 session `01a04c81-392d-7982-af15-a23c79a0ad4b` **CONFIRMED** `3ee3254` (claim surface). Pin-only follow-ups `2446e53`/`53c9de7` retarget three `embed-db.test.ts` ordinary-transform owner sha256s (digest is `test:<title>` plus whole file). Claim surface unchanged; no new D-73.
- Hosted CI: coverage + OIA + smoke required before squash. D-45: no local package-manager, lint, or test workload.

## Merge

Squash only after D-73 CONFIRMED **and** coverage + OIA + smoke are green on this exact candidate. Then replay exact-main CI. One product PR. A8/AH-4/m165 remain HOLD. Do not tag or publish.
