### PR TITLE
docs: state the v7 search contract — score-0 sentinel, parts-only snippet, the row-local limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.7] — 2026-08-31
 
+### The v7 search contract says what the parts pass does and does not promise
+
+> **TL;DR:** **A score of exactly `0` marks a hit found only through the identifier-parts pass, a parts-only snippet carries no `«»` markers, and the one query shape the pass cannot reach is documented rather than papered over.**
+>
+> **Bounded claim.** Documentation and one folded contract test; no retrieval behaviour changes. The unreachable shape is a title-only word ANDed with a word that exists only as a later chunk's identifier part: FTS5 matches per row and note titles are stored on chunk 0 only, so no single row holds both. It is a pre-existing property of note-level attributes — the same query returned nothing before the parts table existed — and closing it in general would require the title on every parts row, which relocates the candidate-set flooding that storing titles per chunk caused in the first place.
+>
+> **Method note:** C3 re-sweep tail. The contract test ships the control that gives the empty result meaning: the same title word ANDed with a word that IS in chunk 0's own content must be FOUND, so the assertion cannot pass on a broken fixture or a non-AND parser. SECURITY.md now states that the FTS index holds a second copy of the chunk text for identifier-bearing chunks, inside the same file `clear-index` removes whole. Also recorded: v6's weight-0 `scope_tokens` column is not a counter-example to keeping parts out of `chunks` — it lengthens every row by exactly one token, so it shifts BM25's length normalisation uniformly, while identifier parts vary from 0 to 256 per chunk.
+
 ### The v7 identifier-parts table is covered by the integrity, admission and diagnostic contracts
 
 > **TL;DR:** **`chunk_parts` is now audited, fingerprinted, admitted and diagnosed like the searchable state it is, and a database below schema 7 that carries the reserved v7 names is refused instead of having them reclaimed.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,10 @@ running.
 - **Local data at rest.** Depending on enabled options, enquire can store a
   parsed-note cache, a content-bearing FTS5 index, an embedding database,
   HNSW sidecars, and an opt-in feedback file in the local cache directory.
+  Since FTS schema v7 that index holds a SECOND copy of the chunk text for
+  every chunk containing a compound identifier, in its `chunk_parts` table;
+  both copies live inside the same `.fts5.db` file that `clear-index` removes
+  whole, so the erasure surface is unchanged.
   An incomplete cancelled rename can also preserve exact pre-rename file bytes
   inside the vault under `.enquire-rollback/<random-namespace>/`.
   The detailed sections below document their contents, permissions, and threat

--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -74,6 +74,12 @@ const BM25_WEIGHT_ALIASES = 5.0;
 // tokenize identically). A table of its own leaves `chunks` scoring
 // byte-identical to v6; parts matches are found, never ranked — see
 // `searchWithReceipts`.
+//
+// v6's `scope_tokens` is not a counter-example. It is also weight 0 and also
+// lengthens the row, but by exactly one token on EVERY row, so it shifts the
+// length normalisation uniformly and no note moves relative to another.
+// Identifier parts vary from 0 to 256 per chunk, which is what makes them
+// differential — the property that decides the column-versus-table question.
 const MAX_SOURCE_REVISION = Number.MAX_SAFE_INTEGER;
 const MAX_SOURCE_RECEIPT_BATCH = 512;
 const FTS_PERSISTENCE_FAMILY = "fts5-v1";
@@ -465,10 +471,27 @@ export interface FtsSearchHit {
   line_start: number;
   /** 1-based ending line in the source (inclusive). */
   line_end: number;
-  /** Excerpt with matched tokens wrapped in `«»` and `…` truncation markers. */
+  /**
+   * Excerpt with matched tokens wrapped in `«»` and `…` truncation markers.
+   *
+   * v7 caveat — the markers are present only when the query term occurs in the
+   * excerpted text. A hit reached through the identifier-parts pass is
+   * excerpted from that chunk's content COPY while the term that matched lives
+   * in the `parts` column, so such a snippet is a plain excerpt with no `«»`.
+   * Verified against SQLite: `snippet()` marks nothing when the match is in an
+   * unexcerpted column.
+   */
   snippet: string;
-  /** Flipped BM25 score — higher = better (the underlying FTS5 score is
-   *  negative; we negate so callers can sort descending). */
+  /**
+   * Flipped BM25 score — higher = better (the underlying FTS5 score is
+   * negative; we negate so callers can sort descending).
+   *
+   * v7 — exactly `0` is a SENTINEL, not a measurement: it marks a hit found
+   * only through the identifier-parts pass ("found, not ranked"). Those hits
+   * are appended after every ranked hit, so ordering by score keeps them last;
+   * do not read a 0 as "BM25 scored this at zero", and do not filter on
+   * `score > 0` unless dropping parts-only recall is intended.
+   */
   score: number;
   /** v2.8.0 — content-source kind. Defaults to "md" for backward compat. */
   kind: ChunkKind;
@@ -2752,7 +2775,11 @@ export class FtsIndex {
    * @param opts.sinceMtimeMs - Recency filter — only return chunks from
    *   files modified at or after this mtime.
    * @returns Provenance-bound, non-quarantined hits sorted by descending
-   *   score. Each hit carries the `source_state` mtime and monotonic revision
+   *   score. The ranked `chunks` pass runs first and is scored exactly as it
+   *   was before v7; only if it under-fills `limit` is a second pass over the
+   *   sibling `chunk_parts` table appended, with score `0` — those hits are
+   *   FOUND by the words an identifier is spelled from, never RANKED by them.
+   *   Each hit carries the `source_state` mtime and monotonic revision
    *   committed with its indexed bytes; callers that own a live {@link Vault}
    *   must compare both before exposing persisted text. Empty array if no
    *   usable query tokens or no matches.

--- a/tests/fts5.test.ts
+++ b/tests/fts5.test.ts
@@ -3167,6 +3167,43 @@ describe("FTS5 alias + title columns (v3.11.6-rc.6 C-3)", () => {
         ]);
         expect(splitIdentifierParts("cafe\u0301Latte")).toEqual(["café", "latte"]);
         expect(splitIdentifierParts("plain words only_here")).toEqual([]);
+
+        // DOCUMENTED LIMIT (C3 re-sweep). FTS5 matches per ROW, and rc.6 stores
+        // title/aliases on chunk 0 only, so a query pairing a title-only word
+        // with a word that lives in a LATER chunk matches nothing — in either
+        // pass. v7 does not change this: chunk_parts carries the chunk's
+        // content copy and its identifier parts, never the note's title. This
+        // is a pre-existing property of note-level attributes, not a v7
+        // regression: the same query returned nothing before the parts table
+        // existed. Closing it in general would need title on EVERY parts row,
+        // which relocates the rc.6 candidate-set flooding into the score-0
+        // tail — so the limit is documented rather than traded for that.
+        const spacer = Array.from({ length: 400 }, (_, i) => `filler${i}`).join(" ");
+        idx.reindexFile(
+          "Ribosome.md",
+          1000,
+          `translation overview
+
+${spacer}
+
+call buildPeptideChain here`,
+          [],
+          [],
+          "Ribosome",
+          []
+        );
+        // POSITIVE: the title word alone finds it.
+        expect(idx.search("Ribosome").map((hit) => hit.rel_path)).toContain("Ribosome.md");
+        // POSITIVE: the identifier's parts alone find it, through the v7 pass.
+        expect(idx.search("peptide chain").map((hit) => hit.rel_path)).toContain("Ribosome.md");
+        // POSITIVE — the discriminating control: the title word ANDed with a
+        // word that IS in chunk 0's own content DOES match. Without this the
+        // empty assertion below would pass for any reason at all, including a
+        // broken fixture or a non-AND parser.
+        expect(idx.search("Ribosome translation").map((hit) => hit.rel_path)).toContain("Ribosome.md");
+        // THE LIMIT: title word + a word only reachable as a later chunk's
+        // identifier part. No single row holds both.
+        expect(idx.search("Ribosome peptide")).toEqual([]);
       } finally {
         await idx.closeAndRelease();
       }

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -308,7 +308,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
     "fts-persistence-coordination.test.ts",
     { count: 1, sha256: "713c5e208f8b73dbe4423916973e77f95b6de5ecdf50ddf6ddd4d3778925c71d" }
   ],
-  ["fts5.test.ts", { count: 5, sha256: "03d161443be01cd625432f46e76f89185a9eb703060c1aff7a77553fff958357" }],
+  ["fts5.test.ts", { count: 5, sha256: "40d42fb56774acbb821324f0bb341a05be23887e57e322828a7bfd115abdab41" }],
   ["http-transport.test.ts", { count: 1, sha256: "4a199f3e843d763b7dcd9c1ea40088b3d91ca045b7c7ef6b44cec38fda3cbe5c" }],
   [
     "hnsw-sync-critical-section.test.ts",
@@ -1013,8 +1013,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
     "2dc77bab72a06575b3646c365f81d95192f7e2755b268637e608195b43674824"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
-  ["FTS route slug normalization", "93c6394fa720da93e24bfa6656ee6d5762472e2f0d80b94edb904fc6b9132042"],
-  ["FTS shadow schema fixture extension", "2824afc0fe378601b156aff4f65c413407b00bcd56fc6c1b842bd7fb7c64b0f2"],
+  ["FTS route slug normalization", "a0491c850ebdbcb11a602903586303c7ad0c9ad445936741e4a4b13b7d822391"],
+  ["FTS shadow schema fixture extension", "7b47e12f5c91f5e666519b8e44a12a8547fa21e92e0e7c809e550a5318f952cb"],
   [
     "watcher existence-guard whitespace normalization",
     "2e02b86949da126f4b7df90da07e0f01b4a1f40628ae8223f6e401ee10d7af24"


### PR DESCRIPTION
Closes the C3 re-sweep tail. **No retrieval behaviour changes** — documentation, TSDoc, and one contract test folded into an existing registration.

- **`score`** — exactly `0` is a *sentinel* meaning "found through the identifier-parts pass, not ranked", not a BM25 measurement. Stated so a caller does not filter on `score > 0` and silently drop parts-only recall.
- **`snippet`** — a parts-only hit is excerpted from that chunk's content **copy** while the term that matched lives in the `parts` column, so the excerpt carries no `«»` markers. Verified against SQLite rather than asserted.
- **`searchWithReceipts`** — the two passes and the append-under-limit rule are in the `@returns`.
- **The one shape the pass cannot reach**, documented instead of papered over: a title-only word ANDed with a word that exists only as a *later* chunk's identifier part. FTS5 matches per row and titles are stored on chunk 0 only, so no row holds both. This is pre-existing — the same query returned nothing before the parts table existed — and the general fix (title on every parts row) would relocate the candidate-set flooding that storing titles per chunk caused originally.
- **SECURITY.md** — the FTS index holds a second copy of the chunk text for identifier-bearing chunks, inside the same `.fts5.db` that `clear-index` removes whole, so the erasure surface is unchanged.
- **Why v6's weight-0 `scope_tokens` is not a counter-example** to keeping parts out of `chunks`: it lengthens every row by exactly one token, so BM25's length normalisation shifts uniformly and nothing moves relative to anything else. Identifier parts vary from 0 to 256 per chunk — that is what made them differential.

The contract test ships its discriminating control: the same title word ANDed with a word that **is** in chunk 0's own content must be **found**, so the empty assertion cannot pass on a broken fixture or a non-AND parser.

No new `it()`. Seals repinned, each controlled against `main` first — the census tool now reproduces all three of main's committed pins exactly, after its UTF-16-offset fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)