### PR TITLE
fix: count notes once, refuse partial inventories, and stop a folder shadowing its note

### DIFF
--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -966,6 +966,12 @@ export async function listTags(
   for (const e of listing.entries) {
     const { parsed } = await vault.readNoteUncached(e.absPath, e.mtimeMs);
     const fmSet = new Set(extractFrontmatterTagsLower(parsed.frontmatter));
+    // `count` is notes, not spellings. collectTags dedupes case-SENSITIVELY, so one
+    // note writing `tags: [Reading]` and `#reading` in its body arrives here as two
+    // entries that fold to one key — without this guard that note is counted twice,
+    // and `frontmatter_count`/`inline_count` can both be incremented for it. Same
+    // shape as the per-note guard vaultShape carries.
+    const countedInThisNote = new Set<string>();
     for (const t of parsed.tags) {
       const key = foldTag(t); // v3.11.0-rc.9 (L-TAG-1) — NFC+case fold so accented tag forms count as one
       let slot = counts.get(key);
@@ -980,9 +986,12 @@ export async function listTags(
         tagKeyUtf8Bytes += keyBytes;
         slot = { count: 0, fm: 0, inline: 0 };
       }
-      slot.count += 1;
-      if (fmSet.has(key)) slot.fm += 1;
-      else slot.inline += 1;
+      if (!countedInThisNote.has(key)) {
+        countedInThisNote.add(key);
+        slot.count += 1;
+        if (fmSet.has(key)) slot.fm += 1;
+        else slot.inline += 1;
+      }
       counts.set(key, slot);
     }
   }
@@ -1160,7 +1169,19 @@ export async function vaultShape(
     out.push({ key, count: slot.count, types: [...slot.types].sort(), examples: slot.examples });
   }
   out.sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
-  return out.slice(0, limit);
+  // The tool is sold as an inventory: "exhaustive within its scan bounds, and it
+  // refuses rather than returning a partial inventory". Slicing here breaks that
+  // silently, and in the worst direction — the sort is by descending count, so what
+  // a prefix drops is exactly the rare keys someone calls this tool to discover.
+  // The caller then cannot tell "no note uses that key" from "it fell off the end".
+  // Refuse, and say which knob widens the answer, matching every other guard here.
+  if (out.length > limit) {
+    throw new RangeError(
+      `vaultShape found ${out.length} distinct frontmatter keys, more than the ${limit}-key result cap. ` +
+        "Raise `limit` (max 2000), narrow `folder`, or raise `min_count` to drop rare keys deliberately."
+    );
+  }
+  return out;
 }
 
 // ─── obsidian_chat_thread (v2.2.0 — note-tethered AI conversations) ─────────

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -1579,6 +1579,16 @@ export async function resolveTarget(
       const abs = vault.resolveInside(candidate);
       try {
         const stat = await vault.stat(abs);
+        // A directory stats successfully, and the bare candidate is tried first, so a
+        // folder `X` used to shadow the folder note `X.md` entirely: the second
+        // candidate was never reached and every caller got a FileEntry naming the
+        // directory. Read tools then returned an empty result for a note that exists.
+        // Skipping a non-file here lets `${path}.md` be tried, which is the whole
+        // point of having two candidates.
+        if (!stat.isFile) {
+          lastErr = new Error(`Not a file: ${candidate}`);
+          continue;
+        }
         return {
           absPath: abs,
           relPath: vault.toRel(abs),

--- a/tests/dql.test.ts
+++ b/tests/dql.test.ts
@@ -308,6 +308,20 @@ describe("listTags", () => {
     expect(projectTag?.count).toBe(2);
     expect(projectTag?.frontmatter_count).toBe(2);
     expect(tags.find((t) => t.tag === "idea")?.count).toBe(1);
+
+    // `count` is notes, not spellings. collectTags dedupes case-SENSITIVELY, so one
+    // note carrying `tags: [Reading]` AND `#reading` arrives as two entries that fold
+    // to one key. Its own vault, because adding this note to the shared fixture would
+    // move every count asserted above.
+    const caseRoot = await fs.mkdtemp(path.join(os.tmpdir(), "obsidian-mcp-tagcase-"));
+    try {
+      await fs.writeFile(path.join(caseRoot, "n.md"), "---\ntags: [Reading]\n---\nAlso #reading here.\n");
+      const folded = (await listTags(new Vault(caseRoot), {})).find((tag) => tag.tag === "reading");
+      expect(folded?.count).toBe(1);
+      expect((folded?.frontmatter_count ?? 0) + (folded?.inline_count ?? 0)).toBe(1);
+    } finally {
+      await fs.rm(caseRoot, { recursive: true, force: true });
+    }
   });
 
   it("respects min_count", async () => {
@@ -328,12 +342,19 @@ describe("listTags", () => {
     const priority = shape.find((entry) => entry.key === "priority");
     expect(priority?.types).toEqual(["number"]);
     expect(priority?.count).toBe(2);
-    // The map is built only from keys that occur, so asserting an invented key is
-    // absent cannot fail. What CAN fail is the folding contract: `Status` and
-    // `status` are distinct YAML keys and must be reported as one, counted once
-    // for the note that carries them.
-    expect(shape.map((entry) => entry.key)).toEqual(shape.map((entry) => entry.key.toLowerCase()));
-    expect(shape.filter((entry) => entry.key === "status")).toHaveLength(1);
+    // The folding contract needs a fixture that can VIOLATE it: no note here writes
+    // an uppercase key, so "every reported key is lowercase" held for the same reason
+    // the invented-key check it replaced did — nothing could have made it fail. A
+    // vault whose one note carries both `Status` and `status` discriminates.
+    const foldRoot = await fs.mkdtemp(path.join(os.tmpdir(), "obsidian-mcp-keycase-"));
+    try {
+      await fs.writeFile(path.join(foldRoot, "n.md"), "---\nStatus: open\nstatus: open\n---\nBody.\n");
+      const folded = await vaultShape(new Vault(foldRoot), {});
+      expect(folded.map((entry) => entry.key)).toEqual(["status"]);
+      expect(folded[0]?.count).toBe(1);
+    } finally {
+      await fs.rm(foldRoot, { recursive: true, force: true });
+    }
 
     // `min_count` is INCLUSIVE. `every(count >= 2)` holds for an exclusive filter
     // too, so it is the retained key that discriminates: priority occurs in
@@ -363,6 +384,14 @@ describe("listTags", () => {
     } as unknown as Vault;
     await expect(vaultShape(truncated, {})).rejects.toThrow(/inventory is incomplete/);
     expect(reads).toBe(0);
+
+    // Same contract at the OTHER end. The tool is sold as exhaustive and the sort is
+    // by descending count, so a silent `slice` drops precisely the rare keys someone
+    // calls it to discover. `limit` at the key count returns everything; one below it
+    // must refuse rather than hand back a prefix that reads as the whole inventory.
+    const all = await vaultShape(v, {});
+    expect(await vaultShape(v, { limit: all.length })).toHaveLength(all.length);
+    await expect(vaultShape(v, { limit: all.length - 1 })).rejects.toThrow(/more than the .*-key result cap/);
   });
 
   it("admits the exact distinct-tag/key-byte boundary and rejects one less", async () => {
@@ -377,9 +406,15 @@ describe("listTags", () => {
 
   it("refuses an incomplete bounded inventory before reading any note", async () => {
     let reads = 0;
+    // Supplies an ENTRY, so `reads === 0` proves the guard ran ahead of the read loop.
+    // With an empty listing the counter stays at zero whether the guard exists or not.
     const fake = {
       ensureExists: async () => undefined,
-      listFilesByExtensionsBounded: async () => ({ entries: [], visitedEntries: 4, complete: false }),
+      listFilesByExtensionsBounded: async () => ({
+        entries: [{ absPath: "/x/a.md", relPath: "a.md", basename: "a.md", mtimeMs: 1, size: 1 }],
+        visitedEntries: 4,
+        complete: false
+      }),
       readNoteUncached: async () => {
         reads += 1;
         throw new Error("unreachable");

--- a/tests/frontmatter-ops.test.ts
+++ b/tests/frontmatter-ops.test.ts
@@ -222,9 +222,15 @@ describe("frontmatter_search", () => {
 
   it("refuses an incomplete bounded inventory before reading any note", async () => {
     let reads = 0;
+    // Supplies an ENTRY, so `reads === 0` proves the guard ran ahead of the read loop.
+    // With an empty listing the counter stays at zero whether the guard exists or not.
     const fake = {
       ensureExists: async () => undefined,
-      listFilesByExtensionsBounded: async () => ({ entries: [], visitedEntries: 7, complete: false }),
+      listFilesByExtensionsBounded: async () => ({
+        entries: [{ absPath: "/x/a.md", relPath: "a.md", basename: "a.md", mtimeMs: 1, size: 1 }],
+        visitedEntries: 7,
+        complete: false
+      }),
       readNote: async () => {
         reads += 1;
         throw new Error("unreachable");

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -288,6 +288,22 @@ describe("getBacklinks", () => {
     expect(out.map((h) => h.title)).toEqual(["Gamma"]);
     expect(out[0].count).toBe(1);
     expect(out[0].link_kind).toBe("wikilink");
+
+    // A folder note lives beside a folder of the same name, which is the ordinary
+    // Obsidian layout. `path` resolution tries the bare candidate first, and a
+    // directory stats successfully, so the folder used to shadow `Projects.md`
+    // entirely — the `.md` candidate was never tried and the answer was silently
+    // empty for a note that exists and is linked.
+    const folderRoot = await fs.mkdtemp(path.join(os.tmpdir(), "obsidian-mcp-foldernote-"));
+    try {
+      await fs.mkdir(path.join(folderRoot, "Projects"), { recursive: true });
+      await fs.writeFile(path.join(folderRoot, "Projects.md"), "The folder note.\n");
+      await fs.writeFile(path.join(folderRoot, "Ref.md"), "See [[Projects]].\n");
+      const byBarePath = await getBacklinks(new Vault(folderRoot), { path: "Projects" });
+      expect(byBarePath.map((h) => h.title)).toEqual(["Ref"]);
+    } finally {
+      await fs.rm(folderRoot, { recursive: true, force: true });
+    }
   });
 
   it("finds embed-style backlinks too", async () => {


### PR DESCRIPTION
Three defects from the mandatory re-sweep of the vault-shape line. Two are siblings of things already fixed once — which is what the sweep is for.

| defect | what it did | why it survived |
|---|---|---|
| **`listTags` counted spellings, not notes** | `collectTags` dedupes case-**sensitively**, so a note with `tags: [Reading]` and `#reading` arrives as two entries folding to one key. `count` was incremented twice for one note, and `frontmatter_count` *and* `inline_count` could both be incremented for it. `count: Number of notes containing the tag` was false. | `vaultShape` got the per-note guard when it shipped. Its older twin never did. |
| **`vaultShape` sliced at `limit`** | The tool is sold as *"exhaustive within its scan bounds, and it refuses rather than returning a partial inventory"*, and sorts by descending count — so a silent prefix drops exactly the rare keys the tool exists to surface. The caller cannot tell *"no note uses that key"* from *"it fell off the end"*. | The claim lived in the description; the slice lived in the code. Nothing compared them. |
| **A folder shadowed its note** | Candidates are `[path, path.md]` and the loop returns on the first that stats — but a directory stats fine and the `isFile` bit was dropped. With the ordinary `Projects/` + `Projects.md` layout, `get_backlinks` and `find_similar` returned **empty** for a note that exists and is linked. | The `.md` candidate was never reached, so the failure looked like "no backlinks". |

`vaultShape` now refuses and names the knob that widens the answer, which is what every other guard in that function already does.

## The tests could not have caught any of this

- The `vaultShape` folding assertion ran against a fixture with **no uppercase key**, so it held for the same reason the invented-key check it replaced did — nothing could make it fail. (This is my own #581 fix recursing its own class; the sweep caught it.)
- The guard-order fakes for `listTags` and `frontmatterSearch` supplied **zero entries**, so `reads === 0` was true whether or not the guard existed. #581 fixed this for `vaultShape` and left both twins live.

Fixtures now contain the shape that fails. **Test count unchanged** — assertions are folded into the existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)