### PR TITLE
ci: allow LGPL-3.0-or-later in dependency review for sharp's libvips binaries

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -35,4 +35,10 @@ jobs:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure
           # The repository is MIT; runtime dependencies must be compatible with it.
-          allow-licenses: MIT, ISC, BSD-2-Clause, BSD-3-Clause, Apache-2.0, 0BSD, CC0-1.0, Unlicense, BlueOak-1.0.0, Python-2.0
+          # LGPL-3.0-or-later is here for ONE reason: sharp's prebuilt libvips
+          # binaries (@img/sharp-libvips-*), a devDependency that renders the social
+          # preview in CI and never ships in the npm package. The action cannot scope
+          # a licence rule to dev-only packages, so the allowlist carries it; the
+          # runtime graph is separately held to MIT-compatible terms by check:audit's
+          # published-consumer pass.
+          allow-licenses: MIT, ISC, BSD-2-Clause, BSD-3-Clause, Apache-2.0, 0BSD, CC0-1.0, Unlicense, BlueOak-1.0.0, Python-2.0, LGPL-3.0-or-later


### PR DESCRIPTION
The first dependency bump after #585 landed (#563) was blocked by the new gate on `@img/sharp-libvips-*@1.3.3` — **LGPL-3.0-or-later**. Those are sharp's prebuilt libvips binaries: a **devDependency** that renders the social preview in CI and never ships in the npm package.

`dependency-review-action` cannot scope a licence rule to dev-only packages, so the allowlist carries the term, with the reason written next to it. The runtime graph is separately held to MIT-compatible terms by `check:audit`'s published-consumer pass — that boundary is unchanged.

No vulnerabilities were reported; the gate's advisory half worked as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)