### PR TITLE
fix: a stat failure inside the rename publication window is a partial commit

### DIFF
--- a/src/vault.ts
+++ b/src/vault.ts
@@ -2407,11 +2407,16 @@ export class Vault {
             }
             throw copyErr;
           }
-          publishedStat = await this.statSafe(toAbs);
+          // The destination is published from here on. A failure of EITHER step —
+          // reading the published stat or removing the source — leaves both paths
+          // on disk, and must say so: a bare stat error here used to read as a
+          // pre-publication failure, so the caller "rolled back" a rename that had
+          // in fact already published, and reported the old topology restored.
           try {
+            publishedStat = await this.statSafe(toAbs);
             await this.unlinkSafe(fromAbs);
-          } catch (unlinkError) {
-            throw new RenamePartialCommitError(fromRel, toRelNorm, "copy", unlinkError);
+          } catch (commitError) {
+            throw new RenamePartialCommitError(fromRel, toRelNorm, "copy", commitError);
           }
         } else {
           throw err;
@@ -2425,11 +2430,13 @@ export class Vault {
       // The EXDEV copy path already unlinked; a second unlinkSafe would ENOENT
       // after a completed move (the swallowed fs.unlink.catch used to hide both).
       if (linked) {
-        publishedStat = await this.statSafe(fromAbs);
+        // Same window, same rule: once the hard link exists, a stat failure is a
+        // partial commit, not a reason to pretend nothing was published.
         try {
+          publishedStat = await this.statSafe(fromAbs);
           await this.unlinkSafe(fromAbs);
-        } catch (unlinkError) {
-          throw new RenamePartialCommitError(fromRel, toRelNorm, "hardlink", unlinkError);
+        } catch (commitError) {
+          throw new RenamePartialCommitError(fromRel, toRelNorm, "hardlink", commitError);
         }
       }
     }

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -398,6 +398,39 @@ describe("createNote", () => {
       statSpy.mockRestore();
     }
 
+    // CL-A4 — a stat failure INSIDE the publication window (destination already
+    // linked, source not yet removed) is a partial commit, and must be reported as
+    // one. It used to escape as a bare error, which the rename orchestrator read as
+    // "nothing published yet" and answered with a rollback receipt for a rename
+    // that had already published. Both paths must still exist afterwards.
+    const windowRoot = await fs.mkdtemp(path.join(os.tmpdir(), "obsidian-mcp-rename-window-"));
+    try {
+      await fs.writeFile(path.join(windowRoot, "WinSource.md"), "window sentinel\n");
+      const windowVault = new Vault(windowRoot, { enableWrite: true });
+      await windowVault.ensureExists();
+      const windowInternals = windowVault as unknown as { statSafe(target: string): Promise<import("node:fs").Stats> };
+      const windowStat = windowInternals.statSafe.bind(windowVault);
+      const windowSpy = vi.spyOn(windowInternals, "statSafe").mockImplementation(async (target: string) => {
+        const t = String(target).replace(/\\/g, "/");
+        const destPresent = await fs.stat(path.join(windowRoot, "WinDest.md")).catch(() => null);
+        // Fail the stat that runs after publication (destination exists) and
+        // before source removal (source still exists).
+        if (t.endsWith("WinSource.md") && destPresent) throw new Error("synthetic in-window stat failure");
+        return windowStat(target);
+      });
+      try {
+        await expect(windowVault.renameFile("WinSource.md", "WinDest.md")).rejects.toThrow(
+          /published by hardlink before source removal failed \(synthetic in-window stat failure\)/
+        );
+        expect(await fs.readFile(path.join(windowRoot, "WinSource.md"), "utf8")).toBe("window sentinel\n");
+        expect(await fs.readFile(path.join(windowRoot, "WinDest.md"), "utf8")).toBe("window sentinel\n");
+      } finally {
+        windowSpy.mockRestore();
+      }
+    } finally {
+      await fs.rm(windowRoot, { recursive: true, force: true });
+    }
+
     // Cleanup
     await fs.rm(raceRoot, { recursive: true, force: true });
   });


### PR DESCRIPTION
Audit finding CL-A4 (LOW). Once the destination is linked or copied, two steps remain in `renameFile`: read the published stat, remove the source. An unlink failure was already reported as `RenamePartialCommitError` (both paths on disk). A **stat** failure one line above escaped as a bare error — which the rename orchestrator reads as "nothing published yet" and answers with a rollback receipt for a rename that had in fact published.

Both in-window stats now sit inside the same guard as the unlinks, for the hardlink and the EXDEV-copy path alike.

**Test:** folded into the existing rename-race test — the stat failure is injected precisely in the window (destination present, source still present); the partial-commit message is asserted and both files must survive. Count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)