### PR TITLE
fix: unlink atomic-write tmp only after this invocation created it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.4] — 2026-08-21
 
+### Atomic overwrite cleanup unlinks only a tmp this invocation created
+
+> **TL;DR:** **A failed atomic overwrite no longer deletes a temp path this invocation never created.** `writeNoteContent` opened a random `<note>.<16hex>.tmp` with `wx` (O_EXCL) and, on any catch, unlinked that path. Exclusive-open can fail with `EEXIST` before `fh` is assigned — a collision, leftover nonce, or planted occupant — and the catch still deleted it. Cleanup now unlinks only after this invocation's exclusive open succeeded.
+>
+> **Bounded claim.** This does **not** change the `overwrite=false` exclusive-create path (no tmp). It does **not** add a vault-wide leftover-`.tmp` sweeper (AH-9b crash leftovers remain operator-manual). It does **not** close an ABA between a successful open and the later unlink. Hardlink/ABA remain bounds. It does **not** publish or tag.
+>
+> **Method note:** BACKLOG §1.CC **A14**. Coverage is extra phases of the existing AUD-01 leftover-tmp NEGATIVE control: a planted occupant of the nonce path survives an exclusive-open collision, and a post-close rename failure still unlinks the owned nonce. No new `it()`. Under D-45 all executable proof is GitHub-hosted; no local package-manager, lint or test workload was used.
+
+- **Overwrite catch unlinks only an owned nonce.** `createdTmp` is set after `openSafe(tmp, "wx")` succeeds; exclusive-open collision leaves a foreign occupant in place.
+
 ### Withheld rename destination bytes are saved under `.enquire-rollback/`
 
 > **TL;DR:** **A withheld `rename_note` destination snapshot is no longer discarded.** When rollback proves the source path holds no regular file, it still does not restore onto the destination (that path may hold the only copy of the renamed note). The destination's own pre-rename bytes are now written to `.enquire-rollback/<dest>` — a hidden prefix, so they stay off the public MCP surface. If that recovery write fails, dest restore is still withheld and those bytes remain unrecoverable.

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -1854,8 +1854,13 @@ export class Vault {
       const tmpMode = targetLstat ? targetLstat.mode & 0o777 : 0o666;
       const tmp = `${abs}.${randomBytes(8).toString("hex")}.tmp`;
       let fh: import("node:fs/promises").FileHandle | undefined;
+      // Exclusive-open can fail before this invocation creates `tmp`. Unlink
+      // only a leaf we actually opened — a collision must not delete a foreign
+      // occupant of the same nonce path.
+      let createdTmp = false;
       try {
         fh = await this.openSafe(tmp, "wx", tmpMode); // O_EXCL — never follows a pre-planted symlink
+        createdTmp = true;
         await this.assertMutationPathPublic(tmp, "write", "temporary destination", opts.rollbackRecovery === true);
         if (Buffer.isBuffer(content)) await fh.writeFile(content);
         else await fh.writeFile(content, "utf8");
@@ -1868,7 +1873,7 @@ export class Vault {
         await this.renameSafe(tmp, abs);
       } catch (err) {
         if (fh) await fh.close().catch(() => {});
-        await this.unlinkSafe(tmp).catch(() => {});
+        if (createdTmp) await this.unlinkSafe(tmp).catch(() => {});
         throw err;
       }
     } else {

--- a/tests/rc13-dual-audit.test.ts
+++ b/tests/rc13-dual-audit.test.ts
@@ -7,7 +7,7 @@
 import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { extractFrontmatterTags } from "../src/parser.js";
 import { listTags } from "../src/tools/read.js";
 import { createNote, frontmatterSet } from "../src/tools/write.js";
@@ -51,6 +51,49 @@ describe("rc.12-audit AUD-01 (Goose, MEDIUM) — atomic writeNote overwrite must
     // no nonce .tmp left behind on the success path
     const leftover = (await fs.readdir(root)).filter((f) => f.endsWith(".tmp"));
     expect(leftover).toEqual([]);
+
+    // A14 causal: exclusive-open collision must not unlink a tmp this invocation
+    // never created. Plant a regular file at the nonce path before `wx` so the
+    // open fails; the occupant must survive. Pre-fix catch unlinked it anyway.
+    await fs.writeFile(path.join(root, "collide.md"), "OLD");
+    const openTarget = v as unknown as {
+      openSafe(p: string, flags: string | number, mode?: number): Promise<import("node:fs/promises").FileHandle>;
+    };
+    const realOpenSafe = openTarget.openSafe.bind(v);
+    let collisionPath: string | undefined;
+    const openSpy = vi.spyOn(openTarget, "openSafe").mockImplementation(async (p, flags, mode) => {
+      if (collisionPath === undefined && flags === "wx" && p.endsWith(".tmp")) {
+        collisionPath = p;
+        await fs.writeFile(p, "FOREIGN_TMP");
+      }
+      return mode === undefined ? realOpenSafe(p, flags) : realOpenSafe(p, flags, mode);
+    });
+    try {
+      await expect(v.writeNote("collide.md", "NEW", { overwrite: true })).rejects.toMatchObject({ code: "EEXIST" });
+    } finally {
+      openSpy.mockRestore();
+    }
+    expect(collisionPath).toBeDefined();
+    expect(await fs.readFile(collisionPath!, "utf8")).toBe("FOREIGN_TMP");
+    expect(await fs.readFile(path.join(root, "collide.md"), "utf8")).toBe("OLD");
+
+    // Owned tmp still cleaned after a post-close rename failure (`fh` is
+    // already undefined). Gating unlink on `if (fh)` would leave the nonce.
+    await fs.writeFile(path.join(root, "owned.md"), "OLD");
+    const renameTarget = v as unknown as {
+      renameSafe(src: string, dest: string): Promise<void>;
+    };
+    const renameSpy = vi
+      .spyOn(renameTarget, "renameSafe")
+      .mockRejectedValueOnce(Object.assign(new Error("synthetic rename failure"), { code: "EIO" }));
+    try {
+      await expect(v.writeNote("owned.md", "NEW", { overwrite: true })).rejects.toThrow(/synthetic rename failure/);
+    } finally {
+      renameSpy.mockRestore();
+    }
+    expect(await fs.readFile(path.join(root, "owned.md"), "utf8")).toBe("OLD");
+    const ownedLeftover = (await fs.readdir(root)).filter((f) => f.startsWith("owned.md.") && f.endsWith(".tmp"));
+    expect(ownedLeftover).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Bound claim

A failed atomic overwrite no longer deletes a temp path this invocation never created.

`writeNoteContent` opened a random `<note>.<16hex>.tmp` with `wx` and, on any catch, unlinked that path. Exclusive-open can fail with `EEXIST` before `fh` is assigned. Cleanup now unlinks only after this invocation's exclusive open succeeded.

## Product

- `createdTmp` is set after `openSafe(tmp, "wx")` succeeds.
- Catch is `if (createdTmp) await this.unlinkSafe(tmp)`.
- `overwrite=false` is unchanged (no tmp).

## Proof

Extra-phases of the existing AUD-01 leftover-tmp NEGATIVE control in `tests/rc13-dual-audit.test.ts`: planted occupant of the nonce path survives an exclusive-open collision; a post-close rename failure still unlinks the owned nonce. No new `it()`.

## Non-claims

Does not add a vault-wide leftover-`.tmp` sweeper (AH-9b remains operator-manual). Does not close ABA between a successful open and the later unlink. Does not tag or publish. A6/A7/AH-4/m165 remain HOLD.

BACKLOG §1.CC **A14**. D-45: executable proof is GitHub-hosted.

D-73 pass 1 session `01a04d40-1ddb-7633-abfc-daf241dc0d1e` CONFIRMED `f57ca2e273941d21206f89b45ec2ff225687bb0d`.
