### PR TITLE
fix: bound the per-comparison cost of did-you-mean ranking

### DIFF
--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -83,6 +83,23 @@ export interface ValidateProposalResult {
 const MAX_VALIDATE_CONTENT_CODE_UNITS = 1_000_000;
 const MAX_VALIDATE_WIKILINKS = 10_000;
 const MAX_VALIDATE_SUGGESTION_COMPARISONS = 50_000;
+/** Longest broken target that still earns did-you-mean ranking.
+ *
+ *  The comparison budget above counts candidate x target PAIRS as if each pair were
+ *  O(1). Each pair actually costs O(|target|), because the scoring chain runs
+ *  `includes` against the target itself — and nothing capped a SINGLE target, only
+ *  the whole submitted body (1 MB) and the number of links. So one 1 MB target bought
+ *  a full-megabyte scan per candidate: measured at 8 s of blocked event loop on a
+ *  50,000-note vault, from one call to an always-on read-only tool, which is a remote
+ *  stall for every other client on the same server.
+ *
+ *  Dividing the budget by the target count made concentration OPTIMAL for an
+ *  attacker: k targets of size 1MB/k cost 50_000 x 1MB / k, maximised at k = 1.
+ *
+ *  A cap is the honest fix rather than a smaller budget, because a target this long
+ *  cannot be a plausible note name — the longest filename any filesystem here accepts
+ *  is 255 bytes. The link is still reported as broken; only the typo hint is skipped. */
+const MAX_VALIDATE_SUGGESTION_TARGET_CODE_UNITS = 1024;
 
 interface ValidationSuggestionBatch {
   byTarget: Map<string, string[]>;
@@ -132,6 +149,11 @@ function validationSuggestions(entries: readonly FileEntry[], targets: readonly 
 
   for (const target of uniqueTargets) {
     const lower = foldName(target.replace(/\.md$/iu, ""));
+    // Bound the per-pair cost, not just the pair count. See the constant's note.
+    if (lower.length > MAX_VALIDATE_SUGGESTION_TARGET_CODE_UNITS) {
+      byTarget.set(target, []);
+      continue;
+    }
     const top: Array<{ path: string; score: number; order: number }> = [];
     for (let index = 0; index < candidatesPerTarget; index++) {
       const candidate = candidates[index];

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -645,6 +645,24 @@ describe("validateNoteProposal — anti-slop write linter (v0.12)", () => {
     expect(noHintWarning).toBeDefined();
     expect(Object.hasOwn(noHintWarning ?? {}, "suggestion")).toBe(false);
     expect(() => textResult(result)).not.toThrow();
+
+    // The did-you-mean budget counts candidate x target PAIRS, but each pair costs
+    // O(|target|): every candidate is searched inside the target. A single target of
+    // ~1 MB therefore bought a full-megabyte scan per candidate — 8 s of blocked
+    // event loop on a 50k-note vault, from one call to an always-on read-only tool.
+    // A target longer than any filesystem allows cannot be a note name, so it earns
+    // no hint; it is still reported broken. A short near-miss right next to it keeps
+    // its hint, which is what makes this assertion about the CAP and not about
+    // suggestions being absent for some other reason.
+    const hugeTarget = `Alph${"a".repeat(2_000)}`;
+    const capped = await validateNoteProposal(v, {
+      path: "Inbox/y.md",
+      content: `[[${hugeTarget}]] and [[Alph]].\n`
+    });
+    const huge = capped.wikilinks.find((w) => w.target === hugeTarget);
+    expect(huge?.status).toBe("broken");
+    expect(huge?.suggestions).toEqual([]);
+    expect(capped.wikilinks.find((w) => w.target === "Alph")?.suggestions.length ?? 0).toBeGreaterThan(0);
   });
 
   it("folds suggestion candidates once and shares one budget across distinct broken targets", async () => {


### PR DESCRIPTION
Re-sweep finding RS-1 (MED, remote): `validateNoteProposal` ranks typo hints under a budget of candidate × target **comparisons**, treating each as O(1). Each actually costs O(|target|) — the candidate is searched inside the target — and nothing capped a *single* target, only the whole body (1 MB) and the link count. One 1 MB `[[…]]` target therefore bought a full-megabyte scan per candidate: **8 s of blocked event loop** on a 50,000-note vault, from one call to an always-on read-only tool. Dividing the budget by the target count made concentration optimal for an attacker (k = 1).

A target longer than any filesystem allows cannot be a note name, so it earns no hint at 1024 code units; the link is still reported broken.

**Test:** folded into the existing broken-wikilink test — a huge target gets `suggestions: []` while a short near-miss beside it keeps its hint, so the assertion is about the cap and not about hints being absent for some other reason. Count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)