### PR TITLE
ci: Scorecard, dependency review, and a remotely emitted transition authority

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,38 @@
+name: Dependency review
+
+# Blocks a pull request that introduces a dependency with a known advisory or a
+# licence outside the allowlist, using the dependency graph diff between base and
+# head. This is a gate on what a PR ADDS; the scoped `check:audit` in CI keeps
+# covering what the resolved tree already CONTAINS. Same threshold as that gate.
+#
+# SHA-pinned per OIA Check 9.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Lets the action post its findings as a PR comment.
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure
+          # The repository is MIT; runtime dependencies must be compatible with it.
+          allow-licenses: MIT, ISC, BSD-2-Clause, BSD-3-Clause, Apache-2.0, 0BSD, CC0-1.0, Unlicense, BlueOak-1.0.0, Python-2.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+name: Scorecard
+
+# OpenSSF Scorecard: an external, reproducible read of this repository's supply-chain
+# posture (pinned dependencies, token permissions, branch protection, SAST…). Results
+# go to the code-scanning tab as SARIF and to the public Scorecard API, which is what
+# the README badge and directory listings read. Weekly plus every push to main, which
+# is the cadence the Scorecard project itself recommends.
+#
+# Every action below is SHA-pinned with a trailing `# vN` comment — OIA Check 9 fails
+# the repository otherwise, and "Pinned-Dependencies" is one of the checks this very
+# workflow is scored on.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "17 4 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Deliberately no repository-wide `permissions:`; each job declares only what it
+# needs, mirroring the rest of this repository's workflows.
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Publish the SARIF into the code-scanning tab.
+      security-events: write
+      # Required so Scorecard can sign its results and publish them to the public API.
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishing to the Scorecard API is what makes the badge and the
+          # public score real rather than a private artifact.
+          publish_results: true
+
+      - name: Keep the SARIF as a run artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Three additive workflow changes, each closing a standing maintainer-gated item now that the account can push workflow files (D-75 re-authorised 2026-09-03; the long-standing items delegated in the same message).

| change | what it gives |
|---|---|
| **`scorecard.yml`** — OpenSSF Scorecard, weekly + on push to `main` | A public, reproducible score for the supply-chain posture this repo already enforces by hand (SHA-pinned actions, scoped tokens, branch protection). SARIF lands in the code-scanning tab; `publish_results: true` is what makes the badge real. Every action is SHA-pinned — *Pinned-Dependencies* is one of the checks it is scored on. |
| **`dependency-review.yml`** — on every PR | Fails a PR that **adds** a dependency with an advisory ≥ moderate or a licence outside the MIT-compatible allowlist, with a comment. `check:audit` keeps covering what the resolved tree already **contains**; the two are complementary and share a threshold. |
| **`ci.yml` docs job** — `emitted-release-mutation-transition` artifact | The transition authority and the current projection map, generated on the runner. The generator needs vite, so it cannot run on a workstation under D-45; without this, registering a reviewed source change meant guessing a witness and letting CI say no, one pin per round. Same shape as the MCP schema inventory artifact two steps above. |

Bootstrap receipt regenerated (it seals `ci.yml`). No `npm`-bearing command is added, so the reviewed job digests do not move.

**Verification this PR can offer itself:** the new Scorecard and dependency-review workflows appear as checks on this PR; the transition artifact appears on this PR's docs job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)