### PR TITLE
fix: hold the v7 chunk_parts table to the integrity, admission and doctor contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.7] — 2026-08-31
 
+### The v7 identifier-parts table is covered by the integrity, admission and diagnostic contracts
+
+> **TL;DR:** **`chunk_parts` is now audited, fingerprinted, admitted and diagnosed like the searchable state it is, and a database below schema 7 that carries the reserved v7 names is refused instead of having them reclaimed.**
+>
+> **Bounded claim.** The audit proves every parts row MIRRORS an existing chunk (path, kind, index, content copy, scope token, line range, tags) and carries non-empty parts; it cannot recompute the identifier split, so a tampered `parts` value is caught by the manifest, not the audit. The manifest generation moves to `v3`: a digest taken before this change is not comparable with one taken after it. Doctor gains the same declaration rules it already applied to `chunks` — an independent reader, deliberately not sharing a producer with `src/fts5.ts`.
+>
+> **Method note:** C3 re-sweep of PR #597 (0 CRIT/HIGH/MED; 16 LOW + 13 INFO). The audit comparison is written as a set difference rather than a join because both tables are FTS5 virtual tables with no index on the compared columns: the join form measured 142 s at 20k x 20k rows against 0.07 s for `EXCEPT`, and a test pins the shape. Controls: a diverged content copy, an empty `parts`, a wrong line range and an orphan parts row each raise `mismatched_files`; a same-shape `parts` mutation moves the manifest while leaving the audit clean; a stray plain `chunk_parts` and a stray plain `chunk_parts_data` on a schema-6 database are each refused with every cell unchanged (the rebuild would otherwise DROP an object admission never proved was ours and then report success); a parts row whose kind is neither `md` nor `pdf` is seen by BOTH audits, not hidden from each; a real index whose `chunk_parts` was rebuilt under the other tokenizer is refused without touching a cell; and doctor's four malformed chunk_parts fixtures ship beside a well-formed control.
+
 ### Erasure receipts are re-statted and name the surviving artifact (AH-5)
 
 > **TL;DR:** **`clear-index` and `clear-embeddings` can no longer print a “removed” receipt for a file that is still on disk, and a failed removal names the exact artifact.**

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -586,33 +586,58 @@ function requireAutoincrementPrimaryKey(db: SnapshotDb, table: string, column: s
   }
 }
 
-function requireFtsDefinition(sql: string, tokenizeMode: unknown): void {
+/**
+ * Validate one FTS5 virtual table's declaration against the layout Enquire
+ * writes: an exact indexed-column prefix in order, every receipt column
+ * UNINDEXED, the tokenizer the metadata claims, and no other FTS5 option.
+ *
+ * The expected layout is spelled out by the caller rather than imported from
+ * `src/fts5.ts`: doctor is an INDEPENDENT reader, and a shared producer would
+ * make a stale definition agree with itself.
+ */
+function requireFtsDefinition(
+  table: string,
+  sql: string,
+  tokenizeMode: unknown,
+  indexedColumns: readonly string[],
+  unindexedColumns: readonly string[]
+): void {
   if (tokenizeMode !== "unicode61" && tokenizeMode !== "trigram") {
     throw new Error("tokenize_mode metadata is missing or invalid");
   }
   const normalized = sql.replace(/["`[\]]/g, "").replace(/\s+/g, " ");
-  if (!/\(\s*content\s*,\s*title\s*,\s*aliases\s*,\s*scope_tokens\s*,/i.test(normalized)) {
-    throw new Error("chunks indexed-column order is incompatible");
+  const indexedOrder = new RegExp(`\\(\\s*${indexedColumns.join("\\s*,\\s*")}\\s*,`, "i");
+  if (!indexedOrder.test(normalized)) {
+    throw new Error(`${table} indexed-column order is incompatible`);
   }
-  for (const column of ["rel_path", "chunk_index", "line_start", "line_end", "tags", "raw_content", "kind"]) {
+  for (const column of unindexedColumns) {
     const declaration = new RegExp(`(?:\\(|,)\\s*${column}\\s+UNINDEXED(?:\\s*,|\\s*\\))`, "i");
-    if (!declaration.test(normalized)) throw new Error(`chunks.${column} must be UNINDEXED`);
+    if (!declaration.test(normalized)) throw new Error(`${table}.${column} must be UNINDEXED`);
   }
   const tokenizer = tokenizeMode === "trigram" ? "trigram" : "unicode61 remove_diacritics 2";
   const escapedTokenizer = tokenizer.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   if (!new RegExp(`\\btokenize\\s*=\\s*['"]${escapedTokenizer}['"]`, "i").test(normalized)) {
-    throw new Error(`chunks tokenizer does not match tokenize_mode=${tokenizeMode}`);
+    throw new Error(`${table} tokenizer does not match tokenize_mode=${tokenizeMode}`);
   }
   const options = [...normalized.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\s*=/g)].map(
     (match) => match[1]?.toLowerCase() ?? ""
   );
   const unsupported = options.filter((option) => option !== "tokenize");
   if (unsupported.length > 0) {
-    throw new Error(`chunks has unsupported FTS5 option(s): ${[...new Set(unsupported)].join(", ")}`);
+    throw new Error(`${table} has unsupported FTS5 option(s): ${[...new Set(unsupported)].join(", ")}`);
   }
   if (options.filter((option) => option === "tokenize").length !== 1) {
-    throw new Error("chunks must declare exactly one tokenize option");
+    throw new Error(`${table} must declare exactly one tokenize option`);
   }
+}
+
+/** The exact decimal schema stamp, or null when the metadata is absent or not
+ *  a canonical integer — a malformed stamp is reported by the version check,
+ *  never silently treated as "old enough to skip a contract". */
+function exactSchemaStamp(raw: unknown): number | null {
+  if (typeof raw !== "string" || !/^(?:0|[1-9][0-9]*)$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
 }
 
 function readIndexColumns(db: SnapshotDb, index: string): string[] {
@@ -678,7 +703,13 @@ async function inspectFtsSnapshot(file: string): Promise<SnapshotResult<FtsSnaps
       "raw_content",
       "kind"
     ]);
-    requireFtsDefinition(table.sql, meta.tokenize_mode);
+    requireFtsDefinition(
+      "chunks",
+      table.sql,
+      meta.tokenize_mode,
+      ["content", "title", "aliases", "scope_tokens"],
+      ["rel_path", "chunk_index", "line_start", "line_end", "tags", "raw_content", "kind"]
+    );
     requireTableColumns(db, "source_state", ["rel_path", "mtime_ms", "n_chunks", "kind", "indexed_at"]);
     requireColumnContract(db, "source_state", {
       rel_path: { type: "TEXT", pk: true },
@@ -692,25 +723,27 @@ async function inspectFtsSnapshot(file: string): Promise<SnapshotResult<FtsSnaps
       .prepare("SELECT COUNT(*) AS count FROM source_state WHERE kind IS NULL OR kind NOT IN ('md', 'pdf')")
       .get() as { count?: unknown } | undefined;
     if (invalidKinds?.count !== 0) throw new Error("source_state contains invalid kind values");
-    if (Number(meta.schema_version) >= 7) {
-      // v7 (SBS-D2') — the sibling identifier-parts table is part of the contract.
+    const stamp = exactSchemaStamp(meta.schema_version);
+    if (stamp !== null && stamp >= 7) {
+      // v7 (SBS-D2') — the sibling identifier-parts table is part of the
+      // contract, and held to the same declaration rules as `chunks`: an
+      // index whose chunk_parts contradicts its metadata is refused at open,
+      // so doctor must not report it healthy.
       const parts = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='chunk_parts'").get() as
         | { sql?: unknown }
         | undefined;
       if (typeof parts?.sql !== "string" || !/\bCREATE\s+VIRTUAL\s+TABLE\b[\s\S]*\bUSING\s+fts5\b/i.test(parts.sql)) {
         throw new Error("chunk_parts is not an FTS5 virtual table");
       }
-      requireTableColumns(db, "chunk_parts", [
-        "content",
-        "parts",
-        "scope_tokens",
-        "rel_path",
-        "chunk_index",
-        "line_start",
-        "line_end",
-        "tags",
-        "kind"
-      ]);
+      const chunkPartsUnindexed = ["rel_path", "chunk_index", "line_start", "line_end", "tags", "kind"];
+      requireTableColumns(db, "chunk_parts", ["content", "parts", "scope_tokens", ...chunkPartsUnindexed]);
+      requireFtsDefinition(
+        "chunk_parts",
+        parts.sql,
+        meta.tokenize_mode,
+        ["content", "parts", "scope_tokens"],
+        chunkPartsUnindexed
+      );
     }
     return {
       ...(meta.schema_version !== undefined ? { schemaVersion: meta.schema_version } : {}),

--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -716,6 +716,15 @@ const FTS_CHUNK_PARTS_COLUMNS = [
   "kind"
 ] as const;
 const FTS_CHUNK_PARTS_MIN_SCHEMA = 7;
+/** FTS5's own shadow tables for `chunk_parts`, by name. Admission types them,
+ *  and below schema 7 their mere presence refuses the database. */
+const FTS_CHUNK_PARTS_SHADOW_NAMES = [
+  "chunk_parts_data",
+  "chunk_parts_idx",
+  "chunk_parts_content",
+  "chunk_parts_docsize",
+  "chunk_parts_config"
+] as const;
 const FTS_CHUNK_PARTS_INSERT_SQL =
   "INSERT INTO chunk_parts (content, parts, scope_tokens, rel_path, chunk_index, line_start, line_end, tags, kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -744,11 +753,7 @@ const FTS_ADMISSION_OBJECT_TYPES = new Map<string, string>([
   ["chunks_docsize", "table"],
   ["chunks_config", "table"],
   ["chunk_parts", "table"],
-  ["chunk_parts_data", "table"],
-  ["chunk_parts_idx", "table"],
-  ["chunk_parts_content", "table"],
-  ["chunk_parts_docsize", "table"],
-  ["chunk_parts_config", "table"],
+  ...FTS_CHUNK_PARTS_SHADOW_NAMES.map((name) => [name, "table"] as const),
   ["source_state", "table"],
   ["source_quarantine", "table"],
   ["source_revision", "table"],
@@ -1825,7 +1830,18 @@ export class FtsIndex {
     } catch {
       throw new Error("Refusing to open a populated SQLite database without valid FTS ownership metadata");
     }
-    if (numericVersion >= FTS_CHUNK_PARTS_MIN_SCHEMA) {
+    if (numericVersion < FTS_CHUNK_PARTS_MIN_SCHEMA) {
+      // The v7 family is reserved but only EXPLICABLE from schema 7 onward. On
+      // an older database its exact declaration is never proved, so the names
+      // must not be silently reclaimed: the rebuild below would DROP an object
+      // this admission never established was ours and then report success,
+      // against the ownership posture every other object in the inventory is
+      // held to (SECURITY.md — "refusal preserves the logical SQLite schema
+      // and committed cells"). Refuse instead; `clear-index` is the remedy.
+      if (["chunk_parts", ...FTS_CHUNK_PARTS_SHADOW_NAMES].some((name) => objects.has(name))) {
+        throw new Error("Refusing to open a populated SQLite database without valid FTS ownership metadata");
+      }
+    } else {
       // v7 — the sibling identifier-parts table is admitted with the same
       // exactness as `chunks`: declared DDL and every FTS5 shadow table.
       const chunkPartsSql = objects.get("chunk_parts")?.sql;
@@ -2283,6 +2299,36 @@ export class FtsIndex {
               ))
               OR typeof(kind) <> 'text'
               OR kind NOT IN ('md', 'pdf')
+           UNION
+           -- v7 — every `chunk_parts` row must MIRROR an existing chunk: same
+           -- path, kind, index, content copy, scope token, line range and tags.
+           -- Stated as a set difference, not a join: both FTS5 tables are
+           -- unindexed on these columns, so `LEFT JOIN ... ON rel_path` is a
+           -- nested scan (measured 142 s at 20k x 20k rows); EXCEPT sorts each
+           -- side once and merges (0.07 s on the same data).
+           SELECT rel_path
+           FROM (
+             SELECT rel_path, kind, chunk_index, content, scope_tokens, line_start, line_end, tags
+             FROM chunk_parts
+             WHERE kind = ?
+             EXCEPT
+             SELECT rel_path, kind, chunk_index, content, scope_tokens, line_start, line_end, tags
+             FROM chunks
+             WHERE kind = ?
+           )
+           UNION
+           -- `parts` has no counterpart in `chunks`, so its own shape is
+           -- checked directly: a row that earns no parts must not exist.
+           SELECT rel_path
+           FROM chunk_parts
+           WHERE kind = ? AND (typeof(parts) <> 'text' OR length(parts) = 0)
+           UNION
+           -- Unscoped, like every sibling table: a row whose kind is neither
+           -- 'md' nor 'pdf' belongs to no audit view, so a kind-scoped arm
+           -- alone would let it hide from both.
+           SELECT rel_path
+           FROM chunk_parts
+           WHERE typeof(kind) <> 'text' OR kind NOT IN ('md', 'pdf')
          )
          SELECT
            (SELECT COUNT(*) FROM declared) AS declared_files,
@@ -2291,7 +2337,7 @@ export class FtsIndex {
            COALESCE((SELECT SUM(actual_count) FROM actual), 0) AS indexed_chunks,
            (SELECT COUNT(*) FROM mismatched) AS mismatched_files`
       )
-      .get<FtsKindAudit>(kind, kind, kind, kind, kind);
+      .get<FtsKindAudit>(kind, kind, kind, kind, kind, kind, kind, kind);
     return (
       row ?? {
         declared_files: 0,
@@ -2309,9 +2355,13 @@ export class FtsIndex {
    *
    * The manifest is intended for before/after integrity checks in strict
    * evidence runs. It includes source mtimes, monotonic revision tombstones,
-   * timestamps, every stored searchable/metadata column, and durable
-   * quarantine markers, so an in-place mutation that keeps aggregate counts
-   * unchanged still changes the digest.
+   * timestamps, every stored searchable/metadata column of BOTH searchable
+   * tables — `chunks` and the v7 sibling `chunk_parts`, whose rows decide what
+   * a search finds — and durable quarantine markers, so an in-place mutation
+   * that keeps aggregate counts unchanged still changes the digest.
+   *
+   * Generation `v3` added the `chunk_parts` rows; a digest taken before v7 is
+   * not comparable with one taken after it.
    *
    * @param kind - Content-source kind to fingerprint.
    * @returns Lowercase SHA-256 digest of the ordered physical rows.
@@ -2320,7 +2370,7 @@ export class FtsIndex {
     if (!isChunkKind(kind)) throw new Error(`Unsupported FTS source kind: ${String(kind)}`);
     const db = this.requireDb();
     const hash = createHash("sha256");
-    hash.update("enquire-fts-kind-manifest-v2;");
+    hash.update("enquire-fts-kind-manifest-v3;");
     for (const row of db
       .prepare(
         `SELECT rel_path, mtime_ms, n_chunks, kind, indexed_at
@@ -2399,6 +2449,38 @@ export class FtsIndex {
       updateManifestValue(hash, row.line_end);
       updateManifestValue(hash, row.tags);
       updateManifestValue(hash, row.raw_content);
+      updateManifestValue(hash, row.kind);
+    }
+    // v7 — the sibling identifier-parts rows are searchable state: they decide
+    // what a query FINDS, so a mutation of `parts` changes results. Hashing
+    // them here is what makes the manifest's coverage claim true after v7.
+    for (const row of db
+      .prepare(
+        `SELECT content, parts, scope_tokens, rel_path, chunk_index, line_start, line_end, tags, kind
+         FROM chunk_parts
+         WHERE kind = ?
+         ORDER BY rel_path, chunk_index, rowid`
+      )
+      .iterate<{
+        content: string;
+        parts: string;
+        scope_tokens: string;
+        rel_path: string;
+        chunk_index: number;
+        line_start: number;
+        line_end: number;
+        tags: string;
+        kind: string;
+      }>(kind)) {
+      hash.update("parts;");
+      updateManifestValue(hash, row.content);
+      updateManifestValue(hash, row.parts);
+      updateManifestValue(hash, row.scope_tokens);
+      updateManifestValue(hash, row.rel_path);
+      updateManifestValue(hash, row.chunk_index);
+      updateManifestValue(hash, row.line_start);
+      updateManifestValue(hash, row.line_end);
+      updateManifestValue(hash, row.tags);
       updateManifestValue(hash, row.kind);
     }
     return hash.digest("hex");

--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -2300,10 +2300,10 @@ export class FtsIndex {
               OR typeof(kind) <> 'text'
               OR kind NOT IN ('md', 'pdf')
            UNION
-           -- v7 — every `chunk_parts` row must MIRROR an existing chunk: same
+           -- v7 -- every chunk_parts row must MIRROR an existing chunk: same
            -- path, kind, index, content copy, scope token, line range and tags.
            -- Stated as a set difference, not a join: both FTS5 tables are
-           -- unindexed on these columns, so `LEFT JOIN ... ON rel_path` is a
+           -- unindexed on these columns, so LEFT JOIN ... ON rel_path is a
            -- nested scan (measured 142 s at 20k x 20k rows); EXCEPT sorts each
            -- side once and merges (0.07 s on the same data).
            SELECT rel_path
@@ -2317,15 +2317,15 @@ export class FtsIndex {
              WHERE kind = ?
            )
            UNION
-           -- `parts` has no counterpart in `chunks`, so its own shape is
-           -- checked directly: a row that earns no parts must not exist.
+           -- parts has no counterpart in chunks, so its own shape is checked
+           -- directly: a row that earns no parts must not exist.
            SELECT rel_path
            FROM chunk_parts
            WHERE kind = ? AND (typeof(parts) <> 'text' OR length(parts) = 0)
            UNION
            -- Unscoped, like every sibling table: a row whose kind is neither
-           -- 'md' nor 'pdf' belongs to no audit view, so a kind-scoped arm
-           -- alone would let it hide from both.
+           -- md nor pdf belongs to no audit view, so a kind-scoped arm alone
+           -- would let it hide from both.
            SELECT rel_path
            FROM chunk_parts
            WHERE typeof(kind) <> 'text' OR kind NOT IN ('md', 'pdf')

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1165,8 +1165,7 @@ describe("runDoctor — strict source-state preservation", () => {
         // to PRAGMA table_info.
         slug: "parts-extra-option",
         chunkParts:
-          `content, parts, scope_tokens, ${partsReceipts}, ` +
-          "tokenize='unicode61 remove_diacritics 2', columnsize=0",
+          `content, parts, scope_tokens, ${partsReceipts}, ` + "tokenize='unicode61 remove_diacritics 2', columnsize=0",
         expected: "chunk_parts has unsupported FTS5 option(s): columnsize"
       },
       {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1152,9 +1152,22 @@ describe("runDoctor — strict source-state preservation", () => {
         expected: "chunk_parts.rel_path must be UNINDEXED"
       },
       {
+        // Owned by requireTableColumns, which compares PRAGMA names in order
+        // and fires before the declaration rules below — recorded here so the
+        // ordering between the two gates is stated rather than assumed.
         slug: "parts-reordered",
         chunkParts: `parts, content, scope_tokens, ${partsReceipts}, tokenize='unicode61 remove_diacritics 2'`,
-        expected: "chunk_parts indexed-column order is incompatible"
+        expected: "chunk_parts column order is incompatible"
+      },
+      {
+        // Only the declaration rules can see this one: the column NAMES and
+        // their order are exactly right, and an extra FTS5 option is invisible
+        // to PRAGMA table_info.
+        slug: "parts-extra-option",
+        chunkParts:
+          `content, parts, scope_tokens, ${partsReceipts}, ` +
+          "tokenize='unicode61 remove_diacritics 2', columnsize=0",
+        expected: "chunk_parts has unsupported FTS5 option(s): columnsize"
       },
       {
         slug: "parts-well-formed",

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1124,6 +1124,75 @@ describe("runDoctor — strict source-state preservation", () => {
       expect(await snapshotDir(dir)).toEqual(candidateBefore);
     }
 
+    // v7 (SBS-D2') — the sibling identifier-parts table is held to the same
+    // declaration rules as `chunks`. Runtime admission refuses an index whose
+    // chunk_parts contradicts its metadata and serve degrades to TF-IDF, so a
+    // doctor that only counted its column names would send an operator
+    // looking in the wrong place. The last row is the control that proves the
+    // others fail for their stated reason and not merely because the fixture
+    // is hand-built.
+    const validChunks =
+      "content, title, aliases, scope_tokens, rel_path UNINDEXED, chunk_index UNINDEXED, " +
+      "line_start UNINDEXED, line_end UNINDEXED, tags UNINDEXED, raw_content UNINDEXED, kind UNINDEXED";
+    const partsReceipts =
+      "rel_path UNINDEXED, chunk_index UNINDEXED, line_start UNINDEXED, line_end UNINDEXED, " +
+      "tags UNINDEXED, kind UNINDEXED";
+    for (const { slug, chunkParts, expected } of [
+      { slug: "parts-absent", chunkParts: null, expected: "chunk_parts is not an FTS5 virtual table" },
+      {
+        slug: "parts-tokenizer",
+        chunkParts: `content, parts, scope_tokens, ${partsReceipts}, tokenize='trigram'`,
+        expected: "chunk_parts tokenizer does not match tokenize_mode=unicode61"
+      },
+      {
+        slug: "parts-indexed-receipt",
+        chunkParts:
+          "content, parts, scope_tokens, rel_path, chunk_index UNINDEXED, line_start UNINDEXED, " +
+          "line_end UNINDEXED, tags UNINDEXED, kind UNINDEXED, tokenize='unicode61 remove_diacritics 2'",
+        expected: "chunk_parts.rel_path must be UNINDEXED"
+      },
+      {
+        slug: "parts-reordered",
+        chunkParts: `parts, content, scope_tokens, ${partsReceipts}, tokenize='unicode61 remove_diacritics 2'`,
+        expected: "chunk_parts indexed-column order is incompatible"
+      },
+      {
+        slug: "parts-well-formed",
+        chunkParts: `content, parts, scope_tokens, ${partsReceipts}, tokenize='unicode61 remove_diacritics 2'`,
+        expected: null
+      }
+    ] as const) {
+      const partsFile = path.join(dir, `${slug}.fts5.db`);
+      const partsDb = new Database(partsFile);
+      partsDb.exec(`
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE VIRTUAL TABLE chunks USING fts5(${validChunks}, tokenize='unicode61 remove_diacritics 2');
+        ${chunkParts === null ? "" : `CREATE VIRTUAL TABLE chunk_parts USING fts5(${chunkParts});`}
+        CREATE TABLE source_state (
+          rel_path TEXT PRIMARY KEY,
+          mtime_ms INTEGER NOT NULL,
+          n_chunks INTEGER NOT NULL,
+          kind TEXT NOT NULL DEFAULT 'md',
+          indexed_at TEXT NOT NULL
+        );
+      `);
+      const partsInsert = partsDb.prepare("INSERT INTO meta (key, value) VALUES (?, ?)");
+      partsInsert.run("schema_version", String(FTS_SCHEMA_VERSION));
+      partsInsert.run("vault_root", await fs.realpath(root));
+      partsInsert.run("tokenize_mode", "unicode61");
+      partsDb.close();
+      const partsBefore = await snapshotDir(dir);
+      const partsResult = await diagnose({
+        tier: "basic",
+        indexFile: partsFile,
+        embedFile: path.join(dir, "missing.embed.db")
+      });
+      const partsDetail = partsResult.checks.find((check) => check.id === "index:fts5")?.detail ?? "";
+      if (expected === null) expect(partsDetail, slug).not.toContain("chunk_parts");
+      else expect(partsDetail, slug).toContain(expected);
+      expect(await snapshotDir(dir)).toEqual(partsBefore);
+    }
+
     const compositeFile = path.join(dir, "composite-source-pk.fts5.db");
     const composite = new Database(compositeFile);
     composite.exec(`

--- a/tests/fts5.test.ts
+++ b/tests/fts5.test.ts
@@ -2409,9 +2409,7 @@ describe("FtsIndex — PDF chunks (v2.8.0)", () => {
       expectMismatches(0, 0);
       raw.prepare("UPDATE chunk_parts SET content = 'diverged copy' WHERE rel_path = 'parts.md'").run();
       expectMismatches(1, 0);
-      raw
-        .prepare("UPDATE chunk_parts SET content = 'call fetchDailyReport once' WHERE rel_path = 'parts.md'")
-        .run();
+      raw.prepare("UPDATE chunk_parts SET content = 'call fetchDailyReport once' WHERE rel_path = 'parts.md'").run();
       expectMismatches(0, 0);
       raw.prepare("UPDATE chunk_parts SET line_end = 99 WHERE rel_path = 'parts.md'").run();
       expectMismatches(1, 0);

--- a/tests/fts5.test.ts
+++ b/tests/fts5.test.ts
@@ -910,12 +910,26 @@ describe("FtsIndex — full lifecycle", () => {
       expect(idx.search("to-be-deleted-marker").length).toBe(0);
       expect(idx.totalFiles()).toBe(0);
       expect(idx.totalChunks()).toBe(0);
+
+      // v7 — a dropped file must leave no identifier-parts row behind. The
+      // sibling table holds a COPY of the chunk text, so a stale row would
+      // resurface the deleted note as a score-0 tail hit. `daily`/`report`
+      // are reachable ONLY through the parts split (unicode61 keeps
+      // `fetchDailyReport` as one token), so this asserts the parts pass.
+      idx.reindexFile("y.md", 1000, "call fetchDailyReport in the pipeline");
+      expect(idx.search("daily report").map((hit) => hit.rel_path)).toEqual(["y.md"]);
+      idx.dropFile("y.md");
+      expect(idx.search("daily report")).toEqual([]);
       // Class invariant for rc.18: every chunk replacement/removal path must
       // enter through the indexed scope token. A bare rel_path DELETE scans
       // the growing FTS virtual table and made a 22k-note fresh build O(N²).
       const source = await fs.readFile(path.resolve("src/fts5.ts"), "utf8");
       expect(source).not.toContain("DELETE FROM chunks WHERE rel_path = ?");
       expect(source.match(/DELETE FROM chunks WHERE chunks MATCH \? AND rel_path = \?/g)).toHaveLength(3);
+      // The v7 sibling table is the same class: `rel_path` is UNINDEXED there
+      // too, so a bare rel_path DELETE would reintroduce the O(N²) scan.
+      expect(source).not.toContain("DELETE FROM chunk_parts WHERE rel_path = ?");
+      expect(source.match(/DELETE FROM chunk_parts WHERE chunk_parts MATCH \? AND rel_path = \?/g)).toHaveLength(3);
     } finally {
       await idx.closeAndRelease();
     }
@@ -1200,6 +1214,84 @@ describe("FtsIndex — full lifecycle", () => {
       /physical tokenizer or schema contradicts metadata/
     );
     expect(snapshot(regularSpoofFile, regularSpoofQueries)).toEqual(beforeRegularSpoof);
+
+    // v7 — the sibling identifier-parts table is admitted with the same
+    // exactness as `chunks`. This fixture is a REAL index whose chunk_parts
+    // was rebuilt under the other tokenizer: every object name, the meta rows
+    // and `chunks` itself are untouched, so only the chunk_parts declaration
+    // can reject it. Without that check the index opens and silently searches
+    // a table whose analysis contradicts its own metadata.
+    const partsSpoofFile = path.join(dbDir, "chunk-parts-spoof.fts5.db");
+    const partsSpoofSeed = new FtsIndex({ file: partsSpoofFile, vaultRoot: "/tmp/vault-A" });
+    await partsSpoofSeed.open();
+    partsSpoofSeed.reindexFile("owned.md", 1001, "call fetchDailyReport once");
+    await partsSpoofSeed.closeAndRelease();
+    const partsSpoofRaw = new Database(partsSpoofFile);
+    partsSpoofRaw.exec(`
+      DROP TABLE chunk_parts;
+      CREATE VIRTUAL TABLE chunk_parts USING fts5(
+        content,
+        parts,
+        scope_tokens,
+        rel_path UNINDEXED,
+        chunk_index UNINDEXED,
+        line_start UNINDEXED,
+        line_end UNINDEXED,
+        tags UNINDEXED,
+        kind UNINDEXED,
+        tokenize='trigram'
+      );
+    `);
+    partsSpoofRaw.close();
+    const partsSpoofQueries = [
+      "SELECT * FROM meta ORDER BY key",
+      "SELECT rowid, * FROM chunks ORDER BY rowid",
+      "SELECT rowid, * FROM chunk_parts ORDER BY rowid",
+      "SELECT * FROM source_state ORDER BY rel_path"
+    ];
+    const beforePartsSpoof = snapshot(partsSpoofFile, partsSpoofQueries);
+    await refusePathFree(
+      new FtsIndex({ file: partsSpoofFile, vaultRoot: "/tmp/vault-A" }),
+      [partsSpoofFile, "/tmp/vault-A"],
+      /physical tokenizer or schema contradicts metadata/
+    );
+    expect(snapshot(partsSpoofFile, partsSpoofQueries)).toEqual(beforePartsSpoof);
+
+    // v7 — the reserved sibling family is only explicable from schema 7. On a
+    // legacy database its declaration is never proved, so admission must
+    // REFUSE rather than let the rebuild reclaim the name: dropping an object
+    // ownership never established, and then reporting success, is the one
+    // outcome the cohabiting-payload fixture below exists to forbid.
+    for (const [slug, ddl] of [
+      ["legacy-stray-chunk-parts", "CREATE TABLE chunk_parts (payload BLOB NOT NULL)"],
+      ["legacy-stray-parts-shadow", "CREATE TABLE chunk_parts_data (id INTEGER PRIMARY KEY, block BLOB)"]
+    ] as const) {
+      const strayFile = path.join(dbDir, `${slug}.fts5.db`);
+      const straySeed = new FtsIndex({ file: strayFile, vaultRoot: "/tmp/vault-A" });
+      await straySeed.open();
+      straySeed.reindexFile("owned.md", 1001, "owned-marker");
+      await straySeed.closeAndRelease();
+      const strayRaw = new Database(strayFile);
+      // Stamp the database back to the last schema without the v7 family, so
+      // the rebuild path is what would otherwise run.
+      strayRaw.prepare("UPDATE meta SET value = ? WHERE key = 'schema_version'").run(String(FTS_SCHEMA_VERSION - 1));
+      strayRaw.exec("DROP TABLE chunk_parts;");
+      strayRaw.exec(ddl);
+      strayRaw.close();
+      const strayQueries = [
+        "SELECT type, name, sql FROM sqlite_master WHERE name NOT GLOB 'sqlite_*' ORDER BY type, name",
+        "SELECT * FROM meta ORDER BY key",
+        "SELECT rowid, * FROM chunks ORDER BY rowid",
+        "SELECT * FROM source_state ORDER BY rel_path"
+      ];
+      const beforeStray = snapshot(strayFile, strayQueries);
+      await refusePathFree(
+        new FtsIndex({ file: strayFile, vaultRoot: "/tmp/vault-A" }),
+        [strayFile, "/tmp/vault-A"],
+        /without valid FTS ownership metadata/
+      );
+      expect(snapshot(strayFile, strayQueries), slug).toEqual(beforeStray);
+    }
 
     // Full-inventory class proof: an otherwise valid FTS database that
     // cohabits with an unowned payload table is not safe to mutate. A
@@ -2298,6 +2390,68 @@ describe("FtsIndex — PDF chunks (v2.8.0)", () => {
         .run(ftsScopeTokens("a.md"));
       expectMismatches(0, 0);
 
+      // v7 — the sibling identifier-parts rows are audited and fingerprinted
+      // like any other searchable state. `a.md` carries no compound
+      // identifier, so this section brings its own.
+      audited.reindexFile("parts.md", 3000, "call fetchDailyReport once");
+      expectMismatches(0, 0);
+      expect(raw.prepare("SELECT COUNT(*) AS n FROM chunk_parts WHERE rel_path = 'parts.md'").get()).toEqual({ n: 1 });
+      const manifestBeforeParts = audited.fingerprintKind("md");
+      // The audit cannot recompute the split, but the manifest must still move
+      // on a same-shape mutation of what the index will match against.
+      raw.prepare("UPDATE chunk_parts SET parts = 'tampered' WHERE rel_path = 'parts.md'").run();
+      expect(audited.fingerprintKind("md")).not.toBe(manifestBeforeParts);
+      expectMismatches(0, 0);
+      // What the audit DOES own: a parts row must mirror an existing chunk.
+      raw.prepare("UPDATE chunk_parts SET parts = '' WHERE rel_path = 'parts.md'").run();
+      expectMismatches(1, 0);
+      raw.prepare("UPDATE chunk_parts SET parts = 'fetch daily report' WHERE rel_path = 'parts.md'").run();
+      expectMismatches(0, 0);
+      raw.prepare("UPDATE chunk_parts SET content = 'diverged copy' WHERE rel_path = 'parts.md'").run();
+      expectMismatches(1, 0);
+      raw
+        .prepare("UPDATE chunk_parts SET content = 'call fetchDailyReport once' WHERE rel_path = 'parts.md'")
+        .run();
+      expectMismatches(0, 0);
+      raw.prepare("UPDATE chunk_parts SET line_end = 99 WHERE rel_path = 'parts.md'").run();
+      expectMismatches(1, 0);
+      raw.prepare("UPDATE chunk_parts SET line_end = 1 WHERE rel_path = 'parts.md'").run();
+      expectMismatches(0, 0);
+      // A parts row whose kind is neither 'md' nor 'pdf' belongs to no scoped
+      // view, so both audits must see it — the same contract `chunks` has.
+      raw.prepare("UPDATE chunk_parts SET kind = 'bogus' WHERE rel_path = 'parts.md'").run();
+      expectMismatches(1, 1);
+      raw.prepare("UPDATE chunk_parts SET kind = 'md' WHERE rel_path = 'parts.md'").run();
+      expectMismatches(0, 0);
+      // An orphan parts row for a path with no chunk row of its own.
+      raw
+        .prepare(
+          `INSERT INTO chunk_parts
+             (content, parts, scope_tokens, rel_path, chunk_index, line_start, line_end, tags, kind)
+           VALUES ('orphan copy', 'orphan copy', ?, 'orphan-parts.md', 0, 1, 1, '', 'md')`
+        )
+        .run(ftsScopeTokens("orphan-parts.md"));
+      expectMismatches(1, 0);
+      raw.prepare("DELETE FROM chunk_parts WHERE rel_path = 'orphan-parts.md'").run();
+      expectMismatches(0, 0);
+      audited.dropFile("parts.md");
+      expectMismatches(0, 0);
+
+      // Shape guard for the comparison above. `chunks` and `chunk_parts` are
+      // both FTS5 virtual tables with no index on the join columns, so the
+      // natural `LEFT JOIN ... ON rel_path` is a nested scan: measured 142 s at
+      // 20k x 20k rows against 0.07 s for the set-difference form. The audit
+      // reads the whole index in strict evidence mode, so the form is
+      // load-bearing, and `discoverScanners` cannot see an SQL string.
+      const auditSource = await fs.readFile(path.resolve("src/fts5.ts"), "utf8");
+      const auditBody = auditSource.slice(
+        auditSource.indexOf("auditKind(kind: ChunkKind)"),
+        auditSource.indexOf("fingerprintKind(kind: ChunkKind)")
+      );
+      expect(auditBody).not.toBe("");
+      expect(auditBody).toMatch(/EXCEPT/);
+      expect(auditBody).not.toMatch(/JOIN\s+chunk_parts\b/);
+
       const manifestBeforeMutation = audited.fingerprintKind("md");
       raw.prepare("UPDATE chunks SET tags = 'same-shape-mutation' WHERE rel_path = 'a.md' AND chunk_index = 0").run();
       expectMismatches(0, 0);
@@ -2503,6 +2657,18 @@ describe("FtsIndex — PDF chunks (v2.8.0)", () => {
       await rebuilt.open();
       expect(rebuilt.totalChunks(), `v${version} rebuild must discard legacy rows`).toBe(0);
       await rebuilt.closeAndRelease();
+      // The rebuild must materialise the v7 sibling table, not just the
+      // schema stamp: an index whose `chunk_parts` is missing is refused by
+      // the very next open.
+      const rebuiltRaw = new Database(legacyFile, { readonly: true, fileMustExist: true });
+      try {
+        const partsSql = rebuiltRaw.prepare("SELECT sql FROM sqlite_master WHERE name = 'chunk_parts'").get() as
+          | { sql?: string }
+          | undefined;
+        expect(partsSql?.sql, `v${version} rebuild must recreate chunk_parts`).toMatch(/USING\s+fts5/i);
+      } finally {
+        rebuiltRaw.close();
+      }
       expect((await peekFtsMetaSafe(legacyFile))?.schema_version).toBe(String(FTS_SCHEMA_VERSION));
     }
 

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -308,7 +308,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     "fts-persistence-coordination.test.ts",
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
-  ["fts5.test.ts", { count: 5, sha256: "5fb6ac0fcc8b41b84892ec19cea293f318cb963f424fca8243950b49620acc60" }],
+  ["fts5.test.ts", { count: 5, sha256: "4ae999c21c5bf5bd9fbe200c5b8216f7b64a6c0d5e3d7a8b838abb4e41b6623c" }],
   ["http-transport.test.ts", { count: 1, sha256: "4a199f3e843d763b7dcd9c1ea40088b3d91ca045b7c7ef6b44cec38fda3cbe5c" }],
   [
     "hnsw-sync-critical-section.test.ts",
@@ -1013,8 +1013,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
     "2dc77bab72a06575b3646c365f81d95192f7e2755b268637e608195b43674824"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
-  ["FTS route slug normalization", "5636dbbe01d8e480d5514eb9af2304e2c5cefd244e8e7c851f91c469aeb9eabd"],
-  ["FTS shadow schema fixture extension", "07c77304f19911d94ebc84891c4aaed5d88af24fe3d149221b3af20b37cf244b"],
+  ["FTS route slug normalization", "206d271cc905faefe8e141d2b67c882fb49d691ff2bedf2c9fededd226b88454"],
+  ["FTS shadow schema fixture extension", "12d9a02966d0848432183222641c91d819684c5c557a5c0da3bbe4aec722eef3"],
   [
     "watcher existence-guard whitespace normalization",
     "2e02b86949da126f4b7df90da07e0f01b4a1f40628ae8223f6e401ee10d7af24"

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -308,7 +308,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     "fts-persistence-coordination.test.ts",
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
-  ["fts5.test.ts", { count: 5, sha256: "4ae999c21c5bf5bd9fbe200c5b8216f7b64a6c0d5e3d7a8b838abb4e41b6623c" }],
+  ["fts5.test.ts", { count: 5, sha256: "03d161443be01cd625432f46e76f89185a9eb703060c1aff7a77553fff958357" }],
   ["http-transport.test.ts", { count: 1, sha256: "4a199f3e843d763b7dcd9c1ea40088b3d91ca045b7c7ef6b44cec38fda3cbe5c" }],
   [
     "hnsw-sync-critical-section.test.ts",
@@ -1013,8 +1013,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
     "2dc77bab72a06575b3646c365f81d95192f7e2755b268637e608195b43674824"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
-  ["FTS route slug normalization", "206d271cc905faefe8e141d2b67c882fb49d691ff2bedf2c9fededd226b88454"],
-  ["FTS shadow schema fixture extension", "12d9a02966d0848432183222641c91d819684c5c557a5c0da3bbe4aec722eef3"],
+  ["FTS route slug normalization", "93c6394fa720da93e24bfa6656ee6d5762472e2f0d80b94edb904fc6b9132042"],
+  ["FTS shadow schema fixture extension", "2824afc0fe378601b156aff4f65c413407b00bcd56fc6c1b842bd7fb7c64b0f2"],
   [
     "watcher existence-guard whitespace normalization",
     "2e02b86949da126f4b7df90da07e0f01b4a1f40628ae8223f6e401ee10d7af24"


### PR DESCRIPTION
C3 risk-triggered re-sweep of PR #597 (FTS schema v7). The sweep returned **0 CRIT / 0 HIGH / 0 MED**, 16 LOW + 13 INFO; this PR closes the integrity/admission/diagnostic cluster.

**What changed**

- **`auditKind`** — every `chunk_parts` row must mirror an existing chunk (path, kind, index, content copy, scope token, line range, tags), carry non-empty `parts`, and hold a valid kind *unscoped*, like every sibling table (a `kind='bogus'` row previously hid from both audit views).
- **`fingerprintKind`** — hashes all nine `chunk_parts` columns; manifest generation `v2 → v3`. A digest taken before v7 is not comparable with one taken after it (no gate can say this, so it is in the CHANGELOG).
- **Admission** — a database below schema 7 carrying the reserved v7 names is **refused**. The first draft dropped them instead; that converted a fail-closed refusal into silently reclaiming an object admission never proved was ours, against SECURITY.md's ownership posture.
- **doctor** — `chunk_parts` is held to the same declaration rules as `chunks` (tokenizer matches `tokenize_mode`, receipt columns UNINDEXED, exactly one option) via a parameterised validator. Every `chunks` message stays byte-identical, and doctor remains an *independent* reader rather than importing the producer. The schema stamp is parsed exactly, so a malformed value never reads as "old enough to skip a contract".

**Measured, not assumed.** The audit comparison is a set difference rather than a join because both tables are FTS5 virtual tables with no index on the compared columns: the join form measured **142 s** at 20k × 20k rows against **0.07 s** for `EXCEPT`. A test pins the shape, since no scanner heuristic can see inside an SQL string.

**Controls** — diverged content copy, empty `parts`, wrong line range, invalid kind and an orphan row each raise `mismatched_files`; a same-shape `parts` mutation moves the manifest while the audit stays clean (it cannot recompute the split, and does not claim to); a dropped file leaves no parts row and its parts-only query goes empty; two stray-family fixtures are refused byte-unchanged; a real index whose `chunk_parts` was rebuilt under the other tokenizer is refused; doctor's four malformed fixtures ship beside a well-formed control.

No new `it()` — every assertion is folded into an existing registration, so the canonical test count and its ~20 sealed surfaces are untouched. `tests/fts5.test.ts` census + owner hashes repinned, each controlled against `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)