### PR TITLE
fix: give the question scan back an aggregate time ceiling

### DIFF
--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -802,6 +802,18 @@ export interface OpenQuestionAdmissionLimits {
   maxWorkerBatchUtf8Bytes: number;
   /** Maximum serialized UTF-8 bytes retained in the exact top-K result heap. */
   maxResultUtf8Bytes: number;
+  /**
+   * Maximum aggregate wall time, across the whole request, spent on regex-worker
+   * overhead — thread startup and teardown — as opposed to matching.
+   *
+   * v4 AUD-1. Charging that overhead to the ReDoS budget was wrong (it rejected
+   * legitimate patterns on large vaults for a reason that had nothing to do with
+   * the pattern), but simply not charging it left the request with NO aggregate
+   * ceiling at all: the per-worker startup bound is per worker, and a vault with
+   * many batches multiplies it. This is the aggregate the matching budget stopped
+   * being.
+   */
+  maxWorkerOverheadMs: number;
 }
 
 /**
@@ -824,7 +836,8 @@ export const DEFAULT_OPEN_QUESTION_ADMISSION_LIMITS: Readonly<OpenQuestionAdmiss
   maxCandidateUtf8Bytes: 256 * 1024 * 1024,
   maxWorkerBatchCandidates: 1024,
   maxWorkerBatchUtf8Bytes: 2 * 1024 * 1024,
-  maxResultUtf8Bytes: 8 * 1024 * 1024
+  maxResultUtf8Bytes: 8 * 1024 * 1024,
+  maxWorkerOverheadMs: 30_000
 });
 
 /**
@@ -1734,6 +1747,11 @@ function normalizeOpenQuestionLimits(
       overrides?.maxResultUtf8Bytes,
       d.maxResultUtf8Bytes,
       "maxResultUtf8Bytes"
+    ),
+    maxWorkerOverheadMs: narrowOpenQuestionLimit(
+      overrides?.maxWorkerOverheadMs,
+      d.maxWorkerOverheadMs,
+      "maxWorkerOverheadMs"
     )
   };
 }
@@ -2008,6 +2026,7 @@ export async function getOpenQuestions(
   // own matching time; wall time is only the fallback when a caller-injected
   // matcher does not report one.
   let matchingRemainingMs = args.pattern === undefined ? 0 : scanBudgetMs;
+  let overheadRemainingMs = limits.maxWorkerOverheadMs;
   const heap: RankedOpenQuestion[] = [];
   let retainedResultBytes = 0;
   let sequence = 0;
@@ -2045,6 +2064,13 @@ export async function getOpenQuestions(
         "(likely catastrophic backtracking / ReDoS). Simplify the pattern or omit it to use the safe default."
     );
 
+  const overheadExhausted = (): Error =>
+    new Error(
+      `obsidian_open_questions: scan abandoned — regex-worker startup and teardown exceeded the ` +
+        `${limits.maxWorkerOverheadMs}ms aggregate budget for one request. This is a scan-cost limit, ` +
+        "NOT a pattern problem: narrow the search with `folder`, or omit `pattern` to use the safe default."
+    );
+
   const flushCandidateBatch = async (): Promise<void> => {
     if (batch.length === 0 || args.pattern === undefined) return;
     if (matchingRemainingMs < 1) throw matchingTimeout();
@@ -2054,7 +2080,17 @@ export async function getOpenQuestions(
     const rawMatches = await matchBatch(args.pattern, batchLines, Math.min(scanBudgetMs, matchingRemainingMs), (ms) => {
       reportedMatchingMs = ms;
     });
-    matchingRemainingMs -= reportedMatchingMs ?? Date.now() - matchingStartedMs;
+    const wallMs = Date.now() - matchingStartedMs;
+    matchingRemainingMs -= reportedMatchingMs ?? wallMs;
+    // AUD-1 — the time that was NOT matching still has to be bounded somewhere.
+    // Keeping it out of the ReDoS budget was right; leaving it unbounded was not,
+    // because the per-worker startup limit is per worker and a vault with many
+    // batches multiplies it. The two failures stay distinct: this one says the
+    // scan cost too much, not that the pattern is catastrophic.
+    if (reportedMatchingMs !== undefined) {
+      overheadRemainingMs -= Math.max(0, wallMs - reportedMatchingMs);
+      if (overheadRemainingMs < 0) throw overheadExhausted();
+    }
     for (const match of validateOpenQuestionMatches(rawMatches, batch.length)) {
       const candidate = batch[match.idx];
       if (!candidate) throw new Error("obsidian_open_questions: regex worker returned an invalid match index");

--- a/tests/open-questions-admission.test.ts
+++ b/tests/open-questions-admission.test.ts
@@ -131,6 +131,87 @@ describe("getOpenQuestions bounded producer admission", () => {
     } finally {
       read.mockRestore();
     }
+
+    // ── AUD-1: the time that is NOT matching still has an aggregate ceiling ──
+    // Keeping worker startup out of the ReDoS budget was right — it rejected
+    // legitimate patterns on large vaults for a reason that had nothing to do
+    // with the pattern. But it left the request with no aggregate clock at all:
+    // the startup bound is per WORKER, and a vault with many batches multiplies
+    // it. A matcher that burns wall time while reporting no matching time is
+    // exactly that shape.
+    const burnWallReportNoMatching = async (
+      pattern: string,
+      lines: readonly string[],
+      _budgetMs: number,
+      onMatchingMs?: (ms: number) => void
+    ): Promise<{ idx: number; q: string }[]> => {
+      const until = Date.now() + 5;
+      while (Date.now() < until) {
+        /* occupy wall time the way thread startup does */
+      }
+      onMatchingMs?.(0);
+      const regex = new RegExp(pattern, "i");
+      return lines.flatMap((line, idx) => {
+        const match = regex.exec(line);
+        return match?.[1] === undefined ? [] : [{ idx, q: match[1] }];
+      });
+    };
+
+    await expect(
+      getOpenQuestions(
+        vault,
+        { pattern: "^Q: (.+)$", scanBudgetMs: 1000 },
+        {
+          limits: { maxWorkerBatchCandidates: 1, maxWorkerBatchUtf8Bytes: 32, maxWorkerOverheadMs: 1 },
+          matchBatch: burnWallReportNoMatching
+        }
+      )
+    ).rejects.toThrow(/aggregate budget for one request/);
+
+    // The two failures stay distinct. Reporting scan cost as catastrophic
+    // backtracking is what sends the next reader hunting a pattern bug that does
+    // not exist, so the message is asserted, not just the rejection.
+    const scanCostError = await getOpenQuestions(
+      vault,
+      { pattern: "^Q: (.+)$", scanBudgetMs: 1000 },
+      {
+        limits: { maxWorkerBatchCandidates: 1, maxWorkerBatchUtf8Bytes: 32, maxWorkerOverheadMs: 1 },
+        matchBatch: burnWallReportNoMatching
+      }
+    ).catch((error: unknown) => (error instanceof Error ? error.message : String(error)));
+    expect(scanCostError).toContain("scan-cost limit");
+    expect(scanCostError).not.toContain("catastrophic backtracking");
+
+    // NEGATIVE control: a matcher that reports its wall time AS matching charges
+    // the ReDoS budget instead and never touches the overhead ceiling, so the
+    // same tiny overhead budget does not trip.
+    const reportAllAsMatching = async (
+      pattern: string,
+      lines: readonly string[],
+      _budgetMs: number,
+      onMatchingMs?: (ms: number) => void
+    ): Promise<{ idx: number; q: string }[]> => {
+      const started = Date.now();
+      const until = started + 5;
+      while (Date.now() < until) {
+        /* same cost, attributed differently */
+      }
+      onMatchingMs?.(Date.now() - started);
+      const regex = new RegExp(pattern, "i");
+      return lines.flatMap((line, idx) => {
+        const match = regex.exec(line);
+        return match?.[1] === undefined ? [] : [{ idx, q: match[1] }];
+      });
+    };
+    const attributed = await getOpenQuestions(
+      vault,
+      { pattern: "^Q: (.+)$", scanBudgetMs: 1000 },
+      {
+        limits: { maxWorkerBatchCandidates: 1, maxWorkerBatchUtf8Bytes: 32, maxWorkerOverheadMs: 1 },
+        matchBatch: reportAllAsMatching
+      }
+    );
+    expect(attributed.map((question) => question.question)).toEqual(["one", "two", "three", "four", "five"]);
   });
 
   it("rejects an invalid batch result instead of trusting an amplified worker payload", async () => {


### PR DESCRIPTION
## What #570 got right, and what it did not

Splitting worker startup out of the ReDoS budget was right: billing thread overhead to a *pattern* budget rejected legitimate patterns on large vaults and named the wrong cause.

But that commit claimed the split was **strictly better**, and it was not. `matchingRemainingMs` was the only aggregate clock in `getOpenQuestions`. After the split it is decremented solely by the worker's self-reported matching time — so nothing bounded the request as a whole. `MAX_QUESTION_WORKER_SPAWN_MS` is per **worker**, and a vault with many batches multiplies it.

Found by audit, on merged code.

## The fix keeps the distinction that motivated the split

Overhead now has its own aggregate budget for the whole request, charged with exactly the time that was not matching:

| failure | message says | points at |
|---|---|---|
| pattern | catastrophic backtracking / ReDoS | the pattern |
| scan cost | scan-cost limit, **not** a pattern problem | `folder`, or omitting `pattern` |

The test asserts the **message**, not just the rejection — reporting scan cost as backtracking is precisely what sends the next reader hunting a bug that does not exist.

## The negative control is the load-bearing one

A matcher that reports its wall time **as matching** charges the ReDoS budget instead and completes under the same 1 ms overhead ceiling. That proves the accounting *distinguishes* the two rather than double-charging — which a test that only checked the rejection could not show.

**Test count unchanged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)