### PR TITLE
feat: make a camelCase identifier reachable by the words it is spelled from

### DIFF
--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -93,6 +93,13 @@ const MAX_FTS_LINK_OCCURRENCES = 4096;
 const MAX_FTS_LINK_TARGETS = 256;
 const MAX_FTS_LINK_TARGET_BYTES = 1024;
 const MAX_FTS_LINK_BYTES = 32 * 1024;
+// Identifier parts are bounded like every other synthetic metadata blob: a
+// generated file full of compound names must not be able to grow one chunk's
+// indexed text without limit.
+const MAX_FTS_IDENTIFIER_OCCURRENCES = 8192;
+const MAX_FTS_IDENTIFIER_PARTS = 512;
+const MAX_FTS_IDENTIFIER_PART_BYTES = 64;
+const MAX_FTS_IDENTIFIER_BYTES = 16 * 1024;
 const MAX_FTS_TAG_OCCURRENCES = 1024;
 const MAX_FTS_TAGS = 128;
 const MAX_FTS_TAG_BYTES = 256;
@@ -163,6 +170,50 @@ export function extractAliases(frontmatter: Record<string, unknown> | undefined 
  * stripped (the note's canonical Obsidian identity). Populates the weighted
  * FTS5 `title` column. (v3.11.6-rc.6.)
  */
+/**
+ * Split the compound identifiers in `text` into the words they are spelled from.
+ *
+ * The FTS5 tokenizer breaks on underscores but never on case, so
+ * `liquidity_pool_day` is indexed as three findable words while `poolDayData`
+ * stays one opaque token. A reader who asks for "pool day data" reaches the
+ * first note and not the second, even though both name the same thing — and the
+ * words are right there in the identifier.
+ *
+ * Only compound spellings are split. An ordinary lowercase word has no internal
+ * boundary to find, so nothing is emitted for it: the output is additional
+ * recall for identifiers, not a second copy of the prose.
+ *
+ * Parts shorter than two characters are dropped — a lone `s` or `x` from a name
+ * like `xPos` is noise in an inverted index, and matching it would surface every
+ * note containing any such fragment.
+ *
+ * @param text - Note text to scan.
+ * @returns Deduplicated lowercase parts, in first-seen order.
+ * @example
+ * ```ts
+ * splitIdentifierTokens("poolDayData and volumeUSD");
+ * // ["pool", "day", "data", "volume", "usd"]
+ * ```
+ */
+export function splitIdentifierTokens(text: string): string[] {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  // Only CASE boundaries are worth emitting. The tokenizer already splits on
+  // `_`, `-` and `.`, so a snake_case or dotted name is findable by its parts
+  // without help; repeating them here would add nothing but IDF noise.
+  for (const match of text.matchAll(/[\p{L}\p{N}]+/gu)) {
+    const segments = match[0].split(/(?<=\p{Ll})(?=\p{Lu})/gu);
+    if (segments.length < 2) continue;
+    for (const segment of segments) {
+      const part = segment.toLowerCase();
+      if (part.length < 2 || seen.has(part)) continue;
+      seen.add(part);
+      parts.push(part);
+    }
+  }
+  return parts;
+}
+
 export function deriveFtsTitle(relPath: string): string {
   const title = path.basename(relPath).replace(/\.md$/i, "");
   return title.length > MAX_FTS_TITLE_LEN ? title.slice(0, MAX_FTS_TITLE_LEN) : title;
@@ -179,6 +230,13 @@ export function deriveFtsTitle(relPath: string): string {
 // title/alias match outranks a body-only mention. title/aliases are stored
 // ONLY on chunk 0 of each note (not every chunk) to avoid one note's
 // title-match flooding the BM25 candidate set. Schema bump auto-rebuilds.
+// v7 (SBS-D2) enriches `content` on chunk 0 with an `[identifier_parts: …]`
+// meta-line: the words a compound identifier is spelled from. The tokenizer
+// splits on `_`/`-`/`.` but never on case, so `poolDayData` was one opaque
+// token no reader could reach by the words it is made of. The schema SHAPE is
+// unchanged — only the indexed text is richer — but the bump is still required,
+// because an index built before it silently lacks the recall and would answer
+// differently from a fresh one. Schema bump auto-rebuilds.
 // v6 (v3.12.0-rc.18) added the INDEXED `scope_tokens` column (col 3).
 // Collision-free encoded path tokens let FTS5 prune replacement
 // deletes and folder-scoped searches inside its inverted index instead of
@@ -2302,6 +2360,13 @@ export class FtsIndex {
       maxItemBytes: MAX_FTS_LINK_TARGET_BYTES,
       maxTotalBytes: MAX_FTS_LINK_BYTES
     });
+    const admittedIdentifierParts = admitFtsMetadata(splitIdentifierTokens(content), {
+      label: "identifierParts",
+      maxOccurrences: MAX_FTS_IDENTIFIER_OCCURRENCES,
+      maxUnique: MAX_FTS_IDENTIFIER_PARTS,
+      maxItemBytes: MAX_FTS_IDENTIFIER_PART_BYTES,
+      maxTotalBytes: MAX_FTS_IDENTIFIER_BYTES
+    });
     const admittedTags = admitFtsMetadata(tags, {
       label: "tags",
       maxOccurrences: MAX_FTS_TAG_OCCURRENCES,
@@ -2338,7 +2403,17 @@ export class FtsIndex {
         const breadcrumbPrefix = c.breadcrumb ? `[section: ${c.breadcrumb}]\n` : "";
         const linksSuffix =
           i === 0 && admittedLinkTargets.length ? `\n[wikilink_targets: ${admittedLinkTargets.join(", ")}]` : "";
-        const enriched = `${breadcrumbPrefix}${c.text}${linksSuffix}`;
+        // v7 — the words a compound identifier is spelled from, on chunk 0 only,
+        // for the same reason the title lives there: one note's identifiers must
+        // not score all of its chunks and crowd other notes out of the candidate
+        // set. They ride in `content` at weight 1 rather than in a column of
+        // their own, so an identifier-part match is ordinary body-strength
+        // evidence — weaker than a title match, which is what it is.
+        const identifierSuffix =
+          i === 0 && admittedIdentifierParts.length
+            ? `\n[identifier_parts: ${admittedIdentifierParts.join(", ")}]`
+            : "";
+        const enriched = `${breadcrumbPrefix}${c.text}${linksSuffix}${identifierSuffix}`;
         // v3.11.6-rc.6 re-sweep fix: store title/aliases ONLY on chunk 0, not
         // every chunk. Repeating them per-chunk made a title/alias-matching query
         // score ALL of a note's chunks high (10×/5× weight) — a single large note

--- a/src/schema-contract.ts
+++ b/src/schema-contract.ts
@@ -4,7 +4,7 @@
 // coordinate implementation modules but are not a public package subpath.
 
 /** Current on-disk FTS5 schema version. */
-export const FTS_SCHEMA_VERSION = 6;
+export const FTS_SCHEMA_VERSION = 7;
 
 /** Current on-disk embedding database schema version. */
 export const EMBED_DB_SCHEMA_VERSION = 5;

--- a/tests/fts5.test.ts
+++ b/tests/fts5.test.ts
@@ -1738,6 +1738,26 @@ describe("FtsIndex — full lifecycle", () => {
       const apolloHits = idx.search("Apollo");
       expect(apolloHits.length).toBe(1);
       expect(apolloHits[0]?.rel_path).toBe("daily.md");
+
+      // SBS-D2 — the same meta-line device, for the words a compound identifier
+      // is spelled from. The tokenizer splits on `_` but never on case, so the
+      // snake_case name was already reachable by its parts and the camelCase one
+      // was not, though both name the same thing.
+      idx.reindexFile("camel.md", 1000, "Aggregate poolDayData for the window.");
+      idx.reindexFile("snake.md", 1000, "Aggregate liquidity_pool_day for the window.");
+
+      // POSITIVE control: the whole identifier is still findable as written.
+      expect(idx.search("poolDayData").map((hit) => hit.rel_path)).toEqual(["camel.md"]);
+      // POSITIVE control: the snake_case twin still splits, as it always did.
+      expect(idx.search("pool day").map((hit) => hit.rel_path)).toContain("snake.md");
+      // The change: the camelCase note is now reachable by its words too.
+      expect(idx.search("pool day data").map((hit) => hit.rel_path)).toContain("camel.md");
+
+      // NEGATIVE control: ordinary prose has no case boundary to split, so no
+      // synthetic parts are invented for it — the meta-line adds identifier
+      // recall, not a second copy of the body.
+      idx.reindexFile("prose.md", 1000, "Aggregate the window carefully.\n");
+      expect(idx.search("identifier_parts").map((hit) => hit.rel_path)).not.toContain("prose.md");
     } finally {
       await idx.closeAndRelease();
     }

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -1013,8 +1013,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
     "f6ba8edabb8d41b9fbc08254ada72afc4de06a322da94f97a9cb9986e010501e"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
-  ["FTS route slug normalization", "4c85c74d066bfaf4b0177ad8da61b867bc62ae819b9e5b98becb13d8fbf80028"],
-  ["FTS shadow schema fixture extension", "4126dfbeab9070f30db8b4c1ff125d53bd417558b83755adff0511b63c4a4242"],
+  ["FTS route slug normalization", "bb1606e40daf22780843fa5d512dfe352ec56f4e87150229d1ee5b30e47ad689"],
+  ["FTS shadow schema fixture extension", "483328f7ce7a5cea7a00fa1d45d013d356274b9b79334d0c65eaa82bfb8431c9"],
   [
     "watcher existence-guard whitespace normalization",
     "2e02b86949da126f4b7df90da07e0f01b4a1f40628ae8223f6e401ee10d7af24"


### PR DESCRIPTION
## Two names for the same thing, opposite retrievability

The FTS5 tokenizer breaks on `_`, `-` and `.` — but never on case:

| in a note | reachable by "pool day data" |
|---|---|
| `liquidity_pool_day` | ✅ always was |
| `poolDayData` | ✕ one opaque token |

Nothing in the note explains why. Chunk 0 now carries an `[identifier_parts: …]` meta-line — the same device the index already uses for wikilink targets — holding the words each compound identifier is spelled from.

## Only case boundaries

```
poolDayData        → pool, day, data
volumeUSD          → volume, usd
getUserByEmail     → get, user, by, email
liquidity_pool_day → (nothing — the tokenizer already splits it)
ordinary words     → (nothing)
Ликвидность пула   → (nothing)
```

A snake_case or dotted name is split already, so repeating its parts would add IDF noise and no recall. Ordinary prose has no boundary to find: this is extra reach for **identifiers**, not a second copy of the body. Parts under two characters are dropped — a lone `x` from `xPos` would match everywhere and mean nothing.

## Placement is the ranking decision

Parts ride in `content` at **weight 1**, not in a column of their own, so an identifier-part match is ordinary body-strength evidence — weaker than a title match, which is what it is.

**Chunk 0 only**, for the same reason the title lives there: one note's identifiers must not score all of its chunks and crowd other notes out of the candidate set (the rc.6 lesson).

Bounded like every other synthetic blob, so a generated file full of compound names cannot grow one chunk's indexed text without limit.

## Schema bump

The schema *shape* is unchanged — only the indexed text is richer. The bump is still required: an index built before this silently lacks the recall and would answer differently from a fresh one. The existing migration test walks every version below the current one, so v6 is covered the moment the constant moves.

Controls: the whole identifier is still findable as written; the snake_case twin still splits as it always did; ordinary prose produces no synthetic parts.

**Test count unchanged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)