### PR TITLE
test: pin why a multi-word question can return nothing

### DIFF
--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -20,7 +20,8 @@ import {
   frontmatterMatches,
   MAX_FANOUT_QUERIES,
   pruneExcludedHits,
-  searchHybridMulti
+  searchHybridMulti,
+  semanticSearch
 } from "../src/tools/search.js";
 import { Vault } from "../src/vault.js";
 import {
@@ -665,6 +666,66 @@ describe("searchHybrid — BM25 + TF-IDF fusion path", () => {
     expect(result.matches.length).toBeGreaterThan(0);
     // Top hit must be from Auth/, not Cooking/.
     expect(result.matches[0]?.path.startsWith("Auth/")).toBe(true);
+
+    // ── SBS-R0 characterization: why a multi-word question can return nothing ──
+    // These phases PIN today's behavior so a later recall fix has something to
+    // move. They build their own vaults so the shared fixture above — whose
+    // rankings other tests assert — is untouched.
+    const probeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-sbs-r0-"));
+    const probeVault = new Vault(probeRoot);
+    await probeVault.ensureExists();
+    await fs.writeFile(path.join(probeRoot, "One.md"), "The carbonara is finished.\n");
+    await fs.writeFile(path.join(probeRoot, "Two.md"), "The sourdough is proofing.\n");
+    await fs.writeFile(path.join(probeRoot, "Three.md"), "The issuer signs it.\n");
+    // A camelCase identifier and its snake_case twin, to separate tokenizer
+    // behavior from ranking behavior.
+    await fs.writeFile(path.join(probeRoot, "Camel.md"), "Aggregate poolDayData for the window.\n");
+    await fs.writeFile(path.join(probeRoot, "Snake.md"), "Aggregate liquidity_pool_day for the window.\n");
+    const probeIdx = new FtsIndex({ file: defaultIndexFile(probeRoot), vaultRoot: probeRoot });
+    await probeIdx.open();
+    try {
+      for (const entry of await probeVault.listMarkdown()) {
+        const note = await probeVault.readNote(entry.absPath, entry.mtimeMs);
+        probeIdx.reindexFile(entry.relPath, entry.mtimeMs, note.content, [], note.parsed.tags);
+      }
+
+      // Phase A — FTS5 joins terms with an implicit AND, and a chunk is the unit
+      // that has to satisfy it. Three words that each exist in the vault, but
+      // never together in one note, match nothing.
+      // POSITIVE control: each word alone is indexed and findable.
+      for (const word of ["carbonara", "sourdough", "issuer"]) {
+        expect(probeIdx.search(word, { limit: 10 }).length).toBeGreaterThan(0);
+      }
+      // NEGATIVE control: the probe does not report matches that do not exist.
+      expect(probeIdx.search("zzzabsentzzz", { limit: 10 })).toEqual([]);
+      // Characterization: the conjunction of three present words is empty.
+      expect(probeIdx.search("carbonara sourdough issuer", { limit: 10 })).toEqual([]);
+
+      // Phase B — TF-IDF has no such conjunction rule, so the same question is
+      // answerable by the signal that runs unconditionally beside BM25. This is
+      // the asymmetry a recall fix can exploit; whether the default 0.05 cosine
+      // floor then hides these hits on long documents is a separate measurement.
+      const unfloored = await semanticSearch(probeVault, {
+        query: "carbonara sourdough issuer",
+        min_score: 0,
+        limit: 10
+      });
+      expect(unfloored.matches.length).toBeGreaterThan(0);
+
+      // Phase C — the tokenizer splits on underscores but never on case, so a
+      // camelCase identifier stays one opaque token and cannot be reached by
+      // the words it is spelled from.
+      // POSITIVE control: the whole token IS indexed and findable.
+      expect(probeIdx.search("pooldaydata", { limit: 10 }).map((hit) => hit.rel_path)).toEqual(["Camel.md"]);
+      // POSITIVE control: the snake_case twin DOES split into its parts.
+      expect(probeIdx.search("pool day", { limit: 10 }).map((hit) => hit.rel_path)).toEqual(["Snake.md"]);
+      // Characterization: spelling the camelCase identifier as words finds
+      // only the snake_case note — never the camelCase one.
+      expect(probeIdx.search("pool day data", { limit: 10 }).map((hit) => hit.rel_path)).not.toContain("Camel.md");
+    } finally {
+      await probeIdx.closeAndRelease();
+      await fs.rm(probeRoot, { recursive: true, force: true });
+    }
   });
 
   it("hits ranked in BOTH signals score higher than single-signal hits (fusion working)", async () => {


### PR DESCRIPTION
## What this establishes

A question phrased in several ordinary words can come back **empty** even when every one of those words is in the vault. Nothing in the suite says so today, so a recall fix would have nothing to move and no way to prove it moved.

This is characterization only — **no behavior changes**.

## Three mechanisms, pinned separately

They are separate mechanisms, and a single end-to-end query conflates them:

| Phase | What it pins |
|---|---|
| **A** | FTS5 joins terms with an implicit **AND**, and a *chunk* is the unit that must satisfy it — three words living in three different notes match nothing |
| **B** | TF-IDF has no conjunction rule, so the same question **is** answerable by the signal that runs unconditionally beside BM25 |
| **C** | The tokenizer splits on `_` but never on case — `poolDayData` stays one opaque token the words it is spelled from cannot reach, while `liquidity_pool_day` splits and can |

Phase B is the useful one for design: the asymmetry between the two lexical signals is what a recall fix can exploit, and it is now asserted rather than assumed.

## Controls

Every phase carries a **positive control** proving the probe works — each word alone is findable, the whole camelCase token is findable, the snake_case twin does split. The conjunction phase adds a **negative control** proving the probe does not report matches that do not exist. Without those, a green assertion here would prove nothing.

## Deliberately not pinned

Whether the default **0.05 cosine floor** hides TF-IDF's partial matches on long documents. Short synthetic notes give a matched term a large weight, so a floor assertion would pass here for reasons that do not hold on a real vault — it would silently mean something other than it says. That is a measurement, and it belongs with the recall work.

## Scope discipline

The phases build their own vaults, so the shared fixture whose rankings other tests assert is untouched. They fold into an existing test rather than adding one: a new `it()` moves pinned counts across dozens of surfaces and a frozen receipt.

**Test count unchanged. No `src/` change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)