### PR TITLE
docs: close the AH-6 re-sweep tail — four claims that stopped being true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented here. The format follows 
 >
 > **Method note:** the SDK's high-level resource API structurally cannot paginate — a `ResourceTemplate`'s `list` callback receives no request params, so an inbound cursor never reaches it, and the SDK rebuilds the reply from `result.resources` alone, so an outbound `nextCursor` is dropped. `resources/list` is therefore taken over by a raw handler installed AFTER registration (registering first and replacing later is required: the reverse order makes the registration itself throw). Both resource descriptions now come from one exported constant used by the registration and the page alike, so the merged wire shape cannot drift between them. Privacy filtering happens inside the walk, so an excluded note is absent before anything is counted or cut.
 
+> **Follow-up corrections (post-merge re-sweep tail).** `docs/api.md` claimed the note template implements `list` and that a client "will see the full vault enumerated on connect" — both halves became false with this change, and the page/cursor/refusal contract is stated there now. The chunk template's `list` callback returned an empty array that no longer routes anywhere, so it is `undefined` rather than dead code reading like a contributing one. A `{@link}` pointed at a symbol that was never created. The handler's non-string-cursor guard is labelled as unreachable through the SDK's own routing rather than implying it fires.
+
 ### `clear-feedback` erases the active vault's marks (AH-5c)
 
 > **TL;DR:** **The closed-loop feedback sidecar of the vault you are USING is now erasable by a command.**

--- a/docs/api.md
+++ b/docs/api.md
@@ -868,7 +868,7 @@ Surgical YAML manipulation: set one or more frontmatter keys, or remove them by 
 | `obsidian://vault/info`      | static JSON    | Root, note count, write flag, byte/cache limits, server version. |
 | `obsidian://note/{notePath}` | template (md)  | Each markdown note. `notePath` is the URI-encoded vault-relative path. |
 
-The note template implements `list`, so MCP clients with a resource browser will see the full vault enumerated on connect.
+`resources/list` is answered by the server in bounded pages (500 notes) with an opaque `nextCursor`, so a resource browser walks the vault a page at a time rather than receiving it whole on connect. A cursor the server did not mint is refused with `-32602`. Page boundaries carry no snapshot: as the protocol itself states, a client that needs a coherent view of the whole listing re-fetches from the beginning without a cursor. A vault beyond the inventory budget (10,000 notes / 100,000 visited entries) still refuses the listing — see AH-6b.
 
 ## MCP prompts
 

--- a/src/resource-admission.ts
+++ b/src/resource-admission.ts
@@ -44,7 +44,7 @@ export function decodeNotePath(uriPath: string): string {
  * `resources/list` page and the SDK registration in `tool-registry.ts` cannot
  * describe the same resource differently. The SDK merges a template entry as
  * `{ ...templateMetadata, ...resource }` and a static entry as
- * `{ uri, name, ...metadata }`, so {@link mergeResourcePage} below reproduces
+ * `{ uri, name, ...metadata }`, so {@link pageVaultResources} below reproduces
  * exactly that shape rather than inventing its own.
  */
 export const VAULT_INFO_RESOURCE = {
@@ -328,6 +328,9 @@ export async function readChunkResource(
 export function registerPagedResourceList(server: McpServer, vault: Vault): void {
   server.server.setRequestHandler("resources/list", async (request: { params?: { cursor?: unknown } }) => {
     const raw = request.params?.cursor;
+    // Defense in depth only: the SDK validates the request shape before a
+    // handler runs, so a non-string cursor is already rejected upstream and
+    // this branch is unreachable through the SDK's own routing.
     if (raw !== undefined && typeof raw !== "string") {
       throw new ProtocolError(ProtocolErrorCode.InvalidParams, "resources/list cursor must be a string");
     }

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1549,15 +1549,14 @@ export function registerChunkResource(server: McpServer, idx: FtsIndex, vault: V
   // Index FIRST so the {+notePath} can greedily eat slash-bearing paths.
   server.registerResource(
     "vault-chunk",
-    new ResourceTemplate("obsidian://chunk/{chunkIndex}/{+notePath}", {
-      list: async () => {
-        // No exhaustive enumeration — chunks are a derived index that can
-        // contain thousands of entries per vault. Clients should construct
-        // these URIs from search hits returned by `obsidian_full_text_search`.
-        // We surface a single example URI so the schema is discoverable.
-        return { resources: [] };
-      }
-    }),
+    // No enumeration: chunks are a derived index that can hold thousands of
+    // entries per vault, and clients construct these URIs from the
+    // `chunk_index` + `rel_path` of a search hit. `list` is absent rather than
+    // returning an empty array because since AH-6 the server answers
+    // `resources/list` with its own handler, which never consults a template
+    // callback — an empty-array callback here would be dead code that reads
+    // like a contributing one.
+    new ResourceTemplate("obsidian://chunk/{chunkIndex}/{+notePath}", { list: undefined }),
     {
       title: "Vault chunks (FTS5 index)",
       description:

--- a/tests/fixtures/release-mutation-transition.v3.json
+++ b/tests/fixtures/release-mutation-transition.v3.json
@@ -43,7 +43,7 @@
       "reason": "reviewed source bytes changed while catalogue identity stayed fixed",
       "witness": {
         "from": "sha256:5b0eff418ec0c12fb950512904762ca5afc9c71c8c09968325c2c08fddbf94de",
-        "to": "sha256:b23496374850df5006409f1674d1c36656d3acf7ea5bb63ac4d7284a9add3678"
+        "to": "sha256:98431699965340689eed310a7648274989efca5b61c9b71a8ebae8fbabb18bd0"
       }
     },
     {

--- a/tests/meta-invariant-coverage.test.ts
+++ b/tests/meta-invariant-coverage.test.ts
@@ -34,7 +34,7 @@ import { releaseMutationVersionedTransitionAuditProblems } from "./release-mutat
 
 const repoRoot = path.resolve(__dirname, "..");
 const RELEASE_MUTATION_IDENTITY_FIXTURE_SHA256 = "8205d24e6d42dd4cb8986368611514131abe701434beb30150e33ea08f4b1288";
-const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "09e46282c4596a4b92578b9086683173216d3e3e835f044ec83302b4ed575a28";
+const RELEASE_MUTATION_TRANSITION_FIXTURE_SHA256 = "68f2a999f808a5f3ca1ce678715965733fc644f3509a67095d0c628f2f09bd8c";
 const releaseMutationIdentityFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-identity.v2.json");
 const releaseMutationTransitionFixturePath = path.join(repoRoot, "tests/fixtures/release-mutation-transition.v3.json");
 const releaseIntegritySourcePath = path.join(repoRoot, "tests/release-integrity.test.ts");


### PR DESCRIPTION
The AH-6 post-merge re-sweep returned 26 confirmed findings; all five HIGHs were the same overclaim seen by five lenses, fixed in #604. This closes the honest-claim tail.

- **`docs/api.md`** said the note template implements `list` and that "MCP clients with a resource browser will see the full vault enumerated on connect". Both halves stopped being true with #603 — the template passes `list: undefined`, and a client now walks pages. It now states the page size, the opaque cursor, the `-32602` refusal, the absence of a cross-page snapshot, and the beyond-budget refusal that is still open.
- **The chunk template's `list` callback** returned `{ resources: [] }`, which no longer routes anywhere now that the server owns `resources/list`. Made `undefined`: dead code that reads like a contributing callback is worse than no callback, because the next reader trusts it.
- **A `{@link}`** pointed at `mergeResourcePage`, a symbol that was never created.
- **The non-string-cursor guard** is labelled as unreachable through the SDK's own routing, rather than implying it fires — the SDK validates the request shape before a handler runs.

Deliberately **not** fixed here, and recorded against AH-6b instead: the 8 MB byte rail is still measured against the whole inventory rather than the page; each page still re-walks the vault; and the paged reply is a hand-maintained duplicate of the SDK's resource registry with nothing pinning the two in agreement. All three are consequences of the page being sliced from an exhaustive walk, so they resolve together when that walk becomes resumable — splitting them across two PRs would mean touching the same code twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)