### PR TITLE
feat: answer a question the strict rankers leave empty

### DIFF
--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -2997,6 +2997,11 @@ export async function syncPdfFtsIndex(vault: Vault, idx: FtsIndex): Promise<PdfF
  * protection is untouched — a term arriving from the query is still quoted, and
  * only the separators this function inserts are operators.
  *
+ * Terms are separated by a single linear scan that tracks quote state rather
+ * than by a regular expression. A quote-aware split expressed as a lookahead
+ * needs nested quantifiers, which is the shape this project has repeatedly had
+ * to remove from other sinks; a scan cannot exceed linear time for any input.
+ *
  * @param q - User query string.
  * @returns An FTS5 `MATCH` expression that any single term satisfies, or the
  *   empty string when the input has no terms.
@@ -3008,7 +3013,19 @@ export async function syncPdfFtsIndex(vault: Vault, idx: FtsIndex): Promise<PdfF
 export function anyFts5Query(q: string): string {
   const terms = safeFts5Query(q).trim();
   if (terms.length === 0) return "";
-  const parts = terms.split(/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/u).filter((part) => part.length > 0);
+  const parts: string[] = [];
+  let current = "";
+  let quoted = false;
+  for (const char of terms) {
+    if (char === '"') quoted = !quoted;
+    if (char === " " && !quoted) {
+      if (current.length > 0) parts.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.length > 0) parts.push(current);
   return parts.length <= 1 ? terms : parts.join(" OR ");
 }
 

--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -2448,7 +2448,7 @@ export class FtsIndex {
    */
   search(
     rawQuery: string,
-    opts: { limit?: number; folder?: string; tag?: string; sinceMtimeMs?: number } = {}
+    opts: { limit?: number; folder?: string; tag?: string; sinceMtimeMs?: number; match?: "all" | "any" } = {}
   ): FtsSearchHit[] {
     return this.searchWithReceipts(rawQuery, opts).map((hit) => ({
       rel_path: hit.rel_path,
@@ -2488,11 +2488,11 @@ export class FtsIndex {
    */
   searchWithReceipts(
     rawQuery: string,
-    opts: { limit?: number; folder?: string; tag?: string; sinceMtimeMs?: number } = {}
+    opts: { limit?: number; folder?: string; tag?: string; sinceMtimeMs?: number; match?: "all" | "any" } = {}
   ): FtsReceiptSearchHit[] {
     const db = this.requireDb();
     const limit = opts.limit ?? 25;
-    const safe = safeFts5Query(rawQuery);
+    const safe = opts.match === "any" ? anyFts5Query(rawQuery) : safeFts5Query(rawQuery);
     if (!safe) return [];
     let matchQuery = `{content title aliases} : (${safe})`;
     const where: string[] = [
@@ -2978,6 +2978,40 @@ export async function syncPdfFtsIndex(vault: Vault, idx: FtsIndex): Promise<PdfF
  * @returns Sanitized query ready to pass to FTS5's `MATCH` operator.
  *   Empty string when input is empty / whitespace-only.
  */
+/**
+ * Sanitize `q` the way {@link safeFts5Query} does, but join the terms with an
+ * explicit `OR` so a document satisfying ANY term matches.
+ *
+ * `safeFts5Query` separates terms with spaces, which FTS5 reads as an implicit
+ * AND — and the unit that must satisfy it is one chunk, not one note. That is
+ * the right default: it is precise, and a question whose words genuinely belong
+ * together should not match documents that merely contain one of them.
+ *
+ * It is the wrong LAST word, though. When the conjunction matches nothing the
+ * choice is not between precision and recall — it is between some ranked
+ * answers and none at all. Callers use this to ask the weaker question only
+ * after the stronger one has come back empty.
+ *
+ * `OR` is emitted unquoted here on purpose: {@link safeFts5Query} deliberately
+ * quotes a user's literal `OR` so they can search for the word, and that
+ * protection is untouched — a term arriving from the query is still quoted, and
+ * only the separators this function inserts are operators.
+ *
+ * @param q - User query string.
+ * @returns An FTS5 `MATCH` expression that any single term satisfies, or the
+ *   empty string when the input has no terms.
+ * @example
+ * ```ts
+ * anyFts5Query("carbonara sourdough"); // '"carbonara" OR "sourdough"' semantics
+ * ```
+ */
+export function anyFts5Query(q: string): string {
+  const terms = safeFts5Query(q).trim();
+  if (terms.length === 0) return "";
+  const parts = terms.split(/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/u).filter((part) => part.length > 0);
+  return parts.length <= 1 ? terms : parts.join(" OR ");
+}
+
 export function safeFts5Query(q: string): string {
   const RESERVED = new Set(["AND", "OR", "NOT", "NEAR"]);
   const parts = q.trim().split(/\s+/);

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2987,6 +2987,71 @@ export async function searchHybrid(
     }
   }
 
+  // SBS-D1 — recall fallback. Every ranker above asks a STRICT question: BM25
+  // requires all terms in one chunk, TF-IDF requires a cosine above 0.05. Each
+  // is a good default and a bad last word — a question whose words are all in
+  // the vault, just not together in one chunk and not concentrated enough in a
+  // long note, currently returns nothing at all.
+  //
+  // The relaxation runs ONLY when the strict pass produced no candidate in any
+  // signal. That makes it a provable no-op for every query that answers today:
+  // if anything ranked, nothing here executes, so no existing result can be
+  // reordered. The choice at this point is not precision versus recall — it is
+  // some ranked answers versus none.
+  const strictPassFoundNothing =
+    bm25Ranked.length === 0 && tfidfRanked.length === 0 && embedRanked.length === 0;
+  if (strictPassFoundNothing) {
+    if (ctx.ftsIndex) {
+      try {
+        const anyHits = await filterLiveVaultHits(
+          vault,
+          ctx.ftsIndex
+            .searchWithReceipts(args.query, { limit: fanOutK, folder: args.folder, match: "any" })
+            .filter((hit) => !vault.isExcluded(hit.rel_path)),
+          (hit) => hit.rel_path,
+          fanOutK,
+          (hit) => hit,
+          (receipts) => ctx.ftsIndex?.currentSourceReceiptMask(receipts) ?? receipts.map(() => false)
+        );
+        bm25Ranked = anyHits.map((hit, index) => ({
+          id: granularity === "block" ? `${hit.rel_path}#${hit.chunk_index}` : hit.rel_path,
+          rank: index + 1,
+          score: hit.score,
+          snippet: hit.snippet,
+          chunk_index: hit.chunk_index,
+          line_start: hit.line_start,
+          line_end: hit.line_end,
+          kind: hit.kind,
+          indexed_mtime_ms: hit.indexed_mtime_ms,
+          indexed_revision: hit.indexed_revision
+        }));
+        if (bm25Ranked.length > 0 && !signalsUsed.includes("bm25")) signalsUsed.push("bm25");
+      } catch (err) {
+        signalErrors.bm25 = err instanceof Error ? err.message : String(err);
+      }
+    }
+    try {
+      // The floor exists to keep weak cosines out of a ranked answer. With no
+      // answer to dilute it cannot do that job, and it is the reason a term in
+      // a long note scores near 0.014 against a 0.05 threshold.
+      const unfloored = await semanticSearch(vault, {
+        query: args.query,
+        folder: args.folder,
+        limit: fanOutK,
+        min_score: 0
+      });
+      tfidfRanked = unfloored.matches.map((match, index) => ({
+        id: match.path,
+        rank: index + 1,
+        score: match.score,
+        snippet: match.snippet
+      }));
+      if (tfidfRanked.length > 0 && !signalsUsed.includes("tfidf")) signalsUsed.push("tfidf");
+    } catch (err) {
+      signalErrors.tfidf = err instanceof Error ? err.message : String(err);
+    }
+  }
+
   // B3 — TF-IDF is note-scoped. At block granularity BM25 and embeddings
   // fuse on `path#chunk`. Project each TF-IDF note onto the block ids those
   // rankers already produced for that path; if none exist, emit `path#0`

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2998,8 +2998,7 @@ export async function searchHybrid(
   // if anything ranked, nothing here executes, so no existing result can be
   // reordered. The choice at this point is not precision versus recall — it is
   // some ranked answers versus none.
-  const strictPassFoundNothing =
-    bm25Ranked.length === 0 && tfidfRanked.length === 0 && embedRanked.length === 0;
+  const strictPassFoundNothing = bm25Ranked.length === 0 && tfidfRanked.length === 0 && embedRanked.length === 0;
   if (strictPassFoundNothing) {
     if (ctx.ftsIndex) {
       try {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -3012,18 +3012,36 @@ export async function searchHybrid(
           (hit) => hit,
           (receipts) => ctx.ftsIndex?.currentSourceReceiptMask(receipts) ?? receipts.map(() => false)
         );
-        bm25Ranked = anyHits.map((hit, index) => ({
-          id: granularity === "block" ? `${hit.rel_path}#${hit.chunk_index}` : hit.rel_path,
-          rank: index + 1,
-          score: hit.score,
-          snippet: hit.snippet,
-          chunk_index: hit.chunk_index,
-          line_start: hit.line_start,
-          line_end: hit.line_end,
-          kind: hit.kind,
-          indexed_mtime_ms: hit.indexed_mtime_ms,
-          indexed_revision: hit.indexed_revision
-        }));
+        // The relaxed pass must produce the SAME SHAPE as the strict one. At note
+        // granularity that means collapsing a note's chunks to its best-ranked
+        // hit: emitting one entry per chunk would put duplicate ids into RRF,
+        // which fuses on the id, so a multi-chunk note would be counted several
+        // times and outrank a single-chunk one for no reason but its length.
+        const relaxed = new Map<string, (typeof bm25Ranked)[number]>();
+        anyHits.forEach((hit, index) => {
+          const id = granularity === "block" ? `${hit.rel_path}#${hit.chunk_index}` : hit.rel_path;
+          const existing = relaxed.get(id);
+          if (existing !== undefined && existing.rank <= index + 1) return;
+          relaxed.set(id, {
+            id,
+            rank: index + 1,
+            score: hit.score,
+            snippet: hit.snippet,
+            chunk_index: hit.chunk_index,
+            line_start: hit.line_start,
+            line_end: hit.line_end,
+            kind: hit.kind,
+            indexed_mtime_ms: hit.indexed_mtime_ms,
+            indexed_revision: hit.indexed_revision
+          });
+        });
+        bm25Ranked = [...relaxed.values()].sort((a, b) => a.rank - b.rank);
+        // Ranks must stay consecutive from 1 after the collapse — RRF weights by
+        // rank, so a gap silently discounts every hit below it.
+        for (let index = 0; index < bm25Ranked.length; index++) {
+          const hit = bm25Ranked[index];
+          if (hit) hit.rank = index + 1;
+        }
         if (bm25Ranked.length > 0 && !signalsUsed.includes("bm25")) signalsUsed.push("bm25");
       } catch (err) {
         signalErrors.bm25 = err instanceof Error ? err.message : String(err);

--- a/tests/docs-consistency.test.ts
+++ b/tests/docs-consistency.test.ts
@@ -2976,6 +2976,7 @@ type FtsSearchOptions = {
   folder?: string;
   tag?: string;
   sinceMtimeMs?: number;
+  match?: "all" | "any";
 };
 type EmbedSearchOptions = { folder?: string; minScore?: number };
 type EmbedPeekMeta = {

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -151,7 +151,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "../embeddings.js|resolveStoredEmbeddingConfiguration|resolveStoredEmbeddingConfiguration"
     ],
     k1Opens: 1,
-    sha256: "3aa2b91c829191f51a999849a2856a52d8047f34274e3e78ff3bb805d7ac1961"
+    sha256: "38d211c88ca57006d15169b71afad1eb47ee7a303394fe13ac5dab68c79cc0a3"
   }
 };
 

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -968,10 +968,10 @@ type ReviewedOrdinaryTransformId = (typeof REVIEWED_ORDINARY_TRANSFORMS)[number]
 // the complete source file, so a reachable decoy, relocated clone, or severed
 // helper consumer cannot inherit authority from the same filename/title/count.
 const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
-  ["pdf OCR quote normalization", "f263ff5abfb450dc69c3c38babc4d3fec97d504eebfe5b1adb8c38da4c95433c"],
-  ["pdf OCR whitespace normalization", "f263ff5abfb450dc69c3c38babc4d3fec97d504eebfe5b1adb8c38da4c95433c"],
-  ["lifecycle whitespace normalization", "75e8a2471e27ad3f24e3fc1535e866f13f98900e4dcd71a9ca1f42594fa30223"],
-  ["release gate parenthesis unescape", "283599de342dcd0e162a045dc3779c36ab76a9d24cf801065cc38e488de3c635"],
+  ["pdf OCR quote normalization", "5b94eac8f1b45d56105e33e13fc03e8252090b0278afc73e8e993e01e5f5256d"],
+  ["pdf OCR whitespace normalization", "5b94eac8f1b45d56105e33e13fc03e8252090b0278afc73e8e993e01e5f5256d"],
+  ["lifecycle whitespace normalization", "34e935f9b4097fa624dba82f5e4c7bd25067675f9712530e831555bb5173ae72"],
+  ["release gate parenthesis unescape", "4ba7ffff10e9ec1e9aac4f18873db2fa7f4e765bc638b1a2a49351e414ab3382"],
   ["entrypoint block-comment stripping", "319def01444e238d986cd6674091a75f17ce843b71ac7e74e2c1aeba07741b0a"],
   ["entrypoint line-comment stripping", "319def01444e238d986cd6674091a75f17ce843b71ac7e74e2c1aeba07741b0a"],
   ["release-check open-parenthesis unescape", "e12c9f3c715151d4535e1531ca2c067e426973eae147b325fbac7b990bd36108"],
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "9bb382eb2d071464957b3c6cec271cb2a843dfeeabd9225c92e4497597d839ef"],
   ["K-1 block-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
   ["K-1 line-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
-  ["K-1 module-extension normalization", "bec1d52b3e54eb60d1bc2e28ea41228b6847e5c7f83339600f6b506ad3e80949"],
-  ["K-1 source-path separator normalization", "5971db634d342a8044dbdccd270fe3070e07a7ed0406ca8a5ce78e7fb07cb3b9"],
+  ["K-1 module-extension normalization", "62116e0b791489598bcf7911462d849a7535390b5812154c6dfd3acb21e1bd5d"],
+  ["K-1 source-path separator normalization", "1df0e474d2ffb64efc9eb0b79934d531fd5b4600d61f3caa979f14cd5aaa612e"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -833,6 +833,14 @@ describe("searchHybrid — BM25 + TF-IDF fusion path", () => {
         { ftsIndex: longIdx, embedFile: path.join(longRoot, "nonexistent.embed.db") }
       );
       expect(recalled.matches.map((hit) => hit.path).sort()).toEqual(["Alpha.md", "Bravo.md"]);
+      // The result alone does not prove the RELAXATION produced it — TF-IDF at a
+      // lowered floor could have. `bm25` in the signals proves the any-term pass
+      // ran, which is the branch under test.
+      expect(recalled.signals_used).toContain("bm25");
+      // A note is one candidate however many chunks matched. RRF fuses on the
+      // id, so emitting a note once per chunk would count it several times and
+      // let length alone outrank a shorter, better note.
+      expect(new Set(recalled.matches.map((hit) => hit.path)).size).toBe(recalled.matches.length);
     } finally {
       await longIdx.closeAndRelease();
       await fs.rm(longRoot, { recursive: true, force: true });

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -793,6 +793,51 @@ describe("searchHybrid — BM25 + TF-IDF fusion path", () => {
     expect(result.matches.length).toBeGreaterThan(0);
     expect(result.matches.every((m) => m.path.startsWith("Cooking/"))).toBe(true);
 
+    // ── SBS-D1: the relaxation runs only when nothing ranked ──
+    // NO-OP control. "OAuth carbonara" has no chunk holding both terms, so BM25
+    // finds nothing — but these notes are short, so TF-IDF clears its floor and
+    // the strict pass DOES produce candidates. The fallback must therefore stay
+    // dormant, and the proof is that `bm25` is absent from the signals: had the
+    // any-term pass run, both notes match it and bm25 would be listed.
+    const noopResult = await searchHybrid(
+      new Vault(ftsRoot),
+      { query: "OAuth carbonara", limit: 5 },
+      { ftsIndex: idx, embedFile: path.join(ftsRoot, "nonexistent.embed.db") }
+    );
+    expect(noopResult.matches.length).toBeGreaterThan(0);
+    expect(noopResult.signals_used).toContain("tfidf");
+    expect(noopResult.signals_used).not.toContain("bm25");
+
+    // RECALL control. Same question shape, but in notes long enough that the
+    // TF-IDF floor also rejects the partial matches. Now every strict signal is
+    // empty, the fallback engages, and the question is answered instead of
+    // returning nothing.
+    const longRoot = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-sbs-d1-"));
+    const longVault = new Vault(longRoot);
+    await longVault.ensureExists();
+    const filler = Array.from({ length: 5000 }, (_, index) => `qq${index.toString(36)}`).join(" ");
+    await fs.writeFile(path.join(longRoot, "Alpha.md"), `alpha appears here. ${filler}\n`);
+    await fs.writeFile(path.join(longRoot, "Bravo.md"), `bravo appears here. ${filler}2\n`);
+    const longIdx = new FtsIndex({ file: defaultIndexFile(longRoot), vaultRoot: longRoot });
+    await longIdx.open();
+    try {
+      for (const entry of await longVault.listMarkdown()) {
+        const note = await longVault.readNote(entry.absPath, entry.mtimeMs);
+        longIdx.reindexFile(entry.relPath, entry.mtimeMs, note.content, [], note.parsed.tags);
+      }
+      // POSITIVE control: the strict conjunction really is empty here.
+      expect(longIdx.search("alpha bravo", { limit: 10 })).toEqual([]);
+      const recalled = await searchHybrid(
+        longVault,
+        { query: "alpha bravo", limit: 5 },
+        { ftsIndex: longIdx, embedFile: path.join(longRoot, "nonexistent.embed.db") }
+      );
+      expect(recalled.matches.map((hit) => hit.path).sort()).toEqual(["Alpha.md", "Bravo.md"]);
+    } finally {
+      await longIdx.closeAndRelease();
+      await fs.rm(longRoot, { recursive: true, force: true });
+    }
+
     // AH-1 receipt controls stay in this established BM25-route test so the
     // causal coverage does not add another test registration.
     {


### PR DESCRIPTION
## The failure this removes

Every ranker asks a **strict** question:

- BM25 requires all terms inside **one chunk**
- TF-IDF requires a cosine above **0.05**

Both are good defaults and bad last words. A question whose words are all in the vault — just not together in one chunk, and not concentrated enough in a long note — returns **nothing**. The note is there, the words are there, and the tool reports no matches with no error.

#573 and #574 pinned both halves of that mechanism. This answers it.

## Gated on total emptiness — a provable no-op

The relaxation runs **only when the strict pass produced no candidate in any signal**. BM25 re-asks with an explicit `OR`; TF-IDF re-asks without its floor.

If anything ranked, none of it executes — so **no existing result can be reordered**. That is why this lands without an eval sweep: the guarantee is *structural*, not measured, which is stronger than a benchmark this repository cannot run in CI anyway.

`anyFts5Query` leaves `safeFts5Query`'s protection intact: a user's literal `OR` is still quoted so they can search for the word. Only the separators this function inserts are operators.

## The load-bearing test is the no-op control

| control | fixture | expectation |
|---|---|---|
| **no-op** | `OAuth carbonara`, short notes | BM25 empty, TF-IDF clears its floor → strict pass is non-empty → fallback stays dormant. Proof: `bm25` is **absent** from `signals_used` — had the any-term pass run, both notes match it and it would be listed. |
| **recall** | same question, ~5000-token notes | floor also rejects the partial matches → every strict signal empty → both notes returned instead of nothing |

A positive control asserts the strict conjunction really is empty in the recall fixture, so that test cannot pass for the wrong reason.

## Deliberately not included

A marker distinguishing a relaxed hit from a strict one. It changes the response shape and therefore `docs/api.md`, which #569 is currently holding — and a hit found only by relaxation is weaker evidence an agent should be able to see. It follows once that branch lands.

**Test count unchanged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)