### PR TITLE
fix: every erasure receipt answers to one rule, in one place (AH-5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.7] — 2026-08-31
 
+### Every erasure receipt answers to one rule, in one place (AH-5b)
+
+> **TL;DR:** **AH-5's rule now covers the erasers that were delegated one line below it — the HNSW family, staged generations, the watcher guard, the parse cache and `prune` — and a receipt-path function that removes without it fails CI.**
+>
+> **Bounded claim.** `src/erasure-receipt.ts` is the single implementation: only `ENOENT` is idempotent success, every other failure names the artifact by BASENAME (an erasure error can reach an MCP client, and the absolute path must not), and a removal is believed only once the entry is re-statted absent. This closes receipt truth, not atomicity: a failure still leaves earlier removals done, loudly. `Vault` keeps its own root-sanitising IO wrappers and confirms through them, so its receipt is pinned by token rather than by the raw-sink detector.
+>
+> **Corrects a false claim.** The AH-5 entry below states that the persistent-cache, HNSW-generation, staged-temp and watcher-guard erasers "already followed this rule". They did not — every one of them set `removed = true` immediately after `fs.unlink`, feeding the same boolean AH-5 had just made trustworthy for the SQLite families. The post-merge re-sweep of AH-5 found it; the statement was wrong when written.
+>
+> **Method note:** mandatory post-merge re-sweep of AH-5 (6 lenses × 3 skeptics, 87 agents; 23 confirmed findings deduplicating to this class plus the docs corrections). The structural close extends the erasure manifest with a per-family `receiptMembers` list, asserted inside the existing registrations: each named function's body must contain no raw `fs.unlink`/`fs.rmdir`/`fs.rm`. Negative controls pin the detector on the exact pre-fix shape, on a directory removal, on the shared-leaf form, and on a commented-out sink.
+
 ### The v7 search contract says what the parts pass does and does not promise
 
 > **TL;DR:** **A score of exactly `0` marks a hit found only through the identifier-parts pass, a parts-only snippet carries no `«»` markers, and the one query shape the pass cannot reach is documented rather than papered over.**
@@ -24,7 +34,7 @@ All notable changes to this project will be documented here. The format follows 
 
 > **TL;DR:** **`clear-index` and `clear-embeddings` can no longer print a “removed” receipt for a file that is still on disk, and a failed removal names the exact artifact.**
 >
-> **Bounded claim.** Only `ENOENT` is idempotent success. Permission, type, busy and any other inspection or unlink failure is a visible error carrying the artifact’s basename; a successful `unlink` is believed only once the entry is re-statted absent. The persistent-cache, HNSW-generation, staged-temp and watcher-guard erasers already followed this rule and are unchanged.
+> **Bounded claim.** Only `ENOENT` is idempotent success. Permission, type, busy and any other inspection or unlink failure is a visible error carrying the artifact’s basename; a successful `unlink` is believed only once the entry is re-statted absent. The persistent-cache, HNSW-generation, staged-temp and watcher-guard erasers are unchanged by this entry — see the AH-5b entry above, which corrects the claim originally made here that they already followed the rule, and brings them under it.
 >
 > **Method note:** BACKLOG **AH-5**. Controls: injected non-`ENOENT` unlink failure on the FTS main file and a “successful” unlink that leaves the WAL in place both reject with the named artifact and leave every sentinel byte intact; a mode-0500 index directory makes the compiled `clear-index` exit non-zero with no receipt on stdout; a missing file still returns the idempotent “no fts5 index files” path.
 

--- a/src/cache-prune.ts
+++ b/src/cache-prune.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { removeArtifact } from "./erasure-receipt.js";
 import { planCachePruneOnDisk } from "./fts5.js";
 import { acquirePersistenceNamespaceEraser } from "./persistence-coordination.js";
 import { PersistenceLeaseIntegrityError, revalidatePersistenceLeaseScope } from "./persistence-lease.js";
@@ -111,10 +112,10 @@ export async function executeCachePrune(cacheDir: string, keepHash: string): Pro
           const removedGenerated = await removeSensitiveArtifactTempEntry(target);
           if (!removedGenerated) throw new Error("artifact changed after prune preflight");
         } else {
-          await fs.unlink(target);
+          await removeArtifact(target, "preflighted cache artifact");
         }
       } catch (error) {
-        throw new Error("Unable to remove a preflighted cache artifact", { cause: error });
+        throw new Error(`Unable to remove a preflighted cache artifact: ${name}`, { cause: error });
       }
       await revalidatePersistenceLeaseScope(eraser.scope);
       removed += 1;

--- a/src/embed-db.ts
+++ b/src/embed-db.ts
@@ -21,6 +21,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { removeArtifact } from "./erasure-receipt.js";
 import { clearHnswPersistedArtifactsWithEraser, preflightHnswPersistedArtifacts } from "./hnsw.js";
 import { optionalDepDetail } from "./optional-dep.js";
 import {
@@ -1589,27 +1590,10 @@ export class EmbedDb {
         }
         await this.revalidatePersistenceScopes();
         for (const p of targets) {
-          try {
-            await fs.unlink(p);
-            removed = true;
-          } catch (err) {
-            if (errnoCode(err) !== "ENOENT") {
-              // Recovery must never report success while a permission/type/race
-              // error leaves a derived-data sidecar behind.
-              throw new Error(`Unable to remove embedding-index artifact: ${path.basename(p)}`, { cause: err });
-            }
-            continue;
-          }
-          // AH-5 — a removal is believed only once the entry is re-statted absent.
-          try {
-            await fs.lstat(p);
-          } catch (err) {
-            if (errnoCode(err) === "ENOENT") continue;
-            throw new Error(`Unable to confirm removal of embedding-index artifact: ${path.basename(p)}`, {
-              cause: err
-            });
-          }
-          throw new Error(`Embedding-index artifact still present after removal: ${path.basename(p)}`);
+          // Recovery must never report success while a permission/type/race
+          // error leaves a derived-data sidecar behind, and a removal is
+          // believed only once the entry is re-statted absent.
+          removed = (await removeArtifact(p, "embedding-index artifact")) || removed;
         }
         await this.revalidatePersistenceScopes();
         removed = (await clearHnswPersistedArtifactsWithEraser(hnswBase, eraserCapability)) || removed;

--- a/src/erasure-receipt.ts
+++ b/src/erasure-receipt.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+/**
+ * The one rule every erasure receipt in this product answers to.
+ *
+ * AH-5 established it for the two SQLite families: only `ENOENT` is idempotent
+ * success, every other failure names the artifact it could not remove, and a
+ * successful `unlink` is believed only once the entry is re-statted absent —
+ * so no command can print "removed" for a file that is still on disk. The
+ * post-merge re-sweep then found the rule applied to the loop AH-5 was pointed
+ * at and not to the erasers delegated one line below it (the HNSW family, the
+ * staged temps, the watcher guard, the parse cache and `prune`), all of which
+ * feed the SAME `removed` boolean. This leaf exists so the rule has one
+ * implementation instead of six, and so a new eraser inherits it by
+ * construction; `tests/erasure-invariant.test.ts` fails CI on a receipt-path
+ * function that unlinks without it.
+ *
+ * Paths are reported by BASENAME only: an erasure error can reach an MCP client
+ * through a tool response, and the absolute vault/cache path is exactly what
+ * the abs-path-leak class forbids exposing.
+ *
+ * @module
+ */
+
+function errnoCode(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null || !("code" in err)) return undefined;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+/** The canonical failure when a removal could not be attempted or completed. */
+export function artifactRemovalError(label: string, target: string, cause: unknown): Error {
+  return new Error(`Unable to remove ${label}: ${path.basename(target)}`, { cause });
+}
+
+/**
+ * Prove an entry is gone after a removal that reported success.
+ *
+ * @param target - Absolute path just removed.
+ * @param label - Human-readable artifact class, used verbatim in the message.
+ * @throws If the entry is still present, or if its absence cannot be established.
+ * @example
+ * await fs.unlink(file);
+ * await assertArtifactAbsent(file, "FTS index artifact");
+ */
+export async function assertArtifactAbsent(target: string, label: string): Promise<void> {
+  try {
+    await fs.lstat(target);
+  } catch (err) {
+    if (errnoCode(err) === "ENOENT") return;
+    throw new Error(`Unable to confirm removal of ${label}: ${path.basename(target)}`, { cause: err });
+  }
+  throw new Error(`${label} still present after removal: ${path.basename(target)}`);
+}
+
+/**
+ * Remove one file and return whether it existed, under the receipt rule.
+ *
+ * @param target - Absolute path to remove.
+ * @param label - Human-readable artifact class for any failure message.
+ * @returns `true` when an entry was removed, `false` when it was already absent.
+ * @throws If the removal fails for any reason other than `ENOENT`, or if the
+ *   entry survives a removal that reported success.
+ * @example
+ * const removed = await removeArtifact(sidecar, "HNSW artifact");
+ */
+export async function removeArtifact(target: string, label: string): Promise<boolean> {
+  try {
+    await fs.unlink(target);
+  } catch (err) {
+    if (errnoCode(err) === "ENOENT") return false;
+    throw artifactRemovalError(label, target, err);
+  }
+  await assertArtifactAbsent(target, label);
+  return true;
+}
+
+/**
+ * Remove one directory entry under the same rule as {@link removeArtifact}.
+ *
+ * @param target - Absolute directory path to remove.
+ * @param label - Human-readable artifact class for any failure message.
+ * @returns `true` when a directory was removed, `false` when already absent.
+ * @throws If the removal fails for any reason other than `ENOENT`, or if the
+ *   directory survives a removal that reported success.
+ * @example
+ * await removeArtifactDirectory(guardPath, "watcher activation guard directory");
+ */
+export async function removeArtifactDirectory(target: string, label: string): Promise<boolean> {
+  try {
+    await fs.rmdir(target);
+  } catch (err) {
+    if (errnoCode(err) === "ENOENT") return false;
+    throw artifactRemovalError(label, target, err);
+  }
+  await assertArtifactAbsent(target, label);
+  return true;
+}

--- a/src/fts5.ts
+++ b/src/fts5.ts
@@ -15,6 +15,7 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { removeArtifact } from "./erasure-receipt.js";
 import { foldName, lookupFoldedKey } from "./name-fold.js";
 import { optionalDepDetail } from "./optional-dep.js";
 import {
@@ -35,21 +36,6 @@ import {
 import { iterateContentLines } from "./structure.js";
 import { MAX_INDEX_SYNC_FILES, MAX_INDEX_SYNC_VISITED_ENTRIES, type Vault } from "./vault.js";
 import { stripTrailingSlashes } from "./wildcard-match.js";
-
-/**
- * AH-5 — an erasure receipt is only truthful when the entry is gone. Re-stat
- * after a successful unlink; anything but ENOENT (still present, or a parent
- * that cannot be inspected any more) is a visible failure naming the artifact.
- */
-async function assertArtifactAbsent(target: string, label: string): Promise<void> {
-  try {
-    await fs.lstat(target);
-  } catch (err) {
-    if (errnoCode(err) === "ENOENT") return;
-    throw new Error(`Unable to confirm removal of ${label}: ${path.basename(target)}`, { cause: err });
-  }
-  throw new Error(`${label} still present after removal: ${path.basename(target)}`);
-}
 
 function errnoCode(err: unknown): string | undefined {
   if (typeof err !== "object" || err === null || !("code" in err)) return undefined;
@@ -1356,16 +1342,7 @@ export class FtsIndex {
         // failure names the exact artifact, and a removal is believed only once
         // the entry is re-statted absent, so the CLI receipt never says
         // "removed" for a file that is still there.
-        try {
-          await fs.unlink(target);
-          removed = true;
-        } catch (err) {
-          if (errnoCode(err) !== "ENOENT") {
-            throw new Error(`Unable to remove FTS index artifact: ${path.basename(target)}`, { cause: err });
-          }
-          continue;
-        }
-        await assertArtifactAbsent(target, "FTS index artifact");
+        removed = (await removeArtifact(target, "FTS index artifact")) || removed;
       }
       await this.revalidateEraser(eraser.scopes);
     } catch (error) {

--- a/src/hnsw.ts
+++ b/src/hnsw.ts
@@ -46,6 +46,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
+import { removeArtifact } from "./erasure-receipt.js";
 import type { EmbedReceiptSearchHit, EmbedSearchHit } from "./embed-db.js";
 import { importOptionalDependency, optionalDepDetail } from "./optional-dep.js";
 import {
@@ -1666,12 +1667,7 @@ async function clearHnswPersistedArtifactsUnchecked(file: string): Promise<boole
       removed = (await removeSensitiveArtifactTempEntry(entry.entryPath)) || removed;
       continue;
     }
-    try {
-      await fs.unlink(entry.entryPath);
-      removed = true;
-    } catch (err) {
-      if (errnoCode(err) !== "ENOENT") throw err;
-    }
+    removed = (await removeArtifact(entry.entryPath, "HNSW artifact")) || removed;
   }
   return removed;
 }

--- a/src/hnsw.ts
+++ b/src/hnsw.ts
@@ -46,8 +46,8 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { removeArtifact } from "./erasure-receipt.js";
 import type { EmbedReceiptSearchHit, EmbedSearchHit } from "./embed-db.js";
+import { removeArtifact } from "./erasure-receipt.js";
 import { importOptionalDependency, optionalDepDetail } from "./optional-dep.js";
 import {
   acquirePersistenceFamilyLease,

--- a/src/sensitive-artifact.ts
+++ b/src/sensitive-artifact.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fs, constants as fsConstants } from "node:fs";
+import { removeArtifact, removeArtifactDirectory } from "./erasure-receipt.js";
 import * as path from "node:path";
 
 const TOKEN_BYTES = 24;
@@ -443,12 +444,14 @@ export async function removeSensitiveArtifactTempEntry(entryPath: string): Promi
   const inspected = await inspectSensitiveArtifactTempEntry(entryPath);
   if (!inspected) return false;
   if (inspected.generated.kind === "tmp") {
-    await fs.unlink(entryPath);
+    await removeArtifact(entryPath, "generated temporary artifact");
     return true;
   }
   await removeInspectedEmptyEmbedLeaseNamespace(entryPath, inspected.leaseScopeDirectories);
-  for (const child of orderedStagedChildrenForRemoval(inspected)) await fs.unlink(path.join(entryPath, child));
-  await fs.rmdir(entryPath);
+  for (const child of orderedStagedChildrenForRemoval(inspected)) {
+    await removeArtifact(path.join(entryPath, child), "staged generation member");
+  }
+  await removeArtifactDirectory(entryPath, "staged generation directory");
   return true;
 }
 

--- a/src/sensitive-artifact.ts
+++ b/src/sensitive-artifact.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { promises as fs, constants as fsConstants } from "node:fs";
-import { removeArtifact, removeArtifactDirectory } from "./erasure-receipt.js";
 import * as path from "node:path";
+import { removeArtifact, removeArtifactDirectory } from "./erasure-receipt.js";
 
 const TOKEN_BYTES = 24;
 const TOKEN_HEX_LENGTH = TOKEN_BYTES * 2;

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -1040,10 +1040,18 @@ export class Vault {
     for (const target of [file, `${file}.tmp`]) {
       try {
         await this.unlinkSafe(target);
-        removed = true;
       } catch (err) {
         if (!(isErrnoException(err) && err.code === "ENOENT")) throw err;
+        continue;
       }
+      // The parse cache holds full note bodies, so its receipt is the one that
+      // must not lie: believe the removal only once the entry is re-statted
+      // absent. `lstatIfExistsSafe` keeps the vault root out of any error the
+      // way every other Vault sink does.
+      if ((await this.lstatIfExistsSafe(target)) !== null) {
+        throw new Error(`Persistent-cache artifact still present after removal: ${path.basename(target)}`);
+      }
+      removed = true;
     }
     removed = (await removeSensitiveArtifactTemps(file)) > 0 || removed;
     return removed;

--- a/src/watcher-activation-guard.ts
+++ b/src/watcher-activation-guard.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { promises as fs, constants as fsConstants } from "node:fs";
 import * as path from "node:path";
+import { removeArtifact, removeArtifactDirectory } from "./erasure-receipt.js";
 import { assertEmbedDbFilePath } from "./persistence-path.js";
 
 const ACTIVATION_GUARD_VERSION = 1;
@@ -248,12 +249,12 @@ export async function clearWatcherActivationGuard(embedDbFile: string): Promise<
   const { guardPath, childName } = recovery;
 
   if (childName) {
-    await fs.unlink(path.join(guardPath, childName));
+    await removeArtifact(path.join(guardPath, childName), "watcher activation guard entry");
     await syncDirectory(guardPath);
   }
 
   try {
-    await fs.rmdir(guardPath);
+    await removeArtifactDirectory(guardPath, "watcher activation guard directory");
   } catch (err) {
     throw new Error("Unable to remove watcher activation guard directory during recovery", { cause: err });
   }

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1134,6 +1134,7 @@ describe("runDoctor — strict source-state preservation", () => {
     const validChunks =
       "content, title, aliases, scope_tokens, rel_path UNINDEXED, chunk_index UNINDEXED, " +
       "line_start UNINDEXED, line_end UNINDEXED, tags UNINDEXED, raw_content UNINDEXED, kind UNINDEXED";
+    const partsTokenizerWithExtraOption = "tokenize='unicode61 remove_diacritics 2', columnsize=0";
     const partsReceipts =
       "rel_path UNINDEXED, chunk_index UNINDEXED, line_start UNINDEXED, line_end UNINDEXED, " +
       "tags UNINDEXED, kind UNINDEXED";
@@ -1164,7 +1165,7 @@ describe("runDoctor — strict source-state preservation", () => {
         // their order are exactly right, and an extra FTS5 option is invisible
         // to PRAGMA table_info.
         slug: "parts-extra-option",
-        chunkParts: `content, parts, scope_tokens, ${partsReceipts}, tokenize='unicode61 remove_diacritics 2', columnsize=0`,
+        chunkParts: `content, parts, scope_tokens, ${partsReceipts}, ${partsTokenizerWithExtraOption}`,
         expected: "chunk_parts has unsupported FTS5 option(s): columnsize"
       },
       {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1164,8 +1164,7 @@ describe("runDoctor — strict source-state preservation", () => {
         // their order are exactly right, and an extra FTS5 option is invisible
         // to PRAGMA table_info.
         slug: "parts-extra-option",
-        chunkParts:
-          `content, parts, scope_tokens, ${partsReceipts}, ` + "tokenize='unicode61 remove_diacritics 2', columnsize=0",
+        chunkParts: `content, parts, scope_tokens, ${partsReceipts}, tokenize='unicode61 remove_diacritics 2', columnsize=0`,
         expected: "chunk_parts has unsupported FTS5 option(s): columnsize"
       },
       {

--- a/tests/embed-db.test.ts
+++ b/tests/embed-db.test.ts
@@ -1772,7 +1772,7 @@ describe("EmbedDb", () => {
     });
     try {
       await expect(db.clearOnDisk()).rejects.toThrow(
-        `Embedding-index artifact still present after removal: ${path.basename(wal)}`
+        `embedding-index artifact still present after removal: ${path.basename(wal)}`
       );
     } finally {
       spy.mockRestore();

--- a/tests/erasure-invariant.test.ts
+++ b/tests/erasure-invariant.test.ts
@@ -254,13 +254,20 @@ const ERASURE_MANIFEST = [
         member: "expectedHnswBasename",
         requiredTokens: ["isHnswGenerationBasename("]
       }
+    ],
+    receiptMembers: [
+      { file: "src/embed-db.ts", member: "clearOnDisk" },
+      { file: "src/hnsw.ts", member: "clearHnswPersistedArtifactsUnchecked" },
+      { file: "src/sensitive-artifact.ts", member: "removeSensitiveArtifactTempEntry" },
+      { file: "src/watcher-activation-guard.ts", member: "clearWatcherActivationGuard" }
     ]
   },
   {
     family: "FTS5 index + SQLite WAL/SHM/rollback-journal sidecars",
     file: "src/fts5.ts",
     eraser: "clearOnDisk",
-    requiredTokens: ["-wal", "-shm", "-journal"]
+    requiredTokens: ["-wal", "-shm", "-journal"],
+    receiptMembers: [{ file: "src/fts5.ts", member: "clearOnDisk" }]
   },
   {
     family: "parse cache + atomic-write temp (full note bodies)",
@@ -280,11 +287,41 @@ const ERASURE_MANIFEST = [
       {
         file: "src/vault.ts",
         member: "clearDiskCacheOnce",
-        requiredTokens: [".tmp", "preflightSensitiveArtifactTemps(file)", "removeSensitiveArtifactTemps(file)"]
+        requiredTokens: [
+          ".tmp",
+          "preflightSensitiveArtifactTemps(file)",
+          "removeSensitiveArtifactTemps(file)",
+          // Vault removes through its own root-sanitising wrapper, so the raw-sink
+          // detector cannot see it; pin the confirm by token instead.
+          "still present after removal"
+        ]
       }
+    ],
+    receiptMembers: [
+      { file: "src/vault.ts", member: "clearDiskCacheOnce" },
+      { file: "src/cache-prune.ts", member: "executeCachePrune" }
     ]
   }
 ] as const;
+
+// ── AH-5b (post-merge re-sweep): RECEIPT TRUTH. Above proves an eraser reaches
+// every suffix of its family. This proves it does not LIE about having done so.
+// AH-5 gave the two SQLite loops the rule — only ENOENT is idempotent success,
+// every other failure names the artifact, and an unlink is believed only once
+// the entry is re-statted absent — and the re-sweep found the erasers delegated
+// one line below still setting `removed = true` straight after `fs.unlink`,
+// feeding the SAME receipt. `src/erasure-receipt.ts` is now the single
+// implementation, so a receipt-path function must not call the raw sinks at
+// all. Pure detector, negative-controlled below. ──
+const RAW_ERASURE_SINK = /\bfs\.(?:unlink|rmdir|rm)\s*\(/;
+
+/** Pure: the raw removal sinks a receipt-path function must not call directly. */
+function rawErasureSinks(body: string): string[] {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => !line.startsWith("//") && !line.startsWith("*") && RAW_ERASURE_SINK.test(line));
+}
 
 /** Slice a 2-space-indented class method body: from `async <name>(` through its
  *  own closing `\n  }` (deeper-indented nested closers like `\n    }` don't
@@ -4952,6 +4989,19 @@ describe("erasure-completeness invariant (rc.36, P-2 class)", () => {
             `${route.file}#${route.member} is missing a delegated family token`
           ).toEqual([]);
         }
+        // Receipt truth: every function whose removals feed this family's
+        // "removed" boolean must route through `src/erasure-receipt.ts`, never
+        // a raw fs sink — otherwise the receipt can claim an artifact was
+        // erased while it is still on disk.
+        for (const receipt of "receiptMembers" in m ? m.receiptMembers : []) {
+          const receiptSource = readFileSync(path.join(repoRoot, receipt.file), "utf8");
+          const receiptBodies = runtimeMemberBodies(receiptSource, receipt.file, receipt.member);
+          expect(receiptBodies, `${receipt.file}#${receipt.member} must resolve exactly once`).toHaveLength(1);
+          expect(
+            rawErasureSinks(receiptBodies[0] ?? ""),
+            `${receipt.file}#${receipt.member} removes without the shared erasure receipt`
+          ).toEqual([]);
+        }
       });
     }
 
@@ -4962,6 +5012,14 @@ describe("erasure-completeness invariant (rc.36, P-2 class)", () => {
       const missing = missingErasureTokens(buggy, ["-wal", "-shm", ".hnsw", ".bin", ".meta.json"]);
       expect(missing).toContain(".meta.json"); // the rc.34 P-2 leak suffix
       expect(missing).toContain("-shm");
+
+      // NEGATIVE control for receipt truth: the pre-AH-5b shape — believing an
+      // unlink without confirming it — must be flagged, and the shared-leaf
+      // form must not be. A commented-out sink must not count either.
+      expect(rawErasureSinks("await fs.unlink(entry);\nremoved = true;")).toHaveLength(1);
+      expect(rawErasureSinks("await fs.rmdir(guardPath);")).toHaveLength(1);
+      expect(rawErasureSinks('removed = await removeArtifact(entry, "HNSW artifact");')).toEqual([]);
+      expect(rawErasureSinks("// await fs.unlink(entry);")).toEqual([]);
     });
 
     // NEGATIVE control: extractMethod must isolate the method body (so a token in

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -986,13 +986,13 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["GitHub environment-token redaction", "d8ab2f87a80b4c0cbe4af8bf3e0f59391219109390fb4f6bcac01b23d41cda65"],
   ["GitHub authorization-header redaction", "d8ab2f87a80b4c0cbe4af8bf3e0f59391219109390fb4f6bcac01b23d41cda65"],
   ["GitHub diagnostic whitespace compaction", "d8ab2f87a80b4c0cbe4af8bf3e0f59391219109390fb4f6bcac01b23d41cda65"],
-  ["erasure source-path separator normalization", "04ffd632f663d469e7eed90a35790073c422c58ffeec1ddbde2409f3a2c56f46"],
-  ["SQLite positive-shape label normalization", "09a46a07c3b1dbf7a9bd84f05d445a665bdbfbc65a2a19c2215ad53957e69f84"],
-  ["SQLite suffix label normalization", "12a6cec320d4e156c5f696d4c5a86654f1e69b24c23b7f91d93a2f033810f637"],
-  ["sensitive-reader kind label normalization", "6ec8abdb9f452fb9f6410a5b56a075c842ea120510a9f589c45b2a5df6e075d6"],
-  ["sensitive-reader growth label normalization", "c370cb610800d11331ed2bf5d875646eaefeabc7aa2552ab82c2a83e34ff8b3d"],
-  ["publisher kind label normalization", "b6150d5505863137def2c129c515cd4d919c5ebdc539426e61c9762a545a718c"],
-  ["hardlink route label normalization", "08a10a651414f0ea82679e9bff6dff2f7eabd364fd7d0cb494ab7a934bd16248"],
+  ["erasure source-path separator normalization", "851cf48b95b65e1ca34c1ee28ec0a559318947ab3b7f38bad4a08453b2b600ef"],
+  ["SQLite positive-shape label normalization", "8cd749d3f37477e0b137173caaf3d713d9c2f6ed1af9a12e5d71d486318284c7"],
+  ["SQLite suffix label normalization", "58e97e1e7ab1256926369696ae379ba208b1630834a6477dab71c94c0b68bce2"],
+  ["sensitive-reader kind label normalization", "9a848bd1b46336998059cacbcf8d9a564e8254c433e13d39f84f79d982d50c17"],
+  ["sensitive-reader growth label normalization", "eff19c303571dc1ba9a7678568daa5104a2cc401eeaa0e5e55413fc8bfe8c8ed"],
+  ["publisher kind label normalization", "8a4fc482841f114ef2a8a593e8ef792301a7014c6554d39312fbbd76d45707f8"],
+  ["hardlink route label normalization", "dbbd01a772c73e3108112cabeec5412e749761b71fb44066187aab5847ef461b"],
   ["K-1 statement semicolon normalization", "9bb382eb2d071464957b3c6cec271cb2a843dfeeabd9225c92e4497597d839ef"],
   ["K-1 block-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
   ["K-1 line-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
@@ -1005,12 +1005,12 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["ReDoS catastrophic control transform", "99358421ccbe92052218efb7bcf19e31029854d36548144c4a1ac4d68ec5540b"],
   [
     "Embed synchronous admission label normalization",
-    "65738e9c64b19cc053a600e58fa7da9cdb8a82d9165584c951abd6913a524da5"
+    "067b0f3da66ba515ca37cd8f74e253d9fddf0f3919a67c52a361eea06b29ccbf"
   ],
-  ["Embed sidecar route label normalization", "316e14d33eec19c95840ea3c54d82c4773416625a364df491761a9c6f85e41dc"],
+  ["Embed sidecar route label normalization", "f4871baa256234b783529193cddc1c701b234648022d789f35e29b8ff2ffc87c"],
   [
     "Embed malformed-generation value normalization",
-    "2dc77bab72a06575b3646c365f81d95192f7e2755b268637e608195b43674824"
+    "d2d4751061087305b4b125064d6330b3a4e9ff28f618c93d06ed5a9e42438bd4"
   ],
   ["embedding index extension mapping", "9b30b5965abe1f6de24f5b0de8392a92859489f735556e39c5f83bac285d87d1"],
   ["FTS route slug normalization", "a0491c850ebdbcb11a602903586303c7ad0c9ad445936741e4a4b13b7d822391"],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -294,7 +294,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "erasure-invariant.test.ts",
-    { count: 105, sha256: "4a58437359c826c444ea81fb4427503ff2e05fd2e3a7c142ecb9cd09e3e23407" }
+    { count: 105, sha256: "c3615365636384eb257dfdb1ded27bafdabf8712a576d2d98879e6e67f84df37" }
   ],
   [
     "embeddings-offline.test.ts",


### PR DESCRIPTION
Mandatory post-merge re-sweep of **AH-5** (#598) — 6 lenses × 3 skeptics, 87 agents, 23 confirmed findings that deduplicate to one class plus its documentation corrections.

**What the re-sweep found.** AH-5 gave the two SQLite loops the receipt rule and left the erasers delegated *one line below* untouched — the HNSW family, staged generations, the watcher guard, the parse cache and `prune` each set `removed = true` straight after `fs.unlink`, feeding the **same** boolean AH-5 had just made trustworthy. The project's signature shape: the fix hardened what it was pointed at and recursed its own class one delegation down.

**It also found a false claim I shipped.** The AH-5 CHANGELOG says those four erasers "already followed this rule". They did not. Corrected here, in the entry, rather than quietly.

**The close**

- `src/erasure-receipt.ts` — one implementation. Only `ENOENT` is idempotent success; every other failure names the artifact by **basename** (an erasure error can reach an MCP client, so the absolute path must not appear); a removal is believed only once the entry is re-statted absent.
- `fts5`, `embed-db`, `hnsw`, `sensitive-artifact`, `watcher-activation-guard`, `cache-prune` route through it. `Vault` keeps its own root-sanitising IO wrappers and confirms through them, so its receipt is pinned by token instead of by the raw-sink detector.
- **Structural close:** the erasure manifest gains a per-family `receiptMembers` list, asserted inside the existing registrations — a receipt-path function body must contain no raw `fs.unlink`/`fs.rmdir`/`fs.rm`. This is what makes the *next* eraser inherit the rule instead of relying on someone remembering it.

**Bounded claim.** This closes receipt truth, not atomicity: a failure still leaves earlier removals done, loudly. Severity is MED, not HIGH — both `clearOnDisk` call sites are CLI-only, and every ordinary error (EACCES/EPERM/EBUSY) already failed closed; the residual was a filesystem reporting success from `unlink(2)` while the entry survives, plus unnamed errors.

Negative controls pin the detector on the exact pre-fix shape, on a directory removal, on the shared-leaf form, and on a commented-out sink. No new `it()`. Ten owner hashes repinned, each controlled against `main` first.

Follow-ups recorded, not silently dropped: the current vault's `feedback.json` is erasable by no command while SECURITY.md names `prune` as the right-to-erasure path; `prune`'s ENOENT handling; naming on the remaining embed-db/vault preflight messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)