### PR TITLE
docs: the semantic-route quarantine has one cause now, and the message says so

### DIFF
--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1451,11 +1451,13 @@ function watcherSemanticRouteIsQuarantined(health?: Readonly<{ semanticUsable: b
 }
 
 const SEMANTIC_ROUTE_QUARANTINED =
-  "Embedding search is quarantined for this server generation. Restart recovers a watcher backlog overflow; a durable embedding-integrity refusal needs the embedding index repaired or rebuilt, then a restart.";
+  "Embedding search is quarantined for this server generation: the live watcher's event queue overflowed, so " +
+  "the in-memory semantic route may no longer match disk. The on-disk embedding index is intact — restart the " +
+  "server; no rebuild is needed.";
 
 /**
- * Refuse every embedding-search route while the watched index is quarantined
- * after an incomplete startup activation.
+ * Refuse every embedding-search route while the on-disk watcher activation
+ * guard is still armed (an interrupted startup left the interlock in place).
  *
  * @param embedFile - Prepared embedding database path.
  * @param vaultRoot - Canonical vault root that must own any present database.
@@ -2667,8 +2669,8 @@ export async function searchHybrid(
     hnsw?: HnswSearchContext | null;
     /**
      * Semantic-route health for this prepared server generation. False
-     * `semanticUsable` is a live watcher backlog overflow or a startup
-     * embedding-integrity refusal (the latter can fire without `--watch`).
+     * `semanticUsable` has exactly one cause since the per-path quarantine
+     * landed: a live watcher event-queue overflow (`LiveWatcherAdmissionLimitError`).
      * Hybrid search then degrades to its coherent lexical signals.
      */
     watcherHealth?: Readonly<{ semanticUsable: boolean }>;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -105,12 +105,12 @@ function sameHnswRowManifest(
  * A quarantine-marker write failure is logged per sink without a broad route
  * latch; a fail-stop policy for that residual needs explicit authorization.
  *
- * `semanticUsable` is latched false by (1) live pending-event queue overflow
- * (`LiveWatcherAdmissionLimitError`) when a watcher exists, and (2) startup
- * embedding-integrity refusal on the server-owned health object — which is
- * `watcher.searchHealth` when `--watch` is on, or a fallback object when it
- * is not. Bare restart recovers (1). (2) is a durable snapshot mismatch:
- * repair or rebuild the embedding index, then restart.
+ * `semanticUsable` is latched false by exactly one cause: live pending-event
+ * queue overflow (`LiveWatcherAdmissionLimitError`) when a watcher exists.
+ * Dropped events mean the in-memory route may diverge from disk, so the whole
+ * semantic route is refused for this process. The on-disk index is intact; a
+ * bare restart recovers. The startup embedding-integrity latch that used to be
+ * cause (2) was removed with the per-path quarantine (PR #525).
  */
 export interface WatcherSearchHealth {
   semanticUsable: boolean;

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -151,7 +151,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "../embeddings.js|resolveStoredEmbeddingConfiguration|resolveStoredEmbeddingConfiguration"
     ],
     k1Opens: 1,
-    sha256: "3aa2b91c829191f51a999849a2856a52d8047f34274e3e78ff3bb805d7ac1961"
+    sha256: "09bccbed15cdb7445bb5a0ebfc4fd25d6547a01a2e43e6535bde98aa7ef6efbd"
   }
 };
 

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "ff2a56f40c536be926ab8dc201be1e629117b967ce9c584a75a1855b7311ae4c" }
+    { count: 4, sha256: "a5f24137a4d864a3139cdd7aa4a1223ed0d9632b0206154605f1878de9c43213" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "9bb382eb2d071464957b3c6cec271cb2a843dfeeabd9225c92e4497597d839ef"],
   ["K-1 block-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
   ["K-1 line-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
-  ["K-1 module-extension normalization", "bec1d52b3e54eb60d1bc2e28ea41228b6847e5c7f83339600f6b506ad3e80949"],
-  ["K-1 source-path separator normalization", "5971db634d342a8044dbdccd270fe3070e07a7ed0406ca8a5ce78e7fb07cb3b9"],
+  ["K-1 module-extension normalization", "7d920df4c52e82af1078b14bf84ee900bb91e35a72dd8e07a917d9e128b3be2f"],
+  ["K-1 source-path separator normalization", "a01e63c3eaacf16b6c8335b7fc458c2628f640630f3d768f7c8eb3ed6ef53139"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/search-hybrid.test.ts
+++ b/tests/search-hybrid.test.ts
@@ -193,6 +193,10 @@ describe("searchHybrid (v2.0 beta — RRF over available signals)", () => {
     );
     expect(availabilityQuarantined.signals_used).toEqual(["tfidf"]);
     expect(availabilityQuarantined.signal_errors?.embeddings).toMatch(/quarantined for this server generation/i);
+    // The only remaining cause is a watcher backlog; the message must not send an
+    // operator to rebuild an index that is intact (the deleted startup latch's advice).
+    expect(availabilityQuarantined.signal_errors?.embeddings).toMatch(/restart the server; no rebuild is needed/i);
+    expect(availabilityQuarantined.signal_errors?.embeddings).not.toMatch(/repaired or rebuilt/i);
     await expect(
       embeddingsSearch(v, { query: "OAuth JWT tokens", limit: 5 }, missingEmbedFile, undefined, {
         semanticUsable: false


### PR DESCRIPTION
Audit finding CL-B0 (LOW, user-facing text). #525 removed the global latch a single bad note used to trip, leaving **one** way for `semanticUsable` to go false: the live watcher's event queue overflowing (`watcher.ts:1287`, the only assignment left — `server.ts` has none).

Four surfaces still described the deleted startup embedding-integrity latch — the runtime error text, the activation-guard TSDoc, the server-deps TSDoc, and the watcher header — so an operator hitting the one remaining cause was told the index might need repairing or rebuilding. It does not: the on-disk index is intact; a restart recovers.

The runtime message now names the cause and the recovery. The test keeps its existing match and adds two: the restart advice must be present, the rebuild advice must be absent. Count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)