### PR TITLE
fix: add first-party trusted Vitest bootstrap generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Trusted Vitest bootstrap has a regeneration script
+
+> **TL;DR:** **The trusted Vitest bootstrap receipt can now be regenerated.** `.github/trusted-vitest-bootstrap.sha256` and its single `expected_manifest_sha=` CI carrier had no checked-in generator, so every dependency bump failed `lint` before `setup-node`. `scripts/generate-vitest-bootstrap.mjs` writes the 16-line receipt from the reviewed file census and updates that one carrier. Path-census pins (`expected_path_sha`, line count) stay fail-closed; expanding the freeze is still a reviewed inventory change.
+>
+> **Bounded claim.** This does **not** bump `package.json` / `package-lock.json`. It does **not** merge Dependabot #451/#510/#515. It does **not** add the generator to the frozen 16-file census. It does **not** publish or retag. A7's hono override remains a separate dependency-policy PR.
+>
+> **Method note:** BACKLOG §1.CC **A8**. Coverage is extra phases of the existing bootstrap NEGATIVE control: a copied fixture regenerates byte-identical receipt bytes, and later receipt-restore steps run the generator. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Receipt regeneration is a first-party script.** `node scripts/generate-vitest-bootstrap.mjs` writes the receipt and the single CI carrier.
+
 ### Same-config embed schema upgrade keeps vectors
 
 > **TL;DR:** **A 3.11.6 embedding index is no longer emptied when v4 opens it.** Schema 3→5 admitted the store as owned, then `bootstrapSchema` dropped `embeddings` and stamped schema 5. Default serve does not run `syncEmbedDb`, so semantic search degraded to BM25+TF-IDF while `doctor` reported `ok` at 0 chunks. Same-config historical schemas whose vector table already has `kind` (v2/v3/v4) now keep their rows and only install v5 UUID/epoch metadata. v1 still rebuilds. Model, dimension, or quantization mismatch still rebuilds.

--- a/scripts/generate-vitest-bootstrap.mjs
+++ b/scripts/generate-vitest-bootstrap.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Regenerates the trusted Vitest bootstrap receipt and its single CI carrier.
+//
+// BACKLOG §1.CC A8: package.json + package-lock.json are byte-frozen in
+// `.github/trusted-vitest-bootstrap.sha256`, verified as the first lint step
+// before setup-node. This script is the reviewed regeneration path. It does not
+// expand the 16-file census; path-sha and line-count pins stay fail-closed.
+
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isEntrypoint } from "./lib/entrypoint.mjs";
+import {
+  ciWorkflowReceiptDigest,
+  EXPECTED_VITEST_BOOTSTRAP_FILES,
+  VITEST_BOOTSTRAP_MANIFEST
+} from "./lib/oia-vitest-bootstrap.mjs";
+
+const DEFAULT_REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CI_WORKFLOW = ".github/workflows/ci.yml";
+const SHA256 = /^[0-9a-f]{64}$/u;
+const MANIFEST_CARRIER_RE = /^ {10}expected_manifest_sha=([0-9a-f]{64})$/gmu;
+const PATH_SHA_RE = /^ {10}expected_path_sha=([0-9a-f]{64})$/gmu;
+const LINE_COUNT_RE = /^ {10}\[\[ "\$line_count" -eq (\d+) \]\]$/gmu;
+const PATH_COUNT_RE = /^ {10}\[\[ \$\{#paths\[@\]\} -eq (\d+) \]\]$/gmu;
+
+function fail(message) {
+  throw new Error(`vitest bootstrap generator: ${message}`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function physicalFile(root, relativePath) {
+  const absolute = join(root, relativePath);
+  let stat;
+  try {
+    stat = lstatSync(absolute);
+  } catch (error) {
+    fail(
+      error && typeof error === "object" && "code" in error && error.code === "ENOENT"
+        ? `${relativePath} is missing`
+        : `${relativePath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (stat === undefined || stat.isSymbolicLink() || !stat.isFile()) {
+    fail(`${relativePath} must be a physical non-symlink file`);
+  }
+  return absolute;
+}
+
+function uniqueMatch(source, pattern, label) {
+  pattern.lastIndex = 0;
+  const matches = [...source.matchAll(pattern)];
+  const match = matches[0];
+  if (matches.length !== 1 || match?.[1] === undefined) {
+    fail(`expected one ${label} pin, found ${matches.length}`);
+  }
+  return match[1];
+}
+
+/**
+ * Render the exact trusted Vitest bootstrap receipt for one repository root.
+ *
+ * @param {string} root Repository root whose reviewed bootstrap files are hashed.
+ * @returns {string} LF-terminated receipt with one line per reviewed path.
+ */
+export function renderVitestBootstrapManifest(root) {
+  if (EXPECTED_VITEST_BOOTSTRAP_FILES.at(-1) !== CI_WORKFLOW) {
+    fail("CI workflow must remain the final receipt path so raw file hashes stay checkable");
+  }
+  const lines = EXPECTED_VITEST_BOOTSTRAP_FILES.map((relativePath) => {
+    const absolute = physicalFile(root, relativePath);
+    const digest =
+      relativePath === CI_WORKFLOW
+        ? ciWorkflowReceiptDigest(readFileSync(absolute, "utf8"))
+        : sha256(readFileSync(absolute));
+    return `${digest}  ${relativePath}`;
+  });
+  const manifest = `${lines.join("\n")}\n`;
+  if (manifest.includes("\r") || !manifest.endsWith("\n")) {
+    fail("receipt must be LF-only with one final LF");
+  }
+  return manifest;
+}
+
+/**
+ * Replace the lint job's single receipt-SHA carrier.
+ *
+ * @param {string} source Raw `.github/workflows/ci.yml` source.
+ * @param {string} manifestDigest SHA-256 of the raw receipt bytes.
+ * @returns {string} Workflow source with the carrier updated.
+ */
+export function replaceVitestBootstrapCarrier(source, manifestDigest) {
+  if (!SHA256.test(manifestDigest)) fail("manifest digest is not lowercase SHA-256");
+  MANIFEST_CARRIER_RE.lastIndex = 0;
+  const matches = [...source.matchAll(MANIFEST_CARRIER_RE)];
+  const match = matches[0];
+  if (matches.length !== 1 || match?.index === undefined) {
+    fail(`expected one canonical receipt carrier, found ${matches.length}`);
+  }
+  return (
+    source.slice(0, match.index) +
+    `          expected_manifest_sha=${manifestDigest}` +
+    source.slice(match.index + match[0].length)
+  );
+}
+
+/**
+ * Write the trusted Vitest bootstrap receipt and update its single CI carrier.
+ *
+ * Path-census pins stay fail-closed: expanding EXPECTED_VITEST_BOOTSTRAP_FILES
+ * requires a reviewed change to expected_path_sha and the two line-count pins.
+ *
+ * @param {string} root Repository root to regenerate.
+ * @returns {string} SHA-256 of the written receipt bytes.
+ */
+export function generateVitestBootstrapReceipt(root) {
+  const ciPath = physicalFile(root, CI_WORKFLOW);
+  const ciSource = readFileSync(ciPath, "utf8");
+  const expectedCount = String(EXPECTED_VITEST_BOOTSTRAP_FILES.length);
+  const lineCount = uniqueMatch(ciSource, LINE_COUNT_RE, "line_count");
+  const pathCount = uniqueMatch(ciSource, PATH_COUNT_RE, "paths length");
+  const expectedPathSha = uniqueMatch(ciSource, PATH_SHA_RE, "expected_path_sha");
+  const actualPathSha = sha256(`${EXPECTED_VITEST_BOOTSTRAP_FILES.join("\n")}\n`);
+  if (lineCount !== expectedCount || pathCount !== expectedCount) {
+    fail(
+      `CI path census pins are line_count=${lineCount} paths=${pathCount}; ` +
+        `EXPECTED_VITEST_BOOTSTRAP_FILES has ${expectedCount}. Expanding the freeze is a reviewed inventory change.`
+    );
+  }
+  if (actualPathSha !== expectedPathSha) {
+    fail(
+      `CI expected_path_sha=${expectedPathSha} but census digest is ${actualPathSha}. ` +
+        "Expanding the freeze is a reviewed inventory change."
+    );
+  }
+
+  const manifest = renderVitestBootstrapManifest(root);
+  const manifestDigest = sha256(manifest);
+  const nextCi = replaceVitestBootstrapCarrier(ciSource, manifestDigest);
+  writeFileSync(join(root, VITEST_BOOTSTRAP_MANIFEST), manifest);
+  if (nextCi !== ciSource) writeFileSync(ciPath, nextCi);
+  return manifestDigest;
+}
+
+function parseRoot(argv) {
+  if (argv.length > 1) fail("usage: node scripts/generate-vitest-bootstrap.mjs [repo-root]");
+  return argv[0] === undefined ? DEFAULT_REPO_ROOT : resolve(argv[0]);
+}
+
+if (isEntrypoint(import.meta.url)) {
+  try {
+    process.stdout.write(`${generateVitestBootstrapReceipt(parseRoot(process.argv.slice(2)))}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -329,7 +329,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "no-internal-imports.test.ts",
-    { count: 79, sha256: "5ed3320ec2b9a2aa04afcce4c737955b4819d1bb9a11dcf1cb989a01d456846d" }
+    { count: 79, sha256: "3eef0add16e7b0dd8d4f446cc28fe5ca4058135f0155d69546fd0c5c90390d55" }
   ],
   ["ocr-admission.test.ts", { count: 2, sha256: "90087510a75587d7bc1e3f94812692b128d5466f4aba05638305fa2815809faa" }],
   ["pages.test.ts", { count: 53, sha256: "bce9e4ba732c418f8f9779814cb9febc937844730cb224933b931df6bed8f21e" }],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -329,7 +329,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "no-internal-imports.test.ts",
-    { count: 79, sha256: "3eef0add16e7b0dd8d4f446cc28fe5ca4058135f0155d69546fd0c5c90390d55" }
+    { count: 79, sha256: "0ffa1d9bca5c883b8ccfa206c0676a3a02bc8ca124c7521bf00d5b87d6e9aba1" }
   ],
   ["ocr-admission.test.ts", { count: 2, sha256: "90087510a75587d7bc1e3f94812692b128d5466f4aba05638305fa2815809faa" }],
   ["pages.test.ts", { count: 53, sha256: "bce9e4ba732c418f8f9779814cb9febc937844730cb224933b931df6bed8f21e" }],

--- a/tests/no-internal-imports.test.ts
+++ b/tests/no-internal-imports.test.ts
@@ -2472,16 +2472,16 @@ describe("Class A invariant — no test imports value from registration boilerpl
       expect(await fs.readFile(manifestPath, "utf8")).toBe(baselineManifest);
       expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual([]);
 
-      const ciPath = path.join(bootstrapScratch, ".github", "workflows", "ci.yml");
-      const baselineCi = await fs.readFile(ciPath, "utf8");
+      const pathShaCiPath = path.join(bootstrapScratch, ".github", "workflows", "ci.yml");
+      const pathShaCi = await fs.readFile(pathShaCiPath, "utf8");
       const pathShaNeedle = "expected_path_sha=";
-      const pathShaAt = baselineCi.indexOf(pathShaNeedle);
+      const pathShaAt = pathShaCi.indexOf(pathShaNeedle);
       if (pathShaAt < 0) throw new Error("expected path-sha pin");
       const driftedCi =
-        baselineCi.slice(0, pathShaAt + pathShaNeedle.length) +
+        pathShaCi.slice(0, pathShaAt + pathShaNeedle.length) +
         "0".repeat(64) +
-        baselineCi.slice(pathShaAt + pathShaNeedle.length + 64);
-      await fs.writeFile(ciPath, driftedCi);
+        pathShaCi.slice(pathShaAt + pathShaNeedle.length + 64);
+      await fs.writeFile(pathShaCiPath, driftedCi);
       try {
         try {
           execFileSync(
@@ -2496,7 +2496,7 @@ describe("Class A invariant — no test imports value from registration boilerpl
           expect(`${String(error)}\n${stderr}`).toMatch(/Expanding the freeze is a reviewed inventory change/);
         }
       } finally {
-        await fs.writeFile(ciPath, baselineCi);
+        await fs.writeFile(pathShaCiPath, pathShaCi);
       }
       expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual([]);
 

--- a/tests/no-internal-imports.test.ts
+++ b/tests/no-internal-imports.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import * as os from "node:os";
@@ -1535,7 +1536,7 @@ async function updateVitestBootstrapCarrier(root: string, manifestDigest: string
 }
 
 async function refreshVitestBootstrapReceipt(root: string): Promise<void> {
-  await updateVitestBootstrapCarrier(root, await writeVitestBootstrapManifest(root));
+  execFileSync(process.execPath, [path.join(repoRoot, "scripts", "generate-vitest-bootstrap.mjs"), root]);
 }
 
 function isProductionPath(relativePath: string): boolean {
@@ -2460,6 +2461,45 @@ describe("Class A invariant — no test imports value from registration boilerpl
       await copyVitestBootstrapFixture(repoRoot, bootstrapScratch);
       expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual([]);
 
+      const manifestPath = path.join(bootstrapScratch, ...VITEST_BOOTSTRAP_MANIFEST.split("/"));
+      const baselineManifest = await fs.readFile(manifestPath, "utf8");
+      const generatedDigest = execFileSync(
+        process.execPath,
+        [path.join(repoRoot, "scripts", "generate-vitest-bootstrap.mjs"), bootstrapScratch],
+        { encoding: "utf8" }
+      ).trim();
+      expect(generatedDigest).toBe(createHash("sha256").update(baselineManifest).digest("hex"));
+      expect(await fs.readFile(manifestPath, "utf8")).toBe(baselineManifest);
+      expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual([]);
+
+      const ciPath = path.join(bootstrapScratch, ".github", "workflows", "ci.yml");
+      const baselineCi = await fs.readFile(ciPath, "utf8");
+      const pathShaNeedle = "expected_path_sha=";
+      const pathShaAt = baselineCi.indexOf(pathShaNeedle);
+      if (pathShaAt < 0) throw new Error("expected path-sha pin");
+      const driftedCi =
+        baselineCi.slice(0, pathShaAt + pathShaNeedle.length) +
+        "0".repeat(64) +
+        baselineCi.slice(pathShaAt + pathShaNeedle.length + 64);
+      await fs.writeFile(ciPath, driftedCi);
+      try {
+        try {
+          execFileSync(
+            process.execPath,
+            [path.join(repoRoot, "scripts", "generate-vitest-bootstrap.mjs"), bootstrapScratch],
+            { encoding: "utf8" }
+          );
+          throw new Error("expected generator to fail closed on path-sha drift");
+        } catch (error) {
+          const stderr =
+            error instanceof Error && "stderr" in error && typeof error.stderr === "string" ? error.stderr : "";
+          expect(`${String(error)}\n${stderr}`).toMatch(/Expanding the freeze is a reviewed inventory change/);
+        }
+      } finally {
+        await fs.writeFile(ciPath, baselineCi);
+      }
+      expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual([]);
+
       for (const filename of EXPECTED_VITEST_BOOTSTRAP_FILES) {
         const absolute = path.join(bootstrapScratch, ...filename.split("/"));
         const baseline = await fs.readFile(absolute);
@@ -2471,8 +2511,6 @@ describe("Class A invariant — no test imports value from registration boilerpl
         expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual([]);
       }
 
-      const manifestPath = path.join(bootstrapScratch, ...VITEST_BOOTSTRAP_MANIFEST.split("/"));
-      const baselineManifest = await fs.readFile(manifestPath, "utf8");
       await fs.writeFile(manifestPath, `A${baselineManifest.slice(1)}`);
       expect(inspectRepositoryVitestBootstrap(bootstrapScratch)).toEqual(
         expect.arrayContaining([


### PR DESCRIPTION
## What's in this PR

**The trusted Vitest bootstrap receipt has a first-party regeneration script.**

`.github/trusted-vitest-bootstrap.sha256` froze `package.json` + `package-lock.json` (and 14 other install/Vitest/OIA inputs) as the first `lint` step, before `setup-node`. There was no checked-in generator, so a reviewed dependency bump could not update the receipt and its single `expected_manifest_sha=` carrier in the same change.

`scripts/generate-vitest-bootstrap.mjs` hashes the reviewed 16-file census (CI workflow through the existing normalized-carrier digest) and writes the receipt plus that one carrier. Path-census pins (`expected_path_sha`, line count, paths length) stay fail-closed; expanding the freeze is still a reviewed inventory change.

## Tests

Extra phases of the existing bootstrap NEGATIVE control (no new `it()`):

- A copied fixture regenerates byte-identical receipt bytes and the same digest.
- Path-sha drift fails closed with the freeze-expansion error.
- Later receipt-restore steps in that test exec the generator.

## Bounds

- Does **not** bump `package.json` / `package-lock.json`.
- Does **not** merge Dependabot #451/#510/#515.
- Does **not** add the generator to the frozen 16-file census.
- Does **not** publish, tag, or retarget `@latest` / `@rc`.
- A7's `@hono/node-server` override remains a separate dependency-policy PR.

BACKLOG §1.CC **A8**.
