### PR TITLE
test: give the overhead-ceiling NEGATIVE control real headroom

### DIFF
--- a/tests/open-questions-admission.test.ts
+++ b/tests/open-questions-admission.test.ts
@@ -207,7 +207,11 @@ describe("getOpenQuestions bounded producer admission", () => {
       vault,
       { pattern: "^Q: (.+)$", scanBudgetMs: 1000 },
       {
-        limits: { maxWorkerBatchCandidates: 1, maxWorkerBatchUtf8Bytes: 32, maxWorkerOverheadMs: 1 },
+        // 250 ms, not 1 ms: the overhead this control must NOT trip is wall time the
+        // matcher did not attribute — which includes promise scheduling on the runner,
+        // routinely >1 ms on macOS CI. The POSITIVE control above burns 5 ms and
+        // reports none, so it still trips a 1 ms ceiling; discrimination is intact.
+        limits: { maxWorkerBatchCandidates: 1, maxWorkerBatchUtf8Bytes: 32, maxWorkerOverheadMs: 250 },
         matchBatch: reportAllAsMatching
       }
     );


### PR DESCRIPTION
The NEGATIVE control for #580's aggregate overhead ceiling ran with a **1 ms** ceiling. The overhead it must *not* trip is wall time the matcher did not attribute — which includes promise scheduling on the runner, routinely more than 1 ms on macOS CI. It failed `test-macos` on #588 for no reason related to the code under test.

The POSITIVE control burns 5 ms and reports none, so it still trips a 1 ms ceiling; the NEGATIVE control now uses 250 ms. Discrimination and count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)