### PR TITLE
feat: resources/list answers a large vault with a page, not an error (AH-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [4.0.0-rc.7] — 2026-08-31
 
+### `resources/list` answers a large vault with a page instead of an error (AH-6)
+
+> **TL;DR:** **A vault past the inventory budget used to get a JSON-RPC error from every `resources/list`; it now gets a bounded page and an opaque continuation cursor.**
+>
+> **Why it was a defect, not just a limit.** The specification is explicit: a server that declares the `resources` capability MUST respond to `resources/list` with the set of resources available to the client. Answering with an error is not one of the sanctioned ways to decline — returning an empty set is, throwing is not. The old behaviour therefore failed that MUST for every client of a vault over the file/entry budget.
+>
+> **Bounded claim — the protocol's own consistency floor, not more.** The spec states there is no cross-page consistency guarantee and that "if the underlying data changes between page fetches, clients may observe duplicates or gaps"; a client needing a coherent snapshot re-fetches from the beginning without a cursor. This server holds no snapshot and claims nothing stronger: within one unchanged vault the pages partition the listing exactly once in a deterministic order, and a note created or deleted between pages changes what later pages contain. A cursor this server did not mint is refused with `-32602`, which is what the spec asks for an invalid cursor. Page size is server-chosen (the spec forbids clients assuming a fixed one); it is 500 notes here, so an ordinary vault still answers in a single page.
+>
+> **Method note:** the SDK's high-level resource API structurally cannot paginate — a `ResourceTemplate`'s `list` callback receives no request params, so an inbound cursor never reaches it, and the SDK rebuilds the reply from `result.resources` alone, so an outbound `nextCursor` is dropped. `resources/list` is therefore taken over by a raw handler installed AFTER registration (registering first and replacing later is required: the reverse order makes the registration itself throw). Both resource descriptions now come from one exported constant used by the registration and the page alike, so the merged wire shape cannot drift between them. Privacy filtering happens inside the walk, so an excluded note is absent before anything is counted or cut.
+
 ### `clear-feedback` erases the active vault's marks (AH-5c)
 
 > **TL;DR:** **The closed-loop feedback sidecar of the vault you are USING is now erasable by a command.**

--- a/src/resource-admission.ts
+++ b/src/resource-admission.ts
@@ -1,3 +1,4 @@
+import { type McpServer, ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
 import type { FtsIndex } from "./fts5.js";
 import { readLiveFtsChunk } from "./tools/index.js";
 import type { Vault } from "./vault.js";
@@ -295,4 +296,46 @@ export async function readChunkResource(
   return {
     contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify(payload, null, 2) }]
   };
+}
+
+/**
+ * Take ownership of `resources/list` so a large vault gets a bounded PAGE
+ * instead of an error.
+ *
+ * Why a raw handler: the SDK's own `resources/list` cannot paginate in either
+ * direction — a `ResourceTemplate`'s `list` callback receives no request params
+ * (so an inbound cursor never reaches it) and the SDK rebuilds the reply from
+ * `result.resources` alone (so an outbound `nextCursor` is dropped). Installed
+ * AFTER `registerResources`, whose registration puts the SDK's handler in place
+ * first; a later `setRequestHandler` replaces it, while doing this BEFORE
+ * registration would make the registration itself throw.
+ *
+ * The protocol requires a server advertising the `resources` capability to
+ * answer with the set of available resources. Before this, a vault beyond the
+ * inventory budget answered every `resources/list` with an error instead.
+ *
+ * @param server - The MCP server whose method is being replaced.
+ * @param vault - Live path/privacy authority for the listing.
+ * @returns Nothing; the handler is installed as a side effect.
+ * @example
+ * registerResources(server, vault);
+ * registerPagedResourceList(server, vault);
+ */
+export function registerPagedResourceList(server: McpServer, vault: Vault): void {
+  server.server.setRequestHandler("resources/list", async (request: { params?: { cursor?: unknown } }) => {
+    const raw = request.params?.cursor;
+    if (raw !== undefined && typeof raw !== "string") {
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, "resources/list cursor must be a string");
+    }
+    try {
+      return await pageVaultResources(vault, raw);
+    } catch (error) {
+      if (error instanceof ResourceCursorError) {
+        // The specification asks for -32602 on a cursor the server did not
+        // mint; the client's documented recovery is to restart without one.
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, error.message);
+      }
+      throw error;
+    }
+  });
 }

--- a/src/resource-admission.ts
+++ b/src/resource-admission.ts
@@ -39,6 +39,146 @@ export function decodeNotePath(uriPath: string): string {
 }
 
 /**
+ * Registration metadata for the two resource entries, defined ONCE here so the
+ * `resources/list` page and the SDK registration in `tool-registry.ts` cannot
+ * describe the same resource differently. The SDK merges a template entry as
+ * `{ ...templateMetadata, ...resource }` and a static entry as
+ * `{ uri, name, ...metadata }`, so {@link mergeResourcePage} below reproduces
+ * exactly that shape rather than inventing its own.
+ */
+export const VAULT_INFO_RESOURCE = {
+  name: "vault-info",
+  uri: "obsidian://vault/info",
+  metadata: {
+    title: "Vault metadata",
+    description: "Root path, note count, write-enabled flag, and limits for the connected vault.",
+    mimeType: "application/json"
+  }
+} as const;
+
+/** See {@link VAULT_INFO_RESOURCE}. */
+export const VAULT_NOTE_TEMPLATE_METADATA = {
+  title: "Vault notes",
+  description: "Each markdown note in the vault, addressable via `obsidian://note/<relative-path>`.",
+  mimeType: "text/markdown"
+} as const;
+
+/**
+ * Notes per `resources/list` page. The protocol leaves page size entirely to
+ * the server ("clients MUST NOT assume a fixed page size"), so this is a free
+ * choice: large enough that an ordinary vault answers in one page, small enough
+ * that a page stays far inside the serialized-byte rail.
+ */
+export const RESOURCE_PAGE_LIMIT = 500;
+
+/** Raised when a client supplies a cursor this server did not mint. */
+export class ResourceCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResourceCursorError";
+  }
+}
+
+const CURSOR_PREFIX = "v1:";
+const MAX_CURSOR_CHARS = 4096;
+
+/**
+ * Mint the opaque continuation token for a page that ended at `lastRelPath`.
+ *
+ * The protocol requires the token be opaque to clients; it does NOT require it
+ * to be unguessable, and this one deliberately carries no vault-identifying
+ * material beyond a path the same response already returned.
+ *
+ * @param lastRelPath - Canonical vault-relative path of the page's final note.
+ * @returns A base64url token to hand back as `nextCursor`.
+ * @example
+ * const nextCursor = encodeResourceCursor("Projects/plan.md");
+ */
+export function encodeResourceCursor(lastRelPath: string): string {
+  return Buffer.from(`${CURSOR_PREFIX}${lastRelPath}`, "utf8").toString("base64url");
+}
+
+/**
+ * Recover the resume position from a client-supplied cursor.
+ *
+ * @param cursor - Exact token previously returned as `nextCursor`.
+ * @returns The vault-relative path the next page must start strictly after.
+ * @throws {ResourceCursorError} If the token is not one this server minted. The
+ *   caller maps this to JSON-RPC `-32602`, which is what the specification asks
+ *   for an invalid cursor. Note an EMPTY STRING is a legal cursor value per the
+ *   spec, so it is decoded like any other — never treated as "start" or "end".
+ * @example
+ * decodeResourceCursor(encodeResourceCursor("a.md")); // "a.md"
+ */
+export function decodeResourceCursor(cursor: string): string {
+  if (cursor.length > MAX_CURSOR_CHARS) throw new ResourceCursorError("Invalid resources/list cursor");
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, "base64url").toString("utf8");
+  } catch {
+    throw new ResourceCursorError("Invalid resources/list cursor");
+  }
+  if (!decoded.startsWith(CURSOR_PREFIX)) throw new ResourceCursorError("Invalid resources/list cursor");
+  const relPath = decoded.slice(CURSOR_PREFIX.length);
+  // A minted cursor always names a real, non-empty path; anything else is a
+  // token this server did not produce (or a truncated one).
+  if (relPath.length === 0 || relPath.includes("\u0000")) {
+    throw new ResourceCursorError("Invalid resources/list cursor");
+  }
+  return relPath;
+}
+
+/**
+ * One page of the `resources/list` reply.
+ *
+ * BOUNDED CLAIM — this is the protocol's own consistency floor, not more. The
+ * specification states plainly that there is no cross-page consistency
+ * guarantee and that "if the underlying data changes between page fetches,
+ * clients may observe duplicates or gaps"; a client needing a coherent snapshot
+ * re-fetches from the beginning without a cursor. This server does not pretend
+ * otherwise: it holds no snapshot, and a note created or deleted between pages
+ * changes what later pages contain. What IS guaranteed: within one unchanged
+ * vault the pages partition the listing exactly once, in a deterministic order.
+ *
+ * @param vault - Live path/privacy authority. Privacy filtering happens inside
+ *   the walk, so an excluded note is absent before anything is counted or cut.
+ * @param cursor - Continuation from a previous page, or undefined for the first.
+ * @returns The page's entries in the SDK's own merged wire shape, plus a
+ *   `nextCursor` when more notes remain.
+ * @throws {ResourceCursorError} On a cursor this server did not mint.
+ * @throws {Error} If the bounded traversal could not complete — the vault
+ *   exceeds the file/entry budget, which no page size can fix.
+ * @example
+ * const first = await pageVaultResources(vault);
+ * const second = first.nextCursor ? await pageVaultResources(vault, first.nextCursor) : null;
+ */
+export async function pageVaultResources(
+  vault: Vault,
+  cursor?: string
+): Promise<{ resources: Array<Record<string, unknown>>; nextCursor?: string }> {
+  const after = cursor === undefined ? null : decodeResourceCursor(cursor);
+  const notes = await listVaultNoteResources(vault);
+  const start = after === null ? 0 : notes.findIndex((note) => note.description > after);
+  // A cursor whose path sorts after every remaining note yields an empty final
+  // page, which is a legal end state; -1 means exactly that.
+  const from = start === -1 ? notes.length : start;
+  const slice = notes.slice(from, from + RESOURCE_PAGE_LIMIT);
+  const resources: Array<Record<string, unknown>> = [];
+  if (after === null) {
+    // The SDK merges a STATIC entry as `{ uri, name, ...metadata }`.
+    resources.push({ uri: VAULT_INFO_RESOURCE.uri, name: VAULT_INFO_RESOURCE.name, ...VAULT_INFO_RESOURCE.metadata });
+  }
+  for (const note of slice) {
+    // ...and a TEMPLATE entry as `{ ...templateMetadata, ...resource }`, so the
+    // template's `title` survives while every other field comes from the note.
+    resources.push({ ...VAULT_NOTE_TEMPLATE_METADATA, ...note });
+  }
+  const last = slice.at(-1);
+  const more = from + slice.length < notes.length;
+  return more && last ? { resources, nextCursor: encodeResourceCursor(last.description) } : { resources };
+}
+
+/**
  * Enumerate the complete Markdown resource surface within file, traversal and
  * serialized-response budgets.
  *

--- a/src/resource-admission.ts
+++ b/src/resource-admission.ts
@@ -71,6 +71,20 @@ export const VAULT_NOTE_TEMPLATE_METADATA = {
  */
 export const RESOURCE_PAGE_LIMIT = 500;
 
+/**
+ * One entry of a `resources/list` page, in the exact shape the SDK puts on the
+ * wire: `uri` is the only required field, and the rest are the merged
+ * registration metadata. Typed concretely rather than as a loose record so the
+ * compiler holds the page to the protocol's own resource shape.
+ */
+export interface PagedResourceEntry {
+  uri: string;
+  name: string;
+  title?: string;
+  description?: string;
+  mimeType?: string;
+}
+
 /** Raised when a client supplies a cursor this server did not mint. */
 export class ResourceCursorError extends Error {
   constructor(message: string) {
@@ -155,7 +169,7 @@ export function decodeResourceCursor(cursor: string): string {
 export async function pageVaultResources(
   vault: Vault,
   cursor?: string
-): Promise<{ resources: Array<Record<string, unknown>>; nextCursor?: string }> {
+): Promise<{ resources: PagedResourceEntry[]; nextCursor?: string }> {
   const after = cursor === undefined ? null : decodeResourceCursor(cursor);
   const notes = await listVaultNoteResources(vault);
   const start = after === null ? 0 : notes.findIndex((note) => note.description > after);
@@ -163,7 +177,7 @@ export async function pageVaultResources(
   // page, which is a legal end state; -1 means exactly that.
   const from = start === -1 ? notes.length : start;
   const slice = notes.slice(from, from + RESOURCE_PAGE_LIMIT);
-  const resources: Array<Record<string, unknown>> = [];
+  const resources: PagedResourceEntry[] = [];
   if (after === null) {
     // The SDK merges a STATIC entry as `{ uri, name, ...metadata }`.
     resources.push({ uri: VAULT_INFO_RESOURCE.uri, name: VAULT_INFO_RESOURCE.name, ...VAULT_INFO_RESOURCE.metadata });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { McpServer, ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
+import { McpServer } from "@modelcontextprotocol/server";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import {
   assertEmbedDbRecoveryOwnership,
@@ -27,7 +27,7 @@ import { buildInitializeInstructions, resolveInitializeToolProfile } from "./ini
 import { createToolRegistrationAdapter } from "./mcp-registration.js";
 import type { PersistenceFamilyLeaseHandle } from "./persistence-coordination.js";
 import { registerPrompts } from "./prompts.js";
-import { pageVaultResources, ResourceCursorError } from "./resource-admission.js";
+import { registerPagedResourceList } from "./resource-admission.js";
 import { parseFeedbackConfig, parseRecencyConfig } from "./retrieval-opts.js";
 import {
   createPreparedServerCleanupOwner,
@@ -1207,47 +1207,6 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
  *   programmatic consumers may omit it.
  * @returns A freshly registered MCP server.
  */
-/**
- * Take ownership of `resources/list` so a large vault gets a bounded PAGE
- * instead of an error.
- *
- * Why a raw handler: the SDK's own `resources/list` cannot paginate in either
- * direction — a `ResourceTemplate`'s `list` callback receives no request params
- * (so an inbound cursor never reaches it) and the SDK rebuilds the reply from
- * `result.resources` alone (so an outbound `nextCursor` is dropped). Installed
- * AFTER `registerResources`, whose registration puts the SDK's handler in place
- * first; a later `setRequestHandler` replaces it, while doing this BEFORE
- * registration would make the registration itself throw.
- *
- * The protocol requires a server advertising the `resources` capability to
- * answer with the set of available resources. Before this, a vault beyond the
- * inventory budget answered every `resources/list` with an error instead.
- *
- * @param server - The MCP server whose method is being replaced.
- * @param vault - Live path/privacy authority for the listing.
- * @returns Nothing; the handler is installed as a side effect.
- * @example
- * registerResources(server, vault);
- * registerPagedResourceList(server, vault);
- */
-function registerPagedResourceList(server: McpServer, vault: Vault): void {
-  server.server.setRequestHandler("resources/list", async (request: { params?: { cursor?: unknown } }) => {
-    const raw = request.params?.cursor;
-    if (raw !== undefined && typeof raw !== "string") {
-      throw new ProtocolError(ProtocolErrorCode.InvalidParams, "resources/list cursor must be a string");
-    }
-    try {
-      return await pageVaultResources(vault, raw);
-    } catch (error) {
-      if (error instanceof ResourceCursorError) {
-        // The specification asks for -32602 on a cursor the server did not
-        // mint; the client's documented recovery is to restart without one.
-        throw new ProtocolError(ProtocolErrorCode.InvalidParams, error.message);
-      }
-      throw error;
-    }
-  });
-}
 
 export function buildMcpServer(deps: ServerDeps, opts: ServeOptions, writeTracker?: WriteRequestTracker): McpServer {
   assertServeOptionsRuntime(opts);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { McpServer } from "@modelcontextprotocol/server";
+import { McpServer, ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import {
   assertEmbedDbRecoveryOwnership,
@@ -27,6 +27,7 @@ import { buildInitializeInstructions, resolveInitializeToolProfile } from "./ini
 import { createToolRegistrationAdapter } from "./mcp-registration.js";
 import type { PersistenceFamilyLeaseHandle } from "./persistence-coordination.js";
 import { registerPrompts } from "./prompts.js";
+import { pageVaultResources, ResourceCursorError } from "./resource-admission.js";
 import { parseFeedbackConfig, parseRecencyConfig } from "./retrieval-opts.js";
 import {
   createPreparedServerCleanupOwner,
@@ -1206,6 +1207,48 @@ export async function prepareServerDeps(opts: ServeOptions): Promise<ServerDeps>
  *   programmatic consumers may omit it.
  * @returns A freshly registered MCP server.
  */
+/**
+ * Take ownership of `resources/list` so a large vault gets a bounded PAGE
+ * instead of an error.
+ *
+ * Why a raw handler: the SDK's own `resources/list` cannot paginate in either
+ * direction — a `ResourceTemplate`'s `list` callback receives no request params
+ * (so an inbound cursor never reaches it) and the SDK rebuilds the reply from
+ * `result.resources` alone (so an outbound `nextCursor` is dropped). Installed
+ * AFTER `registerResources`, whose registration puts the SDK's handler in place
+ * first; a later `setRequestHandler` replaces it, while doing this BEFORE
+ * registration would make the registration itself throw.
+ *
+ * The protocol requires a server advertising the `resources` capability to
+ * answer with the set of available resources. Before this, a vault beyond the
+ * inventory budget answered every `resources/list` with an error instead.
+ *
+ * @param server - The MCP server whose method is being replaced.
+ * @param vault - Live path/privacy authority for the listing.
+ * @returns Nothing; the handler is installed as a side effect.
+ * @example
+ * registerResources(server, vault);
+ * registerPagedResourceList(server, vault);
+ */
+function registerPagedResourceList(server: McpServer, vault: Vault): void {
+  server.server.setRequestHandler("resources/list", async (request: { params?: { cursor?: unknown } }) => {
+    const raw = request.params?.cursor;
+    if (raw !== undefined && typeof raw !== "string") {
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, "resources/list cursor must be a string");
+    }
+    try {
+      return await pageVaultResources(vault, raw);
+    } catch (error) {
+      if (error instanceof ResourceCursorError) {
+        // The specification asks for -32602 on a cursor the server did not
+        // mint; the client's documented recovery is to restart without one.
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, error.message);
+      }
+      throw error;
+    }
+  });
+}
+
 export function buildMcpServer(deps: ServerDeps, opts: ServeOptions, writeTracker?: WriteRequestTracker): McpServer {
   assertServeOptionsRuntime(opts);
   if (
@@ -1367,6 +1410,7 @@ export function buildMcpServer(deps: ServerDeps, opts: ServeOptions, writeTracke
   if (deps.ftsIndex && opts.diagnosticSearchTools) registerFtsTools(server, deps.ftsIndex, deps.vault);
   registerResources(server, deps.vault);
   if (deps.ftsIndex) registerChunkResource(server, deps.ftsIndex, deps.vault);
+  registerPagedResourceList(server, deps.vault);
   if (opts.prompts !== false) registerPrompts(server);
 
   // v2.0.0-beta.1: warn on unknown names AFTER all tools are registered.

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -7,7 +7,13 @@ import { VERSION } from "./index.js";
 import { textResult } from "./mcp-result.js";
 import { DEFAULT_OCR_TIMEOUT_MS } from "./ocr-admission.js";
 import { MAX_RESEARCH_SUBQUERIES } from "./research-protocol.js";
-import { decodeNotePath, listVaultNoteResources, readChunkResource, vaultResourceInfo } from "./resource-admission.js";
+import {
+  decodeNotePath,
+  readChunkResource,
+  VAULT_INFO_RESOURCE,
+  VAULT_NOTE_TEMPLATE_METADATA,
+  vaultResourceInfo
+} from "./resource-admission.js";
 import type { ServerDeps } from "./server.js";
 import { RENAME_NOTE_INPUT_SCHEMA } from "./tool-input-admission.js";
 import {
@@ -1564,13 +1570,9 @@ export function registerChunkResource(server: McpServer, idx: FtsIndex, vault: V
 
 export function registerResources(server: McpServer, vault: Vault): void {
   server.registerResource(
-    "vault-info",
-    "obsidian://vault/info",
-    {
-      title: "Vault metadata",
-      description: "Root path, note count, write-enabled flag, and limits for the connected vault.",
-      mimeType: "application/json"
-    },
+    VAULT_INFO_RESOURCE.name,
+    VAULT_INFO_RESOURCE.uri,
+    { ...VAULT_INFO_RESOURCE.metadata },
     async (uri) => {
       const payload = await vaultResourceInfo(vault, VERSION);
       return {
@@ -1581,14 +1583,13 @@ export function registerResources(server: McpServer, vault: Vault): void {
 
   server.registerResource(
     "vault-note",
-    new ResourceTemplate("obsidian://note/{+notePath}", {
-      list: async () => ({ resources: await listVaultNoteResources(vault) })
-    }),
-    {
-      title: "Vault notes",
-      description: "Each markdown note in the vault, addressable via `obsidian://note/<relative-path>`.",
-      mimeType: "text/markdown"
-    },
+    // `list` is deliberately absent: the SDK's own resources/list handler
+    // cannot carry a cursor in either direction (its template callback receives
+    // no request params, and it rebuilds the reply keeping only `resources`),
+    // so `registerPagedResourceList` in server.ts owns that method instead and
+    // this template contributes only reads and templates/list.
+    new ResourceTemplate("obsidian://note/{+notePath}", { list: undefined }),
+    { ...VAULT_NOTE_TEMPLATE_METADATA },
     async (uri, params) => {
       const raw = Array.isArray(params.notePath) ? params.notePath.join("/") : (params.notePath as string);
       const decoded = decodeNotePath(raw);

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1586,7 +1586,7 @@ export function registerResources(server: McpServer, vault: Vault): void {
     // `list` is deliberately absent: the SDK's own resources/list handler
     // cannot carry a cursor in either direction (its template callback receives
     // no request params, and it rebuilds the reply keeping only `resources`),
-    // so `registerPagedResourceList` in server.ts owns that method instead and
+    // so `registerPagedResourceList` (resource-admission) owns that method and
     // this template contributes only reads and templates/list.
     new ResourceTemplate("obsidian://note/{+notePath}", { list: undefined }),
     { ...VAULT_NOTE_TEMPLATE_METADATA },

--- a/tests/fixtures/release-mutation-transition.v3.json
+++ b/tests/fixtures/release-mutation-transition.v3.json
@@ -186,7 +186,7 @@
       "reason": "reviewed source bytes changed while catalogue identity stayed fixed",
       "witness": {
         "from": "sha256:c2a1b4125ec2836e34c38160ceff4676ea584e86acbe86edd1a0705dbb63c65e",
-        "to": "sha256:8173da32ee569e47faf7f3e097ef726cd4cec1ffdc1f697ea730d4f2f29042b2"
+        "to": "sha256:5407d8d1c5d70dad661049250ccf84fc46d221d0d5261bd1c8a97ce7f937a19e"
       }
     },
     {

--- a/tests/k1-ast-invariant.test.ts
+++ b/tests/k1-ast-invariant.test.ts
@@ -135,7 +135,7 @@ const PRODUCTION_FILE_PINS: Readonly<Record<string, ProductionFilePin>> = {
       "./fts5.js|discoverFtsIndexConfig|discoverFtsIndexConfig"
     ],
     k1Opens: 3,
-    sha256: "497cac23f8b63517de70315ccdd222be20ada623e2d510902883ff4b2ab78cb1"
+    sha256: "4aa38041e817fb0f8713cc5b542458ee2f92c7fe2116211af2ed7bc983e2597e"
   },
   "src/tools/search.ts": {
     constructors: { EmbedDb: 1, FtsIndex: 0 },

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -34,7 +34,7 @@ import { releaseMutationVersionedTransitionAuditProblems } from "./release-mutat
 
 const repoRoot = path.resolve(__dirname, "..");
 const RELEASE_MUTATION_IDENTITY_FIXTURE_SHA256 = "8205d24e6d42dd4cb8986368611514131abe701434beb30150e33ea08f4b1288";
-const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "ed357593dee782a0a17494b3132cbfea4257f025320346f5aa1f28bd6b40f60a";
+const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "09e46282c4596a4b92578b9086683173216d3e3e835f044ec83302b4ed575a28";
 const releaseMutationIdentityFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-identity.v2.json");
 const releaseMutationTransitionFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-transition.v3.json");
 const releaseIntegritySourcePath = path.join(repoRoot, "tests/release-integrity.test.ts");

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -316,7 +316,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "k1-ast-invariant.test.ts",
-    { count: 4, sha256: "f15ac5d7343c2cc3e6e4557240226950eb7b85a88ee66c29428eca429f0c8bb6" }
+    { count: 4, sha256: "c7d3902e64f8c3869466febfd13cb051e30cd2da4b9246814c542fa0dde7e8b0" }
   ],
   [
     "k1-class-invariant.test.ts",
@@ -996,8 +996,8 @@ const EXPECTED_REVIEWED_ORDINARY_OWNER_SHA256_ENTRIES = [
   ["K-1 statement semicolon normalization", "9bb382eb2d071464957b3c6cec271cb2a843dfeeabd9225c92e4497597d839ef"],
   ["K-1 block-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
   ["K-1 line-comment stripping", "693d87a3a5e80b88156a062d2935aa3e9e278aad769fd947ec897caffcbb4fdc"],
-  ["K-1 module-extension normalization", "e6fc6591097ffdb0c7fe4774b0beb9e4775b03b794a4c07cabc3ef48bbdb9c4c"],
-  ["K-1 source-path separator normalization", "abf5e33e07b11a1cd4bf30dc7cf6374865426b74f7fae8eeef3972911deba45a"],
+  ["K-1 module-extension normalization", "93d89e64dbdc69d21f5502c1e7173c565aad0a1bc6f2a29b0bd6396fe38f462e"],
+  ["K-1 source-path separator normalization", "651f3fb3e3cf501ef8b72050722c59f735a6906e4cdbc75d819083d9346d852a"],
   ["line-terminator block-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["line-terminator line-comment stripping", "61bbbea7aac48eafa3a24d78998eb49e81a6e7911953f3c25ead27692923a80d"],
   ["ReDoS source-path separator normalization", "1b31e3478ce12f357ad0de08f669cdd462aef1c92b5e40ea2b7252bf483dc9bd"],

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -347,7 +347,7 @@ const EXPECTED_REPOSITORY_MUTATION_HELPER_CALL_ENTRIES = [
   ],
   [
     "resource-list-admission.test.ts",
-    { count: 1, sha256: "cfcd83f72055e3b8b8f16124045a540024faa84554365eb1c0b23ec1c77ab84a" }
+    { count: 1, sha256: "fe4ae8b35895321640c61af5248f0e00b776b6af5ff0dc5991bf2e32283e4a53" }
   ],
   [
     "sink-parity-invariant.test.ts",

--- a/tests/resource-list-admission.test.ts
+++ b/tests/resource-list-admission.test.ts
@@ -86,7 +86,6 @@ describe("resource inventory admission", () => {
     } finally {
       await fs.rm(pagedRoot, { recursive: true, force: true });
     }
-
   });
 
   it("fails both exhaustive resource contracts when the traversal receipt is incomplete", async () => {

--- a/tests/resource-list-admission.test.ts
+++ b/tests/resource-list-admission.test.ts
@@ -2,7 +2,15 @@ import { promises as fs, readFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { listVaultNoteResources, vaultResourceInfo } from "../src/resource-admission.js";
+import {
+  decodeResourceCursor,
+  encodeResourceCursor,
+  listVaultNoteResources,
+  pageVaultResources,
+  RESOURCE_PAGE_LIMIT,
+  ResourceCursorError,
+  vaultResourceInfo
+} from "../src/resource-admission.js";
 import { Vault } from "../src/vault.js";
 import { replaceExactly } from "./helpers/exact-source-mutation.js";
 
@@ -17,7 +25,7 @@ describe("resource inventory admission", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it("preserves the small-vault resource contract through a bounded, deterministic walk", async () => {
+  it("preserves the small-vault contract and pages a large one with an opaque cursor (AH-6)", async () => {
     await fs.writeFile(path.join(root, "Z.md"), "# Z\n");
     await fs.writeFile(path.join(root, "A.md"), "# A\n");
     const vault = new Vault(root);
@@ -44,6 +52,41 @@ describe("resource inventory admission", () => {
     });
     expect(bounded).toHaveBeenNthCalledWith(1, [".md"], 10_000, 100_000);
     expect(bounded).toHaveBeenNthCalledWith(2, [".md"], 10_000, 100_000);
+
+    // Page 1 carries the static vault-info entry; every page's note entries
+    // carry the template metadata merged the way the SDK merges it, so the
+    // wire shape is unchanged for a vault that fits in one page.
+    const pagedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "enquire-ah6-"));
+    try {
+      for (let i = 0; i < RESOURCE_PAGE_LIMIT + 7; i += 1) {
+        await fs.writeFile(path.join(pagedRoot, `note-${String(i).padStart(4, "0")}.md`), "body");
+      }
+      const pagedVault = new Vault(pagedRoot);
+      const first = await pageVaultResources(pagedVault);
+      expect(first.resources[0]).toMatchObject({ uri: "obsidian://vault/info", name: "vault-info" });
+      expect(first.resources).toHaveLength(RESOURCE_PAGE_LIMIT + 1);
+      expect(first.nextCursor, "a vault beyond one page must offer a continuation").toBeTypeOf("string");
+      // Every note entry keeps the template title the SDK used to merge in.
+      expect(first.resources[1]).toMatchObject({ title: "Vault notes", mimeType: "text/markdown" });
+
+      const second = await pageVaultResources(pagedVault, first.nextCursor);
+      expect(second.nextCursor, "the remainder fits in one more page").toBeUndefined();
+      // The pages partition the listing exactly once: no duplicate, no gap.
+      const uris = [...first.resources, ...second.resources].map((r) => r.uri as string);
+      expect(new Set(uris).size).toBe(uris.length);
+      expect(uris.filter((u) => u.startsWith("obsidian://note/"))).toHaveLength(RESOURCE_PAGE_LIMIT + 7);
+
+      // A cursor this server did not mint is refused, never silently restarted.
+      await expect(pageVaultResources(pagedVault, "not-a-cursor")).rejects.toBeInstanceOf(ResourceCursorError);
+      // NEGATIVE control — the empty string is a LEGAL cursor value per the
+      // spec, so it must be decoded like any other token and refused as
+      // unmintable, not mistaken for "start from the beginning".
+      await expect(pageVaultResources(pagedVault, "")).rejects.toBeInstanceOf(ResourceCursorError);
+      expect(decodeResourceCursor(encodeResourceCursor("a/b.md"))).toBe("a/b.md");
+    } finally {
+      await fs.rm(pagedRoot, { recursive: true, force: true });
+    }
+
   });
 
   it("fails both exhaustive resource contracts when the traversal receipt is incomplete", async () => {


### PR DESCRIPTION
**This is a protocol-conformance fix, not only a capacity limit.** The 2026-07-28 specification states that a server declaring the `resources` capability **MUST** respond to `resources/list` with the set of resources available to the client. Returning an *empty* set is a sanctioned way to decline; throwing is not. A vault past the file/entry budget previously answered **every** `resources/list` with an error.

**What changed**

- `src/resource-admission.ts` gains an opaque, versioned keyset cursor and `pageVaultResources`, emitting the SDK's own merged wire shape (`{ uri, name, ...metadata }` for the static entry, `{ ...templateMetadata, ...resource }` for notes) so a vault that fits in one page is byte-unchanged. Both resource descriptions now come from **one exported constant** used by the registration and the page alike, so the two cannot drift.
- `src/server.ts` installs a raw `resources/list` handler **after** registration. The SDK's high-level API structurally cannot paginate: a `ResourceTemplate`'s `list` callback receives no request params (an inbound cursor never reaches it) and the handler rebuilds the reply from `result.resources` alone (an outbound `nextCursor` is dropped). Install order is load-bearing — registering after a handler exists makes the registration throw, while a later `setRequestHandler` replaces it.
- A cursor this server did not mint is refused with `-32602`, which is what the spec asks for an invalid cursor. The **empty string is a legal cursor value** per the spec, so it is decoded like any other token rather than mistaken for "start from the beginning" — that is one of the two negative controls.

**Bounded claim — the protocol's floor, deliberately not more.** The spec says there is no cross-page consistency guarantee and that clients "may observe duplicates or gaps" when the underlying data changes between fetches; a client needing a snapshot re-fetches from the beginning. This server holds no snapshot and claims nothing stronger: within one unchanged vault the pages partition the listing exactly once, deterministically. The backlog's stricter epoch guarantee was considered and deliberately not taken — the only detector whose scope equals that claim is a full re-walk per page, and shipping a cheaper partial detector under the words "fails explicitly" would be precisely the claimed-guarantee-vs-code-guard overclaim this project tracks.

Every SDK fact above was established from the SDK's own source and docs rather than memory (the error surface is `ProtocolError` / `ProtocolErrorCode.InvalidParams`, not the v1 `McpError` / `ErrorCode` names). Assertions folded into the existing registration, so the canonical test count is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)