### PR TITLE
chore: align the biome schema with the installed 2.5.11

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
   "files": {
     "includes": ["src/**/*.ts", "tests/**/*.ts", "!tests/fixtures", "scripts/**/*.{ts,mjs,js}"],
     "maxSize": 2097152


### PR DESCRIPTION
Plan B7 (found in #594's lint log). #563 moved `@biomejs/biome` to 2.5.11; `biome.json` still declared the 2.5.6 schema, which lint reports as an info on every run — the rc.78 config-drift class, a `^`-ranged tool outrunning its pinned schema. Schema URL only; no rule change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)