### PR TITLE
test: make four audit-flagged assertions actually discriminate

### DIFF
--- a/tests/dql.test.ts
+++ b/tests/dql.test.ts
@@ -328,19 +328,34 @@ describe("listTags", () => {
     const priority = shape.find((entry) => entry.key === "priority");
     expect(priority?.types).toEqual(["number"]);
     expect(priority?.count).toBe(2);
-    // NEGATIVE control: a key nothing declares is absent rather than reported empty.
-    expect(shape.find((entry) => entry.key === "zzz_absent_key")).toBeUndefined();
+    // The map is built only from keys that occur, so asserting an invented key is
+    // absent cannot fail. What CAN fail is the folding contract: `Status` and
+    // `status` are distinct YAML keys and must be reported as one, counted once
+    // for the note that carries them.
+    expect(shape.map((entry) => entry.key)).toEqual(shape.map((entry) => entry.key.toLowerCase()));
+    expect(shape.filter((entry) => entry.key === "status")).toHaveLength(1);
 
-    // min_count filters the same way it does for tags.
+    // `min_count` is INCLUSIVE. `every(count >= 2)` holds for an exclusive filter
+    // too, so it is the retained key that discriminates: priority occurs in
+    // exactly two notes and must survive a threshold of two.
     const frequent = await vaultShape(v, { min_count: 2 });
     expect(frequent.every((entry) => entry.count >= 2)).toBe(true);
+    expect(frequent.map((entry) => entry.key)).toContain("priority");
+    expect(await vaultShape(v, { min_count: 3 }).then((r) => r.map((e) => e.key))).not.toContain("priority");
 
     // The walk refuses rather than reporting a prefix — an inventory that
     // silently omits keys cannot be told apart from one that found them all.
+    // The fake supplies ENTRIES so `reads === 0` proves the guard ran: with an
+    // empty listing the counter would stay at zero whether the guard existed or
+    // not, and the control would pass on a build that had lost it.
     let reads = 0;
     const truncated = {
       ensureExists: async () => undefined,
-      listFilesByExtensionsBounded: async () => ({ entries: [], visitedEntries: 4, complete: false }),
+      listFilesByExtensionsBounded: async () => ({
+        entries: [{ absPath: "/x/a.md", relPath: "a.md", basename: "a.md", mtimeMs: 1, size: 1 }],
+        visitedEntries: 4,
+        complete: false
+      }),
       readNoteUncached: async () => {
         reads += 1;
         throw new Error("unreachable");

--- a/tests/embed-db.test.ts
+++ b/tests/embed-db.test.ts
@@ -2758,9 +2758,13 @@ describe("EmbedDb", () => {
     // oversized authority cell; it never selects the full hostile value.
     await expectRefusalToPreserve(/ownership could not be verified/);
 
-    // POSITIVE controls: genuine v1-v3 EmbedDb signatures with the exact
-    // root are supported legacy provenance. v1 still rebuilds (no `kind`
-    // column). v2/v3 already match the current vector table and keep rows.
+    // POSITIVE controls: genuine v1-v3 EmbedDb signatures with the exact root
+    // are supported legacy provenance, and ALL THREE rebuild. Schemas 2 and 3
+    // predate the q8 inference pin, so their vectors came from a different
+    // model space and cannot be kept — which is what the loop below asserts.
+    // The claim that v2/v3 "keep rows" was left here when the assertion was
+    // corrected, and a comment that contradicts the assertion under it is worse
+    // than no comment: it is the version a reader believes.
     for (const legacyVersion of [1, 2, 3]) {
       const legacyFile = path.join(dir, `legacy-v${legacyVersion}.embed.db`);
       const legacy = new Database(legacyFile);

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -1005,12 +1005,12 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["ReDoS catastrophic control transform", "99358421ccbe92052218efb7bcf19e31029854d36548144c4a1ac4d68ec5540b"],
   [
     "Embed synchronous admission label normalization",
-    "623312085a78aa69f7cd644172abe50de56170ff4fea342f2ee20b484b707014"
+    "5fa57cb72127d04836993c1aef085fe5fcef7711c26c19d31eb7e29413a14c43"
   ],
-  ["Embed sidecar route label normalization", "7548fe98aa981167ad89338bc3334f532ba60c77568320c0acb5b5643818da5f"],
+  ["Embed sidecar route label normalization", "551f82b8dc6391f8bfac8071489b9335dc5ff41caec2ce95a2ba6d5b3a98c3c2"],
   [
     "Embed malformed-generation value normalization",
-    "f6ba8edabb8d41b9fbc08254ada72afc4de06a322da94f97a9cb9986e010501e"
+    "9732de69cabfbd9387cdee9ffe7c04e78c19a55530c1a2fb7a50b9a007fda2ad"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
   ["FTS route slug normalization", "c0dbf81c1721fcca167ef89d58fbbacc2bd748eb461f970ede635f23445c4c92"],

--- a/tests/redos-guard.test.ts
+++ b/tests/redos-guard.test.ts
@@ -240,7 +240,14 @@ describe("matchLinesBounded — hard ReDoS sink-bound (v3.10.0-rc.39)", () => {
     // catastrophic backtracking.
     expect(reported).toBeTypeOf("number");
     expect(reported).toBeGreaterThanOrEqual(0);
+    // `wallMs` is taken after the await resolves, so it already contains startup
+    // and teardown; comparing against it only shows the reported number is not
+    // the LARGEST possible one. The property that matters is absolute: matching
+    // three trivial lines is single-digit milliseconds, while spawning and
+    // joining a thread is not, so a duration that still tracked wall time cannot
+    // satisfy this bound on any machine slow enough to matter.
     expect(reported ?? Number.POSITIVE_INFINITY).toBeLessThan(Math.max(wallMs, 1));
+    expect(reported ?? Number.POSITIVE_INFINITY).toBeLessThan(50);
   });
 
   it("REJECTS within the budget a pattern isCatastrophicRegex MISSES (the rc.36 residual)", async () => {

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -719,9 +719,15 @@ describe("searchHybrid — BM25 + TF-IDF fusion path", () => {
       expect(probeIdx.search("pooldaydata", { limit: 10 }).map((hit) => hit.rel_path)).toEqual(["Camel.md"]);
       // POSITIVE control: the snake_case twin DOES split into its parts.
       expect(probeIdx.search("pool day", { limit: 10 }).map((hit) => hit.rel_path)).toEqual(["Snake.md"]);
-      // Characterization: spelling the camelCase identifier as words finds
-      // only the snake_case note — never the camelCase one.
-      expect(probeIdx.search("pool day data", { limit: 10 }).map((hit) => hit.rel_path)).not.toContain("Camel.md");
+      // Characterization: the full spelling reaches NEITHER note, and the two
+      // reasons are different. `Camel.md` is unreachable because the tokenizer
+      // never splits on case; `Snake.md` is unreachable because it has no `data`
+      // token and FTS5 joins the terms with an implicit AND. Asserting the empty
+      // result states both — an earlier `not.toContain("Camel.md")` here was
+      // satisfied by the emptiness alone and said nothing about case splitting.
+      // The discriminating assertion is the `pool day` one above: if camelCase
+      // split, `Camel.md` would appear there too.
+      expect(probeIdx.search("pool day data", { limit: 10 })).toEqual([]);
     } finally {
       await probeIdx.closeAndRelease();
       await fs.rm(probeRoot, { recursive: true, force: true });


### PR DESCRIPTION
Four places where a control passes for a reason other than the one its comment claims. Found by audit, all on merged code.

| where | why it could not fail | now |
|---|---|---|
| `search-hybrid` camelCase phase | `not.toContain("Camel.md")` ran on a query whose conjunction matches **nothing** — `Snake.md` has no `data` token — so emptiness satisfied it | asserts the empty result and names both reasons; the discriminating check was always the `pool day` line above |
| `embed-db` comment | said v2/v3 "keep rows" directly above a loop asserting **all three** rebuild | corrected, with why the contradiction matters |
| `dql` / `vaultShape` ×3 | an invented key cannot appear (the map is built only from keys that occur); `every(count >= 2)` holds for an exclusive filter too; the truncated-walk fake supplied **zero entries**, so `reads === 0` held with or without the guard | folding contract asserted instead; the retained key pinned; the fake now supplies an entry |
| `redos-guard` timing | compared against a wall time measured **after teardown**, showing only that the number is not the largest possible one | absolute bound added |

## The class

A control that checks the **outcome** rather than the **mechanism** passes for whichever mechanism happens to run. The `dql` truncated-walk case is the sharpest: it would have gone green on a build that had lost the guard entirely.

Comments get the same treatment as assertions here, because a comment that contradicts the assertion under it is worse than no comment — it is the version a reader believes.

**Test count unchanged.** Three reviewed-transform owner hashes move with the `embed-db` edit, each recomputed with a positive control against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)